### PR TITLE
Fix Routing Issue

### DIFF
--- a/application/controllers/materialOrdersController.js
+++ b/application/controllers/materialOrdersController.js
@@ -53,6 +53,17 @@ router.get('/', verifyJwtToken, async (request, response) => {
     }
 });
 
+router.get('/create', verifyJwtToken, async (request, response) => {
+    const materials = await MaterialModel.find().exec();
+    const vendors = await VendorModel.find().exec();
+
+    return response.render('createMaterialOrder', {
+        materials,
+        vendors,
+        user: request.user
+    });
+});
+
 router.get('/:id', verifyJwtToken, async (request, response) => {
     try {
         const materialOrder = await MaterialOrderModel
@@ -70,17 +81,6 @@ router.get('/:id', verifyJwtToken, async (request, response) => {
         request.flash('errors', ['An error occurred while attempting to load that Material Order:', error.message]);
         return response.redirect('back');
     }
-});
-
-router.get('/create', verifyJwtToken, async (request, response) => {
-    const materials = await MaterialModel.find().exec();
-    const vendors = await VendorModel.find().exec();
-
-    return response.render('createMaterialOrder', {
-        materials,
-        vendors,
-        user: request.user
-    });
 });
 
 router.post('/create', verifyJwtToken, async (request, response) => {


### PR DESCRIPTION
## Description

Previously two API endpoints existed `GET material-orders/:id` and ` GET material-orders/create`.

However, it was learned that the order of these endpoints maters, since :id will take in any value following `material-orders/*` and be a match, therefore, the fix for this was to move `GET material-orders/create` above the other endpoint in the code so it is selected first.

Note: There's probably a better way to go about naming/placing these api endpoints, but this is fine for now.