### PR TITLE
Store Proof PDFs in AWS S3 Bucket

### DIFF
--- a/application/controllers/productController.js
+++ b/application/controllers/productController.js
@@ -28,7 +28,10 @@ router.post('/:productNumber/upload-proof', upload.single('proof'), async (reque
 
         const index = ticket.products.findIndex((product) => product.productNumber === productNumber);
 
-        ticket.products[index].proof = urlWhereTheFileIsStored;
+        ticket.products[index].proof = {
+            url: urlWhereTheFileIsStored,
+            fileName
+        };
 
         await ticket.save();
 

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -75,11 +75,22 @@ const alertSchema = new Schema({
     }
 }, { timestamps: true });
 
+const proofSchema = new Schema({
+    url: {
+        type: String,
+        validate: [validateUrl, 'Proof attribute "{VALUE}" is not a valid URL'],
+        required: true
+    },
+    fileName: {
+        type: String,
+        required: true
+    }
+}, { timestamps: true });
+
 const schema = new Schema({
     proof: {
-        type: String,
-        required: false,
-        validate: [validateUrl, 'Proof attribute "{VALUE}" is not a valid URL']
+        type: proofSchema,
+        required: false
     },
     hotFolder: {
         type: String,

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -7,6 +7,7 @@ const {getAllDepartments} = require('../enums/departmentsEnum');
 // For help deciphering these regex expressions, visit: https://regexr.com/
 PRODUCT_NUMBER_REGEX = /^\d{3,4}D-\d{1,}$/;
 PRODUCT_DIE_REGEX = /(DR|DO|DC|DSS|XLDR|DB|DD|DRC|DCC)-(.{1,})/;
+URL_VALIDATION_REGEX = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?)/;
 
 const NUMBER_OF_PENNIES_IN_A_DOLLAR = 100;
 const NUMBER_OF_DECIMAL_PLACES_IN_CURRENCY = 2;
@@ -57,32 +58,9 @@ function validateCornerRadius(cornerRadius) {
     return greaterThanOrEqualToZero && lessThanOne;
 }
 
-function validateProofAttributes(proof) {
-    if (!proof) {
-        return true;
-    }
-
-    const fileNameOrContentTypeIsMissing = !proof.fileName || !proof.contentType;
-
-    if (fileNameOrContentTypeIsMissing) {
-        return false;
-    }
-
-    return true;
+function validateUrl(url) {
+    return URL_VALIDATION_REGEX.test(url);
 }
-
-const proofSchema = new Schema({
-    data: {
-        type: Buffer
-    },
-    contentType: {
-        type: String,
-        enum: ['application/pdf']
-    },
-    fileName: {
-        type: String
-    }
-}, { timestamps: true });
 
 const alertSchema = new Schema({
     department: {
@@ -99,8 +77,9 @@ const alertSchema = new Schema({
 
 const schema = new Schema({
     proof: {
-        type: proofSchema,
-        validate: [validateProofAttributes, 'FileName or ContentType are not defined on the Proof']
+        type: String,
+        required: false,
+        validate: [validateUrl, 'Proof attribute "{VALUE}" is not a valid URL']
     },
     hotFolder: {
         type: String,

--- a/application/services/s3Service.js
+++ b/application/services/s3Service.js
@@ -1,0 +1,17 @@
+const AWS = require('aws-sdk');
+
+const s3 = new AWS.S3({
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY
+});
+
+
+module.exports.storeFileInS3 = async (fileName, fileContents) => {
+    const params = {
+        Bucket: process.env.AWS_BUCKET_NAME,
+        Key: fileName,
+        Body: fileContents
+    };
+
+    return await s3.upload(params).promise();
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1367,6 +1367,63 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "aws-sdk": {
+      "version": "2.1145.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1145.0.tgz",
+      "integrity": "sha512-bjZJGFxHJadnp2kbg1etKw7ID1QmmKk1ivML0Xtt6S6GnGSfX8zVuLMkJZaxPMjlyZ6xeilGwzk2F9igxBCPCQ==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.16.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "4.9.2",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "ieee754": {
+          "version": "1.1.13",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+          "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
+        "url": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
+    },
     "babel-jest": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-27.5.1.tgz",
@@ -2622,6 +2679,11 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "execa": {
       "version": "5.1.1",
@@ -4711,6 +4773,11 @@
         }
       }
     },
+    "jmespath": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
+    },
     "joi": {
       "version": "13.7.0",
       "resolved": "https://registry.npmjs.org/joi/-/joi-13.7.0.tgz",
@@ -5933,6 +6000,11 @@
         "sparse-bitfield": "^3.0.3"
       }
     },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
     "saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -6776,6 +6848,15 @@
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
     },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
     "xml2json": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/xml2json/-/xml2json-0.12.0.tgz",
@@ -6785,6 +6866,11 @@
         "joi": "^13.1.2",
         "node-expat": "^2.3.18"
       }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "nodemon": "2.0.15"
   },
   "dependencies": {
+    "aws-sdk": "2.1145.0",
     "bcryptjs": "2.4.3",
     "connect-flash": "0.1.1",
     "cookie-parser": "1.4.6",

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -1010,30 +1010,20 @@ describe('validation', () => {
     });
 
     describe('attribute: proof', () => {
+        let proof;
 
-        it('should contain attribute which is computed automatically', () => {
-            productAttributes.proof = chance.word();
+        beforeEach(() => {
+            proof = {
+                url: chance.url(),
+                fileName: chance.word()
+            };
+        });
+
+        it('should contain attribute', () => {
+            productAttributes.proof = proof;
             const product = new ProductModel(productAttributes);
 
             expect(product.proof).toBeDefined();
-        });
-
-        it('should fail validation if proof is not a valid URL', () => {
-            productAttributes.proof = chance.word();
-            const product = new ProductModel(productAttributes);
-
-            const error = product.validateSync();
-
-            expect(error).toBeDefined();
-        });
-
-        it('should pass validation if proof is a valid URL', () => {
-            productAttributes.proof = chance.url();
-            const product = new ProductModel(productAttributes);
-
-            const error = product.validateSync();
-
-            expect(error).not.toBeDefined();
         });
 
         it('should pass validation if proof is not defined', () => {
@@ -1043,6 +1033,47 @@ describe('validation', () => {
             const error = product.validateSync();
 
             expect(error).not.toBeDefined();
+        });
+
+        it('should fail validation if proof.url is not a valid URL', () => {
+            proof.url = chance.word();
+            productAttributes.proof = proof;
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+
+            expect(error).toBeDefined();
+        });
+
+        it('should pass validation if proof is a valid URL', () => {
+            proof.url = chance.url();
+            productAttributes.proof = proof;
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+
+            expect(error).not.toBeDefined();
+        });
+
+        it('should fail validation if proof.url is defined but fileName is not', () => {
+            delete proof.fileName;
+            productAttributes.proof = proof;
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+
+            expect(error).toBeDefined();
+        });
+
+        it('should fail validation if proof.fileName is defined but url is not', () => {
+            delete proof.url;
+            proof.fileName = chance.word();
+            productAttributes.proof = proof;
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+
+            expect(error).toBeDefined();
         });
     });
 });

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -1010,79 +1010,39 @@ describe('validation', () => {
     });
 
     describe('attribute: proof', () => {
-        let proof;
 
-        beforeEach(() => {
-            proof = {
-                contentType: 'application/pdf',
-                data: 10101,
-                fileName: chance.word(),
-            };
+        it('should contain attribute which is computed automatically', () => {
+            productAttributes.proof = chance.word();
+            const product = new ProductModel(productAttributes);
+
+            expect(product.proof).toBeDefined();
         });
 
-        it('should pass validation if all attributes are defined correctly', () => {
-            productAttributes.proof = proof;
-
+        it('should fail validation if proof is not a valid URL', () => {
+            productAttributes.proof = chance.word();
             const product = new ProductModel(productAttributes);
+
             const error = product.validateSync();
 
-            expect(error).toBe(undefined);
+            expect(error).toBeDefined();
         });
 
-        it('should fail validation if wrong contentType is used', () => {
-            const invalidType = chance.word();
-            productAttributes.proof = {
-                ...proof,
-                contentType: invalidType
-            };
-
+        it('should pass validation if proof is a valid URL', () => {
+            productAttributes.proof = chance.url();
             const product = new ProductModel(productAttributes);
+
             const error = product.validateSync();
 
-            expect(error).not.toBe(undefined);
+            expect(error).not.toBeDefined();
         });
 
-        it('should pass validation if contentType is an accepted value', () => {
-            const validContentType = 'application/pdf';
-            productAttributes.proof = {
-                ...proof,
-                contentType: validContentType
-            };
-
+        it('should pass validation if proof is not defined', () => {
+            delete productAttributes.proof;
             const product = new ProductModel(productAttributes);
+
             const error = product.validateSync();
 
-            expect(error).toBe(undefined);
-        });
-
-        it('should be an object with the correct attributes', () => {
-            productAttributes.proof = proof;
-
-            const product = new ProductModel(productAttributes);
-
-            expect(product.proof.contentType).toBe(proof.contentType);
-            expect(product.proof.data).toBeDefined();
-            expect(product.proof.fileName).toBe(proof.fileName);
-        });
-
-        it('should fail validation if data is provided but contentType is not', () => {
-            delete proof.contentType;
-            productAttributes.proof = proof;
-
-            const product = new ProductModel(productAttributes);
-            const error = product.validateSync();
-
-            expect(error).not.toBe(undefined);
-        });
-
-        it('should fail validation if data is provided but fileName is not', () => {
-            delete proof.fileName;
-            productAttributes.proof = proof;
-
-            const product = new ProductModel(productAttributes);
-            const error = product.validateSync();
-
-            expect(error).not.toBe(undefined);
+            expect(error).not.toBeDefined();
         });
     });
 });


### PR DESCRIPTION
## Description

Previously, a user was allowed to upload a PDF representing a "proof" into the MongoDB database.

However, MongoDB limits the size of each document to 18MB, therefore, any PDF uploaded which is over 18MB results in an exception.

This PR fixes that issue by instead shipping those PDFs to an AWS S3 bucket and only storing that resulting S3 object URL in MongoDB 🎊 

Pretty cool eh?! 