### PR TITLE
Fix Incorrect Value Displayed in Table Column

### DIFF
--- a/application/views/viewMaterialOrders.ejs
+++ b/application/views/viewMaterialOrders.ejs
@@ -68,7 +68,7 @@
                             <td><%= materialOrder.purchaseOrderNumber || 'N/A' %></td>
                             <td><%= materialOrder.material && materialOrder.material.name || 'N/A' %></td>
                             <td><%= materialOrder.totalRolls || 'N/A' %></td>
-                            <td><%= materialOrder.feetPerRoll || 'N/A' %></td>
+                            <td><%= materialOrder.feetPerRoll * materialOrder.totalRolls %></td>
                             <td><%= materialOrder.orderDate && materialOrder.orderDate.toLocaleString('en-US', {year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC'}) || 'N/A' %></td>
                             <td><%= materialOrder.arrivalDate && materialOrder.arrivalDate.toLocaleString('en-US', {year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC'}) || 'N/A' %></td>
                             <td><%= materialOrder.author && materialOrder.author.email || 'N/A' %></td>


### PR DESCRIPTION
## Description

It was desired that the number of feet displayed in this table was calculated based on the formula `materialOrder.totalRolls * materialOrder.feetPerRoll`.

However, it turned out the value was simply `materialOrder.feetPerRoll`, so this PR fixes that.

![image](https://user-images.githubusercontent.com/42784674/163653807-0b6d7579-11bb-4e6f-a340-fc71cc01eb3f.png)
> The column being updated