### PR TITLE
Add link to previously created admin panel

### DIFF
--- a/application/views/profile.ejs
+++ b/application/views/profile.ejs
@@ -7,3 +7,4 @@
 <a class="btn btn-primary" href="/users/change-password" role="button">Change Password</a>
 <a class="btn btn-primary" href="/users/logout" role="button">Logout</a>
 <a class="btn btn-secondary" href="/recipes" role="button">View All Recipes</a>
+<a class="btn btn-secondary" href="/admin" role="button">View Admin Panel</a>


### PR DESCRIPTION
## Description

An admin panel was previously created by other than a user knowing to visit `\admin`, there were no direct links.

This PR adds a link to the admin panel in the users profile.

**Note:** Actual ADMIN validation has not been added yet, that functionality will come in a later PR. For now, every user will be presented/allowed access to view the admin panel, there are no security vulnerabilities for allowing such an action