### PR TITLE
Feature: Group Tickets by Department

### DIFF
--- a/application/controllers/ticketController.js
+++ b/application/controllers/ticketController.js
@@ -8,7 +8,7 @@ const ticketService = require('../services/ticketService');
 const TicketModel = require('../models/ticket');
 const mongooseService = require('../services/mongooseService');
 const MaterialModel = require('../models/material');
-const {departments} = require('../enums/departmentsEnum');
+const {departments, getAllDepartments} = require('../enums/departmentsEnum');
 
 router.use(verifyJwtToken);
 
@@ -17,10 +17,16 @@ function deleteFileFromFileSystem(path) {
 }
 
 router.get('/', async (request, response) => {
-    const tickets = await TicketModel.find({}, 'ticketNumber destination').exec();
+    const tickets = await TicketModel
+        .find()
+        .exec();
+
+    const departments = getAllDepartments();
+
+    const ticketsGroupedByDepartment = ticketService.groupTicketsByDepartment(tickets, departments);
 
     return response.render('viewTickets', {
-        tickets
+        ticketsGroupedByDepartment
     });
 });
 

--- a/application/services/ticketService.js
+++ b/application/services/ticketService.js
@@ -77,3 +77,25 @@ module.exports.convertedUploadedTicketDataToProperFormat = (rawUploadedTicket) =
         extraCharges
     };
 };
+
+module.exports.groupTicketsByDepartment = (tickets, departments) => {
+    let ticketsGroupedByDepartment = [];
+    const inProgress = 'IN PROGRESS';
+    ticketsGroupedByDepartment[inProgress] = [];
+
+    departments.forEach((department) => {
+        ticketsGroupedByDepartment[department] = [];
+    });
+
+    tickets.forEach((ticket) => {
+        const destination = ticket.destination;
+
+        if (destination && destination.department) {
+            ticketsGroupedByDepartment[destination.department].push(ticket);
+        } else {
+            ticketsGroupedByDepartment[inProgress].push(ticket);
+        }
+    });
+
+    return ticketsGroupedByDepartment;
+};

--- a/application/views/viewTickets.ejs
+++ b/application/views/viewTickets.ejs
@@ -17,59 +17,65 @@
   
       </div>
 
-    <div class="table-wrapper">
-        <table class="table recipes" data-endpoint="/recipes">
-            <thead role="rowgroup">
-                <tr role="row">
-                    <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="none" class="">
-                        <div>Ticket Number</div>
-                    </th>
-                    <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="none" class="">
-                        <div>Department</div>
-                    </th>
-                    <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="none" class="">
-                        <div>SubDepartment</div>
-                    </th>
-                    <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="none" class="">
-                        <div>Actions</div>
-                    </th>
-                </tr>
-            </thead>
-            <tbody>
-                <% if (typeof tickets != 'undefined') { %>
-                    <% tickets.forEach((ticket) => { %>
-                        <tr>
-                            <td><%= ticket.ticketNumber %></td>
-                            <td><%= ticket.destination && ticket.destination.department %></td>
-                            <td><%= ticket.destination && ticket.destination.subDepartment %></td>
-                            <td>
-                                <div class="options-reveal-box">
-                                    <svg data-v-32017d0f="" xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="align-middle text-body feather feather-more-vertical"><circle data-v-32017d0f="" cx="12" cy="12" r="1"></circle><circle data-v-32017d0f="" cx="12" cy="5" r="1"></circle><circle data-v-32017d0f="" cx="12" cy="19" r="1"></circle></svg>
-                                    <ul class="options-dropdown">
-                                      <li>
-                                        <a href="/tickets/<%= ticket.id %>">
-                                          <svg xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-eye"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle></svg> View
-                                        </a>
-                                      </li>
-                                      <li>
-                                        <a href="/tickets/update/<%= ticket.id %>">
-                                          <svg data-v-32017d0f="" xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-edit"><path data-v-32017d0f="" d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path data-v-32017d0f="" d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg> Edit
-                                        </a>
-                                      </li>
-                                      <li>
-                                        <a href="/tickets/delete/<%= ticket.id %>">
-                                          <svg data-v-32017d0f="" xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-trash"><polyline data-v-32017d0f="" points="3 6 5 6 21 6"></polyline><path data-v-32017d0f="" d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg> Delete
-                                        </a>
-                                      </li>
-                                    </ul>
-                                </div>
-                            </td>
-                        </tr>
-                    <% }) %>
+      <% if (typeof ticketsGroupedByDepartment != 'undefined') { %>
+        <% Object.keys(ticketsGroupedByDepartment).forEach((department) => { %>
+          <div class="table-wrapper">
+            <table class="table recipes">
+              <caption>Department: <%= department %></caption>
+              <thead role="rowgroup">
+                  <tr role="row">
+                      <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="none" class="">
+                          <div>Ticket Number</div>
+                      </th>
+                      <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="none" class="">
+                          <div>Department</div>
+                      </th>
+                      <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="none" class="">
+                          <div>SubDepartment</div>
+                      </th>
+                      <th role="columnheader" scope="col" tabindex="0" aria-colindex="1" aria-sort="none" class="">
+                          <div>Actions</div>
+                      </th>
+                  </tr>
+              </thead>
+
+              <tbody>
+                <% if (ticketsGroupedByDepartment[department].length) { %>
+                  <% ticketsGroupedByDepartment[department].forEach((ticket) => { %>
+                    <tr>
+                      <td><%= ticket.ticketNumber %></td>
+                      <td><%= ticket.destination && ticket.destination.department %></td>
+                      <td><%= ticket.destination && ticket.destination.subDepartment %></td>
+                      <td>
+                        <div class="options-reveal-box">
+                          <svg data-v-32017d0f="" xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="align-middle text-body feather feather-more-vertical"><circle data-v-32017d0f="" cx="12" cy="12" r="1"></circle><circle data-v-32017d0f="" cx="12" cy="5" r="1"></circle><circle data-v-32017d0f="" cx="12" cy="19" r="1"></circle></svg>
+                          <ul class="options-dropdown">
+                          <li>
+                            <a href="/tickets/<%= ticket.id %>">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-eye"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path><circle cx="12" cy="12" r="3"></circle></svg> View
+                            </a>
+                          </li>
+                          <li>
+                            <a href="/tickets/update/<%= ticket.id %>">
+                            <svg data-v-32017d0f="" xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-edit"><path data-v-32017d0f="" d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path><path data-v-32017d0f="" d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path></svg> Edit
+                            </a>
+                          </li>
+                          <li>
+                            <a href="/tickets/delete/<%= ticket.id %>">
+                            <svg data-v-32017d0f="" xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-trash"><polyline data-v-32017d0f="" points="3 6 5 6 21 6"></polyline><path data-v-32017d0f="" d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path></svg> Delete
+                            </a>
+                          </li>
+                          </ul>
+                        </div>
+                      </td>
+                    </tr>
+                  <% }) %>
                 <% } %>
-            </tbody>
-        </table>
-    </div>
+              </tbody>
+            </table>
+          </div>
+        <% }); %>
+      <% } %>
 </div>
 
 

--- a/test/services/ticketService.spec.js
+++ b/test/services/ticketService.spec.js
@@ -111,5 +111,56 @@ describe('ticketService test suite', () => {
             expect(ticket.extraCharges.length).toBe(numberOfCharges);
         });
     });
+
+    describe('groupTicketsByDepartment', () => {
+        let ticketsWithDepartments;
+        let ticketsWithoutDepartments;
+        let allTickets;
+        let departmentNames;
+        const defaultDepartmentName = 'IN PROGRESS';
+
+        beforeEach(() => {
+            departmentNames = [chance.word(), chance.word(), chance.word()];
+            ticketsWithDepartments = [
+                {
+                    destination: {
+                        department: departmentNames[0]
+                    }
+                },
+                {
+                    destination: {
+                        department: departmentNames[1]
+                    }
+                },
+                {
+                    destination: {
+                        department: departmentNames[2]
+                    }
+                }
+            ];
+            ticketsWithoutDepartments = [{}, {}, {}, {}, {}];
+
+            allTickets = [...ticketsWithDepartments, ...ticketsWithoutDepartments];
+        });
+
+        it('should generate correct department names', () => {
+            const groupedTicketsByDepartment = ticketService.groupTicketsByDepartment(allTickets, departmentNames);
+
+            expect(Object.keys(groupedTicketsByDepartment)).toEqual(expect.arrayContaining([departmentNames[0], departmentNames[1], departmentNames[2], defaultDepartmentName]));
+        });
+
+        it('should map list of tickets according to department', () => {
+            const groupedTicketsByDepartment = ticketService.groupTicketsByDepartment(allTickets, departmentNames);
+            const numberOfDepartmentNamesPlusTheDefaultName = departmentNames.length + 1;
+
+            expect(Object.keys(groupedTicketsByDepartment).length).toBe(numberOfDepartmentNamesPlusTheDefaultName);
+        });
+
+        it('should group tickets without a known department to be placed into a group with some default group name', () => {
+            const groupedTicketsByDepartment = ticketService.groupTicketsByDepartment(allTickets, departmentNames);
+
+            expect(groupedTicketsByDepartment[defaultDepartmentName].length).toBe(ticketsWithoutDepartments.length);
+        });
+    });
 });
 


### PR DESCRIPTION
## Description

Previously, there was a UI View that displayed a single table with every Ticket object listed

Each of those ticket objects has an attribute called "department" and it was decided that the UI View should display many tables, with each view displaying the tickets for a specific department.

The end result is a list of 10 HTML tables, where each table represents the tickets for each of the following departments:
  1. `IN PROGRESS`
  2. `ORDER PREP`
  3. `ART PREP`
  4. `PRE-PRESS`
  5. `PRINTING`
  6. `CUTTING`
  7. `WINDING`
  8. `SHIPPING`
  9. `BILLING`
  10. `COMPLETE`
