### PR TITLE
Fix Issue Profile Picture not Being Displayed Issue

### DIFF
--- a/application/controllers/userController.js
+++ b/application/controllers/userController.js
@@ -163,8 +163,10 @@ router.get('/logout', verifyJwtToken, (request, response) => {
 });
 
 router.get('/profile', verifyJwtToken, async (request, response) => {
+    const user = await UserModel.findById(request.user.id);
+
     response.render('profile', {
-        user: request.user
+        user
     });
 });
 

--- a/application/views/profile.ejs
+++ b/application/views/profile.ejs
@@ -35,6 +35,7 @@
     </form>
 </div>
 
+
 <hr>
     <% if (user.profilePicture) { %>
         


### PR DESCRIPTION
## Description

An issue existed where a `profile.ejs` front-end view was attempting to display the profile picture for a user, but that data was not available.

The fix was to request the data from the database and hand it off to the `profile.ejs` for display.