### PR TITLE
Add `primaryMaterial` to TICKET Object

### DIFF
--- a/application/controllers/ticketController.js
+++ b/application/controllers/ticketController.js
@@ -90,6 +90,7 @@ router.get('/update/:id', async (request, response) => {
         const selectedPrintingType = ticket.printingType;
         const selectedDepartment = ticketDestination && ticketDestination.department;
         const selectedSubDepartment = ticketDestination && ticketDestination.subDepartment;
+        const selectedMaterial = ticket.primaryMaterial;
 
         const subDepartments = departments ? departments[selectedDepartment] : undefined;
 
@@ -102,7 +103,8 @@ router.get('/update/:id', async (request, response) => {
             selectedPrintingType,
             selectedDepartment,
             selectedSubDepartment,
-            subDepartments
+            subDepartments,
+            selectedMaterial
         });
     } catch (error) {
         console.log(`Error rendering ticket update page: ${error.message}`);

--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -3,6 +3,7 @@ const Schema = mongoose.Schema;
 const productSchema = require('./product').schema;
 const chargeSchema = require('./charge').schema;
 const {departments, getAllSubDepartments} = require('../enums/departmentsEnum');
+const MaterialModel = require('../models/material');
 
 // For help deciphering these regex expressions, visit: https://regexr.com/
 TICKET_NUMBER_REGEX = /^\d{1,}$/;
@@ -29,6 +30,22 @@ function departmentIsValid(department) {
 
 function subDepartmentIsValid(subDepartment) {
     return getAllSubDepartments().includes(subDepartment);
+}
+
+async function validateMaterialExists(materialId) {
+    const searchCriteria = {
+        materialId: {$regex: materialId, $options: 'i'}
+    };
+
+    console.log(searchCriteria);
+    
+    try {
+        const material = await MaterialModel.findOne(searchCriteria).exec();
+
+        return !material ? false : true;
+    } catch (error) {
+        return false;
+    }
 }
 
 const departmentNotesSchema = new Schema({
@@ -80,7 +97,8 @@ const ticketSchema = new Schema({
             if (this.products && this.products.length > 0) { // eslint-disable-line no-magic-numbers
                 return this.products[0].primaryMaterial;
             }
-        }
+        },
+        validate: [validateMaterialExists, 'Unknown material ID of "{VALUE}". Please add this material ID thru the admin panel before uploading the XML'],
     },
     departmentNotes: {
         type: departmentNotesSchema,

--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -73,6 +73,15 @@ const destinationSchema = new Schema({
 }, { timestamps: true });
 
 const ticketSchema = new Schema({
+    primaryMaterial: {
+        type: String,
+        required: false,
+        default: function() {
+            if (this.products && this.products.length > 0) { // eslint-disable-line no-magic-numbers
+                return this.products[0].primaryMaterial;
+            }
+        }
+    },
     departmentNotes: {
         type: departmentNotesSchema,
         required: false
@@ -240,6 +249,14 @@ const ticketSchema = new Schema({
         }
     }
 }, { timestamps: true });
+
+ticketSchema.pre('save', function(next) {
+    this.products && this.products.forEach((product) => {
+        product.primaryMaterial = this.primaryMaterial;
+    });
+
+    next();
+});
 
 const Ticket = mongoose.model('Ticket', ticketSchema);
 

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -18,8 +18,13 @@ $( document ).ready(function() {
 
     $('#material-selection').change(function() {
         const selectedMaterialId = $('#material-selection').val();
+        const ticketId = $('#department-notes').data('ticket-id');
 
-        console.log(`selectedMaterialId => ${selectedMaterialId}`);
+        const ticketAttributes = {
+            primaryMaterial: selectedMaterialId
+        };
+
+        updateTicket(ticketAttributes, ticketId);
     });
 
     $('#printing-type-selection').change(function() {

--- a/application/services/userService.js
+++ b/application/services/userService.js
@@ -16,7 +16,7 @@ module.exports.isUserLoggedIn = (jwtToken, jwtSecret) => {
         jwt.verify(jwtToken, jwtSecret);
         return true;
     } catch (error) {
-        console.log(`error during isJwtTokenValid(): ${JSON.stringify(error)}`);
+        console.log(`error during isJwtTokenValid(): ${error}`);
     }
 
     return false;

--- a/application/views/updateTicket.ejs
+++ b/application/views/updateTicket.ejs
@@ -18,9 +18,10 @@
         <div class="form-group">
             <label for="material-selection">Material</label>
             <select name="material" id="material-selection" data-ticket-id="<%= ticket.id %>">
-                <option value="-">-</option>
+                <option value="">-</option>
                 <% materialIds.forEach((materialId) => { %>
-                    <option value="<%= materialId %>"><%= materialId %></option>
+                    <% const isSelected = materialId === selectedMaterial ? 'selected' : ''; %>
+                    <option value="<%= materialId %>" <%= isSelected %>><%= materialId %></option>
                 <% }) %>
             </select>
         </div>
@@ -28,7 +29,7 @@
         <div class="form-group">
             <label for="printing-type-selection">Printing Type</label>
             <select name="printingType" id="printing-type-selection" data-ticket-id="<%= ticket.id %>">
-                <option value="-"><%= '-' %></option>
+                <option value=""><%= '-' %></option>
                 <option value="CMYK" <%= selectedPrintingType === 'CMYK' ? 'selected' : '' %>><%= 'CMYK' %></option>
                 <option value="CMYK + W" <%= selectedPrintingType === 'CMYK + W' ? 'selected' : '' %>><%= 'CMYK + W' %></option>
                 <option value="BLANKS" <%= selectedPrintingType === 'BLANKS' ? 'selected' : '' %>><%= 'Blanks' %></option>

--- a/test/models/ticket.spec.js
+++ b/test/models/ticket.spec.js
@@ -693,10 +693,37 @@ describe('validation', () => {
         });
 
         it('should contain attribute', () => {
-            ticketAttributes.primaryMaterial = 'blah';
+            ticketAttributes.primaryMaterial = chance.word();
             const ticket = new TicketModel(ticketAttributes);
 
             expect(ticket.primaryMaterial).toBeDefined();
+        });
+
+        it('should not fail validation if blank', () => {
+            ticketAttributes.primaryMaterial = '';
+            const ticket = new TicketModel(ticketAttributes);
+    
+            const error = ticket.validateSync();
+    
+            expect(error).toBe(undefined);
+        });
+
+        it('should fail validation if primaryMaterial is not an existing material ID', async () => {
+            ticketAttributes.primaryMaterial = chance.word();
+            const ticket = new TicketModel(ticketAttributes);
+    
+            const error = ticket.validateSync();
+    
+            expect(error).toBe(undefined);
+        });
+
+        it('should pass validation if primaryMaterial is not an existing material ID', async () => {
+            ticketAttributes.primaryMaterial = chance.word();
+            const ticket = new TicketModel(ticketAttributes);
+    
+            const error = ticket.validateSync();
+    
+            expect(error).toBe(undefined);
         });
 
         it('should default the ticket.primaryMaterial to product[0].primaryMaterial', async () => {

--- a/test/models/ticket.spec.js
+++ b/test/models/ticket.spec.js
@@ -1,6 +1,7 @@
 const chance = require('chance').Chance();
 const TicketModel = require('../../application/models/ticket');
 const {departments} = require('../../application/enums/departmentsEnum');
+const databaseService = require('../../application/services/databaseService');
 
 describe('validation', () => {
     let ticketAttributes;
@@ -678,6 +679,55 @@ describe('validation', () => {
             const error = ticket.validateSync();
 
             expect(error).not.toBe(undefined);
+        });
+    });
+
+    describe('attribute: primaryMaterial', () => {
+
+        beforeEach(async () => {
+            await databaseService.connectToTestMongoDatabase();
+        });
+
+        afterEach(async () => {
+            await databaseService.closeDatabase();
+        });
+
+        it('should contain attribute', () => {
+            ticketAttributes.primaryMaterial = 'blah';
+            const ticket = new TicketModel(ticketAttributes);
+
+            expect(ticket.primaryMaterial).toBeDefined();
+        });
+
+        it('should default the ticket.primaryMaterial to product[0].primaryMaterial', async () => {
+            delete ticketAttributes.primaryMaterial;
+
+            ticketAttributes.products = [
+                {primaryMaterial: chance.word()}
+            ];
+            const ticket = new TicketModel(ticketAttributes);
+
+            expect(ticket.primaryMaterial).toBe(ticketAttributes.products[0].primaryMaterial);
+        });
+
+        it('should use the ticket.primaryMaterial to override all ticket.products[n].primaryMaterial before saving', async () => {
+            const materialA = chance.word();
+            const materialB = chance.word();
+
+            ticketAttributes.primaryMaterial = materialA;
+
+            ticketAttributes.products = [
+                {primaryMaterial: materialB},
+                {primaryMaterial: materialB},
+                {primaryMaterial: undefined},
+            ];
+            const ticket = new TicketModel(ticketAttributes);
+
+            const savedTicket = await ticket.save({validateBeforeSave: false});
+
+            expect(savedTicket.products[0].primaryMaterial).toBe(savedTicket.primaryMaterial);
+            expect(savedTicket.products[1].primaryMaterial).toBe(savedTicket.primaryMaterial);
+            expect(savedTicket.products[2].primaryMaterial).toBe(savedTicket.primaryMaterial);
         });
     });
 });

--- a/test/services/databaseService.spec.js
+++ b/test/services/databaseService.spec.js
@@ -47,5 +47,4 @@ describe('test environment database interactions', () => {
 
         await expect(databaseService.clearDatabase()).rejects.toThrow('the database can ONLY be cleared manually in test environments');
     });
-
 });


### PR DESCRIPTION
## Description

A `TICKET` object is composed of many PRODUCTs. Each `PRODUCT` has a primaryMaterial attribute.

It was desired that this primaryMaterial attribute also be included on the TICKET object, and further, any updates to the TICKET.primaryMaterial need to overwrite all primaryMaterials stored on the PRODUCT objects.

This PR does all those things