### PR TITLE
Add CREATE/READ Funcationality for New Objects: `Machine`, `Material`, `Finish`

### DIFF
--- a/application/controllers/adminController.js
+++ b/application/controllers/adminController.js
@@ -1,0 +1,8 @@
+const router = require('express').Router();
+const {verifyJwtToken} = require('../middleware/authorize');
+
+router.get('/', verifyJwtToken, (request, response) => {
+    return response.render('adminPanel')
+});
+
+module.exports = router;

--- a/application/controllers/adminController.js
+++ b/application/controllers/adminController.js
@@ -2,7 +2,7 @@ const router = require('express').Router();
 const {verifyJwtToken} = require('../middleware/authorize');
 
 router.get('/', verifyJwtToken, (request, response) => {
-    return response.render('adminPanel')
+    return response.render('adminPanel');
 });
 
 module.exports = router;

--- a/application/controllers/finishController.js
+++ b/application/controllers/finishController.js
@@ -1,0 +1,37 @@
+const router = require('express').Router();
+const FinishModel = require('../models/finish');
+const {verifyJwtToken} = require('../middleware/authorize');
+
+router.get('/', verifyJwtToken, async (request, response) => {
+    try {
+        const finishes = await FinishModel.find().exec();
+        
+        return response.render('viewFinishes', {
+            finishes: finishes
+        });
+
+    } catch (error) {
+        request.flash('errors', ['Unable to load Finishes, the following error(s) occurred:', error.message]);
+        return response.redirect('back');
+    }
+});
+
+router.get('/create', verifyJwtToken, (request, response) => {
+    return response.render('createFinish')
+});
+
+router.post('/create', verifyJwtToken, async (request, response) => {
+    const {name} = request.body;
+    try {
+        await FinishModel.create({name});
+    } catch (error) {
+        request.flash('errors', ['Unable to save the Finish, the following error(s) occurred:', error.message]);
+
+        return response.redirect('back');
+    }
+    request.flash('alerts', ['Finish created successfully']);
+
+    return response.redirect('/finishes');
+});
+
+module.exports = router;

--- a/application/controllers/finishController.js
+++ b/application/controllers/finishController.js
@@ -17,7 +17,7 @@ router.get('/', verifyJwtToken, async (request, response) => {
 });
 
 router.get('/create', verifyJwtToken, (request, response) => {
-    return response.render('createFinish')
+    return response.render('createFinish');
 });
 
 router.post('/create', verifyJwtToken, async (request, response) => {

--- a/application/controllers/machineController.js
+++ b/application/controllers/machineController.js
@@ -1,0 +1,37 @@
+const router = require('express').Router();
+const MachineModel = require('../models/machine');
+const {verifyJwtToken} = require('../middleware/authorize');
+
+router.get('/', verifyJwtToken, async (request, response) => {
+    try {
+        const machines = await MachineModel.find().exec();
+        
+        return response.render('viewMachines', {
+            machines: machines
+        });
+
+    } catch (error) {
+        request.flash('errors', ['Unable to load Machines, the following error(s) occurred:', error.message]);
+        return response.redirect('back');
+    }
+});
+
+router.get('/create', verifyJwtToken, (request, response) => {
+    return response.render('createMachine');
+});
+
+router.post('/create', verifyJwtToken, async (request, response) => {
+    const {name} = request.body;
+    try {
+        await MachineModel.create({name});
+    } catch (error) {
+        request.flash('errors', ['Unable to save the Machine, the following error(s) occurred:', error.message]);
+
+        return response.redirect('back');
+    }
+    request.flash('alerts', ['Machine created successfully']);
+
+    return response.redirect('/machines');
+});
+
+module.exports = router;

--- a/application/controllers/materialController.js
+++ b/application/controllers/materialController.js
@@ -17,7 +17,7 @@ router.get('/', verifyJwtToken, async (request, response) => {
 });
 
 router.get('/create', verifyJwtToken, (request, response) => {
-    return response.render('createMaterial')
+    return response.render('createMaterial');
 });
 
 router.post('/create', verifyJwtToken, async (request, response) => {

--- a/application/controllers/materialController.js
+++ b/application/controllers/materialController.js
@@ -1,0 +1,37 @@
+const router = require('express').Router();
+const MaterialModel = require('../models/material');
+const {verifyJwtToken} = require('../middleware/authorize');
+
+router.get('/', verifyJwtToken, async (request, response) => {
+    try {
+        const materials = await MaterialModel.find().exec();
+        
+        return response.render('viewMaterials', {
+            materials: materials
+        });
+
+    } catch (error) {
+        request.flash('errors', ['Unable to load Materials, the following error(s) occurred:', error.message]);
+        return response.redirect('back');
+    }
+});
+
+router.get('/create', verifyJwtToken, (request, response) => {
+    return response.render('createMaterial')
+});
+
+router.post('/create', verifyJwtToken, async (request, response) => {
+    const {name} = request.body;
+    try {
+        await MaterialModel.create({name});
+    } catch (error) {
+        request.flash('errors', ['Unable to save the Material, the following error(s) occurred:', error.message]);
+
+        return response.redirect('back');
+    }
+    request.flash('alerts', ['Material created successfully']);
+
+    return response.redirect('/materials');
+});
+
+module.exports = router;

--- a/application/index.js
+++ b/application/index.js
@@ -44,6 +44,10 @@ app.set('layout', path.join(__dirname, '/views/layout.ejs'));
 app.use('/', require('./controllers/index'));
 app.use('/users', require('./controllers/userController'));
 app.use('/recipes', require('./controllers/recipeController'));
+app.use('/admin', require('./controllers/adminController'));
+app.use('/finishes', require('./controllers/finishController'));
+app.use('/machines', require('./controllers/machineController'));
+app.use('/materials', require('./controllers/materialController'));
 
 databaseConnection.on('error', (error) => {
     throw new Error(`Error connecting to the database: ${error}`);

--- a/application/models/finish.js
+++ b/application/models/finish.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const schema = new Schema({
+    name: {
+        type: String,
+        trim: true,
+        required: true,
+    },
+}, { timestamps: true });
+
+const Finish = mongoose.model('Finish', schema);
+
+module.exports = Finish;

--- a/application/models/machine.js
+++ b/application/models/machine.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const schema = new Schema({
+    name: {
+        type: String,
+        trim: true,
+        required: true
+    },
+}, { timestamps: true });
+
+const Machine = mongoose.model('Machine', schema);
+
+module.exports = Machine;

--- a/application/models/material.js
+++ b/application/models/material.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const schema = new Schema({
+    name: {
+        type: String,
+        trim: true,
+        required: true
+    },
+}, { timestamps: true });
+
+const Material = mongoose.model('Material', schema);
+
+module.exports = Material;

--- a/application/views/adminPanel.ejs
+++ b/application/views/adminPanel.ejs
@@ -1,0 +1,9 @@
+<h1> Welcome to the Admin Panel </h1>
+
+<a class="btn btn-primary" href="/finishes/create" role="button">Create Finish</a>
+<a class="btn btn-primary" href="/machines/create" role="button">Create Machine</a>
+<a class="btn btn-primary" href="/materials/create" role="button">Create Material</a>
+
+<a class="btn btn-primary" href="/finishes/" role="button">View Finishes</a>
+<a class="btn btn-primary" href="/machines/" role="button">View Machines</a>
+<a class="btn btn-primary" href="/materials/" role="button">View Materials</a>

--- a/application/views/createFinish.ejs
+++ b/application/views/createFinish.ejs
@@ -1,0 +1,7 @@
+<h1>Create Finish</h1>
+
+<form action="/finishes/create", method="POST">
+    <label for="name">Name</label>
+    <input type="text" name="name" id="name">
+    <input type="submit" value="Create Finish">
+</form>

--- a/application/views/createMachine.ejs
+++ b/application/views/createMachine.ejs
@@ -1,0 +1,7 @@
+<h1>Create Machine</h1>
+
+<form action="/machines/create", method="POST">
+    <label for="name">Name</label>
+    <input type="text" name="name" id="name">
+    <input type="submit" value="Create Machine">
+</form>

--- a/application/views/createMaterial.ejs
+++ b/application/views/createMaterial.ejs
@@ -1,0 +1,7 @@
+<h1>Create Material</h1>
+
+<form action="/materials/create", method="POST">
+    <label for="name">Name</label>
+    <input type="text" name="name" id="name">
+    <input type="submit" value="Create Material">
+</form>

--- a/application/views/viewFinishes.ejs
+++ b/application/views/viewFinishes.ejs
@@ -1,0 +1,21 @@
+<h1>Finishes Table</h1>
+
+<a class="btn btn-primary" href="/finishes/create" role="button">Create Finish</a>
+<table class="table">
+    <thead>
+      <tr>
+        <th scope="col">Row #</th>
+        <th scope="col">Name</th>
+      </tr>
+    </thead>
+    <tbody>
+        <% if (typeof finishes != 'undefined') { %>
+            <% finishes.forEach((finish, index) => { %>
+                <tr>
+                    <td scope="row"><%= index + 1 %></td>
+                    <td><%= finish.name || 'N/A' %></td>
+                </tr>
+            <% }) %>
+        <% } %>
+    </tbody>
+  </table>

--- a/application/views/viewMachines.ejs
+++ b/application/views/viewMachines.ejs
@@ -1,0 +1,21 @@
+<h1>Machines Table</h1>
+
+<a class="btn btn-primary" href="/machines/create" role="button">Create Machine</a>
+<table class="table">
+    <thead>
+      <tr>
+        <th scope="col">Row #</th>
+        <th scope="col">Name</th>
+      </tr>
+    </thead>
+    <tbody>
+        <% if (typeof machines != 'undefined') { %>
+            <% machines.forEach((machine, index) => { %>
+                <tr>
+                    <td scope="row"><%= index + 1 %></td>
+                    <td><%= machine.name || 'N/A' %></td>
+                </tr>
+            <% }) %>
+        <% } %>
+    </tbody>
+  </table>

--- a/application/views/viewMaterials.ejs
+++ b/application/views/viewMaterials.ejs
@@ -1,0 +1,21 @@
+<h1>Materials Table</h1>
+
+<a class="btn btn-primary" href="/materials/create" role="button">Create Material</a>
+<table class="table">
+    <thead>
+      <tr>
+        <th scope="col">Row #</th>
+        <th scope="col">Name</th>
+      </tr>
+    </thead>
+    <tbody>
+        <% if (typeof materials != 'undefined') { %>
+            <% materials.forEach((material, index) => { %>
+                <tr>
+                    <td scope="row"><%= index + 1 %></td>
+                    <td><%= material.name || 'N/A' %></td>
+                </tr>
+            <% }) %>
+        <% } %>
+    </tbody>
+  </table>

--- a/test/models/finish.spec.js
+++ b/test/models/finish.spec.js
@@ -1,0 +1,32 @@
+const chance = require('chance').Chance();
+const FinishModel = require('../../application/models/finish');
+
+describe('validation', () => {
+    let finishAttributes;
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        finishAttributes = {
+            name: chance.string()
+        };
+    });
+
+    describe('successful validation', () => {
+        it('should validate when required attributes are defined', () => {
+            const finish = new FinishModel(finishAttributes);
+    
+            const error = finish.validateSync();
+    
+            expect(error).toBe(undefined);
+        });
+
+        it('should trim whitespace around "name"', () => {
+            const name = chance.string();
+            finishAttributes.name = ' ' + name + ' ';
+
+            const finish = new FinishModel(finishAttributes);
+
+            expect(finish.name).toBe(name);
+        });
+    });
+});

--- a/test/models/machine.spec.js
+++ b/test/models/machine.spec.js
@@ -1,0 +1,32 @@
+const chance = require('chance').Chance();
+const MachineModel = require('../../application/models/machine');
+
+describe('validation', () => {
+    let machineAttributes;
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        machineAttributes = {
+            name: chance.string()
+        };
+    });
+
+    describe('successful validation', () => {
+        it('should validate when required attributes are defined', () => {
+            const machine = new MachineModel(machineAttributes);
+    
+            const error = machine.validateSync();
+    
+            expect(error).toBe(undefined);
+        });
+
+        it('should trim whitespace around "name"', () => {
+            const name = chance.string();
+            machineAttributes.name = ' ' + name + ' ';
+
+            const machine = new MachineModel(machineAttributes);
+
+            expect(machine.name).toBe(name);
+        });
+    });
+});

--- a/test/models/material.spec.js
+++ b/test/models/material.spec.js
@@ -1,0 +1,32 @@
+const chance = require('chance').Chance();
+const MaterialModel = require('../../application/models/material');
+
+describe('validation', () => {
+    let materialAttributes;
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+        materialAttributes = {
+            name: chance.string()
+        };
+    });
+
+    describe('successful validation', () => {
+        it('should validate when required attributes are defined', () => {
+            const finish = new MaterialModel(materialAttributes);
+    
+            const error = finish.validateSync();
+    
+            expect(error).toBe(undefined);
+        });
+
+        it('should trim whitespace around "name"', () => {
+            const name = chance.string();
+            materialAttributes.name = ' ' + name + ' ';
+
+            const material = new MaterialModel(materialAttributes);
+
+            expect(material.name).toBe(name);
+        });
+    });
+});


### PR DESCRIPTION
## Description

In this PR, new MongoDB objects are introduced (aka new database tables are being added).

These tables are named:
  1. Machine
  2. Material
  3. Finish

Endpoints and UX views were added to handle the CREATION/READING of this data.

Also, an `/admin` endpoint was added which is the location that these 3 tables will be creatable/readable from. Typical users (non-admins) will not be given access to view/modify these objects. 