### PR TITLE
Fix Registration Bug

### DIFF
--- a/application/models/user.js
+++ b/application/models/user.js
@@ -62,7 +62,8 @@ const userSchema = new Schema({
         validate: [{
             validator: checkForSpaces, 
             msg: 'Your username must not contain spaces'
-        }]
+        }],
+        sparse: true
     },
     fullName: {
         type: String,


### PR DESCRIPTION
## Description

Previously, when a user would attempt to register, an error occurred preventing the registration.

It turns out, the user object has a non-required field called "username". That field must be unique.

However, a registered user does not need to enter a username yet, therefore the field is null upon registration.

However, since null was indexed and required to be unique, any future user registering was declined since their "null" username was taken already and non-unique.

The fix described [here](https://stackoverflow.com/a/44641358/9273261) was implemented and then I went into mongoDB atlas and manually dropped the existing index which had already indexed null as being a valid/unique username.

If this was confusing to read... just know the problem is fixed 😆 