### PR TITLE
Feature: Add Pagination to `materialOrder` Tableview Page

### DIFF
--- a/application/views/viewMaterialOrders.ejs
+++ b/application/views/viewMaterialOrders.ejs
@@ -18,7 +18,6 @@
             <input type="search" class=" recipe-search-bar" id="query" name="q" placeholder="Search...">
             <a class="btn btn-primary create-new-recipe" href="/material-orders/create" role="button">New Material Order</a>
           </div>
-    
         </div>
 
         <table class="table recipes" data-endpoint="/recipes">
@@ -101,8 +100,23 @@
                             </td>
                         </tr>
                     <% }) %>
-                <% } %> 
+                <% } %>
             </tbody>
         </table>
+        <div class="full-width pagination-box">
+      
+            <a class="arrow-box arrow-left <% if (pageNumber <= 1) { %>deactivate-me<% } %>" <% if (pageNumber > 1) { %>href="/material-orders?pageNumber=<%= parseInt(pageNumber) - 1 %>"<% } %>><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 325.92 325.92"><defs><style>.cls-1{fill:transparent;}</style></defs><g id="Layer_2" data-name="Layer 2"><g id="Layer_1-2" data-name="Layer 1"><path class="cls-1" d="M235.71,325.92H0V0H325.92V325.92H236.34q8.72-7.82,17.41-15.65l-.36-2.06L107.29,163.56,252.23,18.11,236.34,2.05,72.93,163.86a20.79,20.79,0,0,1,3.62,2.29Q155,244.74,233.33,323.39C234.15,324.21,234.92,325.08,235.71,325.92Z"/><path d="M235.71,325.92c-.79-.84-1.56-1.71-2.38-2.53Q155,244.76,76.55,166.15a20.79,20.79,0,0,0-3.62-2.29L236.34,2.05l15.89,16.06L107.29,163.56l146.1,144.65.36,2.06q-8.7,7.83-17.41,15.65Z"/></g></g></svg></a>
+            
+            <div class="wrapper">
+              <% for (let i = 1; i <= totalNumberOfPages; i++ ){ %>
+                <div class="pagination-number-frame">
+                  <a class="pagination-number <% if(pageNumber == i) { %>active<% } %> " href="/material-orders?pageNumber=<%= i %>"><%= i %></a> 
+                </div>
+              <% } %>
+            </div>
+            
+              <a class="arrow-box arrow-right <% if (pageNumber == totalNumberOfPages) { %>deactivate-me<% } %>" <% if (pageNumber != totalNumberOfPages) { %>href="/material-orders?pageNumber=<%= parseInt(pageNumber) + 1 %>"<% } %>><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 325.92 325.92"><defs><style>.cls-1{fill:transparent;}</style></defs><g id="Layer_2" data-name="Layer 2"><g id="Layer_1-2" data-name="Layer 1"><path class="cls-1" d="M90.22,325.92H0V0H325.92V325.92H90.85c.57-.62,1.11-1.26,1.71-1.85q78.58-78.87,157.22-157.69a24.49,24.49,0,0,1,3.82-2.54L90,1.82,74.1,17.89l145.47,146L73.05,309c1.93,1.67,3.38,2.76,4.64,4C81.9,317.27,86.05,321.61,90.22,325.92Z"/><path d="M90.22,325.92c-4.17-4.31-8.32-8.65-12.53-12.93-1.26-1.27-2.71-2.36-4.64-4L219.57,163.87,74.1,17.89,90,1.82l163.61,162a24.49,24.49,0,0,0-3.82,2.54Q171.14,245.19,92.56,324.07c-.6.59-1.14,1.23-1.71,1.85Z"/></g></g></svg></a>
+      
+          </div>
     </div>
 </div>


### PR DESCRIPTION
## Description

Before this PR, every object stored in the `materialOrder` database table would be displayed in a long HTML table.

After this PR, those results are truncated (aka paginated) so only a subset is displayed at any one time.

#### Screenshots
![image](https://user-images.githubusercontent.com/42784674/163653380-b06efd49-125f-4625-89b1-73fc8b3f00f1.png)
> After adding pagination to the HTML table