### PR TITLE
Remove Check for .env as it Does not Play Nicely on Heroku

### DIFF
--- a/application/index.js
+++ b/application/index.js
@@ -2,13 +2,9 @@ const express = require('express');
 const path = require('path');
 const expressLayouts = require('express-ejs-layouts');
 const mongoose = require('mongoose');
-const {error: envLoadError} = require('dotenv').config();
+require('dotenv').config();
 const databaseService = require('./services/databaseService');
 const cookieParser = require('cookie-parser');
-
-if (envLoadError) {
-    throw new Error('No .env file was found, please add one to the root directory of this project!');
-}
 
 databaseService.connectToMongoDatabase(process.env.MONGO_DB_URL);
 const databaseConnection = mongoose.connection;


### PR DESCRIPTION
## Description

Currently the build on heroku is failing because of a check for a .env file.

The .env file should be present and thus removing this check to see if it remedies the situation.