### PR TITLE
Feature: Sort `windingSetup` Columns on Click

### DIFF
--- a/application/views/viewWindingSetups.ejs
+++ b/application/views/viewWindingSetups.ejs
@@ -13,20 +13,20 @@
       </div>
 
     </div>
-    <table class="table recipes">
+    <table class="table recipes" data-endpoint="/winding-setups/all/<%= recipeId %>">
       <thead role="rowgroup">
         <tr role="row">
           <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="none" class=""><div>Row #</div></th>
-          <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="none" class=""><div>Date Created</div></th>
-          <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="none" class=""><div>Author</div></th>
-          <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="none" class=""><div>Machine</div></th>
-          <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="none" class=""><div>Notes</div></th>
-          <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="none" class=""><div>Video</div></th>
-          <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="none" class=""><div>Watch Out</div></th>
-          <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="none" class=""><div>Difficulty</div></th>
-          <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="none" class=""><div>Back Winding</div></th>
-          <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="none" class=""><div>Alert Text Box</div></th>
-          <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="none" class=""><div>Default Machine</div></th>
+          <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="<%= (sortBy && sortBy == 'createdAt') ? sortMethod : "none" %>" class="" id="createdAt"><div>Date Created</div></th>
+          <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="<%= (sortBy && sortBy == 'author') ? sortMethod : "none" %>" class="" id="author"><div>Author</div></th>
+          <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="<%= (sortBy && sortBy == 'machine') ? sortMethod : "none" %>" class="" id="machine"><div>Machine</div></th>
+          <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="<%= (sortBy && sortBy == 'notes') ? sortMethod : "none" %>" class="" id="notes"><div>Notes</div></th>
+          <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="<%= (sortBy && sortBy == 'video') ? sortMethod : "none" %>" class="" id="video"><div>Video</div></th>
+          <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="<%= (sortBy && sortBy == 'watchOutFor') ? sortMethod : "none" %>" class="" id="watchOutFor"><div>Watch Out</div></th>
+          <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="<%= (sortBy && sortBy == 'difficulty') ? sortMethod : "none" %>" class="" id="difficulty"><div>Difficulty</div></th>
+          <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="<%= (sortBy && sortBy == 'backWinding') ? sortMethod : "none" %>" class="" id="backWinding"><div>Back Winding</div></th>
+          <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="<%= (sortBy && sortBy == 'alertTextBox') ? sortMethod : "none" %>" class="" id="alertTextBox"><div>Alert Text Box</div></th>
+          <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="<%= (sortBy && sortBy == 'defaultMachine') ? sortMethod : "none" %>" class="" id="defaultMachine"><div>Default Machine</div></th>
           <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="none" class=""><div>Actions</div></th>
         </tr>
       </thead>


### PR DESCRIPTION
## Description

Previously, an HTML table existed that displayed many `windingSetup` objects from the database.

It was decided that a cool feature would be to allow a user to sort the rows in that table after clicking on any of the column names.

This PR adds the feature that allows a user to sort the table according to any column of their choosing in either `ascending` or `descending` order.