### PR TITLE
Feature: Add Page to Display Details about ONE `materialOrder` Object

### DIFF
--- a/application/controllers/materialOrdersController.js
+++ b/application/controllers/materialOrdersController.js
@@ -36,6 +36,25 @@ router.get('/', verifyJwtToken, async (request, response) => {
     }
 });
 
+router.get('/:id', verifyJwtToken, async (request, response) => {
+    try {
+        const materialOrder = await MaterialOrderModel
+            .findById(request.params.id)
+            .populate({path: 'author'})
+            .populate({path: 'vendor'})
+            .populate({path: 'material'})
+            .exec();
+
+        return response.render('viewOneMaterialOrder', {
+            materialOrder
+        });
+    } catch (error) {
+        console.log(error);
+        request.flash('errors', ['An error occurred while attempting to load that Material Order:', error.message]);
+        return response.redirect('back');
+    }
+});
+
 router.get('/create', verifyJwtToken, async (request, response) => {
     const materials = await MaterialModel.find().exec();
     const vendors = await VendorModel.find().exec();

--- a/application/views/viewMaterialOrders.ejs
+++ b/application/views/viewMaterialOrders.ejs
@@ -71,7 +71,7 @@
                             <td><%= materialOrder.feetPerRoll * materialOrder.totalRolls %></td>
                             <td><%= materialOrder.orderDate && materialOrder.orderDate.toLocaleString('en-US', {year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC'}) || 'N/A' %></td>
                             <td><%= materialOrder.arrivalDate && materialOrder.arrivalDate.toLocaleString('en-US', {year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC'}) || 'N/A' %></td>
-                            <td><%= materialOrder.author && materialOrder.author.email || 'N/A' %></td>
+                            <td><%= materialOrder.author && materialOrder.author.fullName || materialOrder.author.email %></td>
                             <td><%= materialOrder.totalCost || 'N/A' %></td>
                             <td><%= materialOrder.notes || 'N/A' %></td>
                             <td><%= materialOrder.vendor && materialOrder.vendor.name || 'N/A' %></td>

--- a/application/views/viewOneMaterialOrder.ejs
+++ b/application/views/viewOneMaterialOrder.ejs
@@ -1,0 +1,13 @@
+<% if (typeof materialOrder != 'undefined') { %>
+    <h3>P.O #: <%= materialOrder.purchaseOrderNumber || 'N/A' %></h3>
+    <h3>Material: <%= materialOrder.material && materialOrder.material.name || 'N/A' %></h3>
+    <h3>Total Rolls: <%= materialOrder.totalRolls || 'N/A' %></h3>
+    <h3>Feet Per Roll: <%= materialOrder.feetPerRoll * materialOrder.totalRolls %></h3>
+    <h3>Date Ordered: <%= materialOrder.orderDate && materialOrder.orderDate.toLocaleString('en-US', {year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC'}) || 'N/A' %></h3>
+    <h3>Arrival Date: <%= materialOrder.arrivalDate && materialOrder.arrivalDate.toLocaleString('en-US', {year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC'}) || 'N/A' %></h3>
+    <h3>Author: <%= materialOrder.author && materialOrder.author.fullName || materialOrder.author.email %></h3>
+    <h3>Total Cost: <%= materialOrder.totalCost || 'N/A' %></h3>
+    <h3>Notes: <%= materialOrder.notes || 'N/A' %></h3>
+    <h3>Vendor: <%= materialOrder.vendor && materialOrder.vendor.name || 'N/A' %></h3>
+    <h3>Status: <%= materialOrder.hasArrived ? 'Opened' : 'Closed' %></h3>
+<% } %> 


### PR DESCRIPTION
## Description

Previously a table existed that displayed all `materialOrder` objects displayed in the database.

This PR adds the ability for a user to "Click into" one of those objects and see additional information for only that object

![image](https://user-images.githubusercontent.com/42784674/163654544-f47ad8b0-61de-4795-8af1-0f3ebb82c47b.png)
> Newly added page, **NOTE** the page will be CSS styled in a future PR 