### PR TITLE
Add New Page to View any `PrintingSetup` Object Individually 

### DIFF
--- a/application/controllers/printingSetupController.js
+++ b/application/controllers/printingSetupController.js
@@ -13,6 +13,25 @@ const MONGOOSE_SORT_METHODS = {
     'descending': -1
 };
 
+router.get('/:printingSetupId', verifyJwtToken, async (request, response) => {
+    try {
+        const printingSetup = await PrintingSetupModel
+            .findById(request.params.printingSetupId)
+            .populate({path: 'author'})
+            .populate({path: 'machine'})
+            .populate({path: 'material'})
+            .populate({path: 'defaultMachine'})
+            .exec();
+
+        return response.render('viewOnePrintingSetup', {printingSetup});
+    } catch (error) {
+        console.log(error);
+        request.flash('errors', 'unable to find object using the ID which was provided');
+
+        return response.redirect('back');
+    }
+});
+
 router.get('/all/:recipeId', verifyJwtToken, async (request, response) => {
     const queryParams = request.query;
     const sortBy = queryParams.sortBy;

--- a/application/views/viewOnePrintingSetup.ejs
+++ b/application/views/viewOnePrintingSetup.ejs
@@ -1,0 +1,12 @@
+<h3>Author: <%= printingSetup.author && printingSetup.author.email || 'N/A' %></h3>
+<h3>Machine Name: <%= printingSetup.machine && printingSetup.machine.name || 'N/A' %></h3>
+<h3>Frames to Run: <%= printingSetup.framesToRun || 'N/A' %></h3>
+<h3>Notes: <%= printingSetup.notes || 'N/A' %></h3>
+<h3>Material Name: <%= printingSetup.material && printingSetup.material.name || 'N/A' %></h3>
+<h3>Video: <%= printingSetup.video || 'N/A' %></h3>
+<h3>Difficulty: <%= printingSetup.difficulty || 'N/A' %></h3>
+<h3>Alert Text Box: <%= printingSetup.alertTextBox || 'N/A' %></h3>
+<h3>Default Machine Name: <%= printingSetup.defaultMachine && printingSetup.defaultMachine.name || 'N/A' %></h3>
+<h3>Recipe ID: <%= printingSetup.recipe %></h3>
+<h3>Creation Date: <%= printingSetup.createdAt.toLocaleString("en-US", {year: 'numeric', month: 'long', day: 'numeric' }) %></h3>
+<h3>Last Updated: <%= printingSetup.updatedAt.toLocaleString("en-US", {year: 'numeric', month: 'long', day: 'numeric' }) %></h3>

--- a/application/views/viewOneWindingSetup.ejs
+++ b/application/views/viewOneWindingSetup.ejs
@@ -7,6 +7,6 @@
 <h3>BackWinding: <%= windingSetup.backWinding || 'N/A' %></h3>
 <h3>AlertTextBox: <%= windingSetup.alertTextBox || 'N/A' %></h3>
 <h3>Default Machine: <%= windingSetup.defaultMachine && windingSetup.defaultMachine.name || 'N/A' %></h3>
-<h3>Recipe: <%= windingSetup.recipe %></h3>
+<h3>Recipe ID: <%= windingSetup.recipe %></h3>
 <h3>Creation Date: <%= windingSetup.createdAt.toLocaleString("en-US", {year: 'numeric', month: 'long', day: 'numeric' }) %></h3>
 <h3>Last Updated: <%= windingSetup.updatedAt.toLocaleString("en-US", {year: 'numeric', month: 'long', day: 'numeric' }) %></h3>

--- a/application/views/viewPrintingSetups.ejs
+++ b/application/views/viewPrintingSetups.ejs
@@ -59,7 +59,7 @@
         <tbody>
           <% if (typeof printingSetups !='undefined' ) { %>
             <% printingSetups.forEach((printingSetup, index)=> { %>
-              <tr>
+              <tr onclick="window.location='/printing-setups/<%= printingSetup.id %>'">
                 <td scope="row" id="row">
                   <%= index + 1 %>
                 </td>


### PR DESCRIPTION
## Description

Previously a page existed that displayed every `printingSetup` object from the database via an HTML table.

After this PR, you can now click on any row of this table to view all the attributes on their very own page of whichever row was clicked.