### PR TITLE
Fix Front-end Page Crash Issue

### DIFF
--- a/application/views/profile.ejs
+++ b/application/views/profile.ejs
@@ -70,7 +70,7 @@
                     <div class="form-group">
                         <label for="birthDate">Birthday</label>
                         <div class="input-frame">
-                            <input type="date" class="form-control" id="birthDate" name="birthDate" value="<%= new Date(user.birthDate).toISOString().substring(0, 10) %>"> 
+                            <input type="date" class="form-control" id="birthDate" name="birthDate" value="<%= user.birthDate && new Date(user.birthDate).toISOString().substring(0, 10) %>"> 
                         </div>
                     </div>
                     <div class="form-group">


### PR DESCRIPTION
## Description

Previously, the user's birthday was displayed on a hmtl page utilizing EJS and template variables

However, if that user's birthday was not defined, an error occurred and that page crashed with the following error message:
![Screen_Shot_2022-03-31_at_10 50 17_AM](https://user-images.githubusercontent.com/42784674/161139609-03f00775-f4b7-4637-93bb-89ed03a67930.png)

The fix was to ensure the birthday was defined before using it to do anything such as format it as an iso string
