### PR TITLE
Add `Material Inventory` Page

### DIFF
--- a/application/controllers/materialInventory.js
+++ b/application/controllers/materialInventory.js
@@ -1,5 +1,6 @@
 const router = require('express').Router();
 const {verifyJwtToken} = require('../middleware/authorize');
+const materialOrderService = require('../services/materialOrderService');
 
 const MaterialInventoryService = require('../services/materialInventoryService');
 
@@ -8,9 +9,15 @@ router.use(verifyJwtToken);
 router.get('/', async (request, response) => {
     try {
         const materialInventories = await MaterialInventoryService.getAllMaterialInventoryData();
+        const lengthOfAllMaterialsInInventory = await materialOrderService.getLengthOfAllMaterialsInInventory();
+        const lengthOfAllMaterialsOrdered = await materialOrderService.getLengthOfAllMaterialsOrdered();
+        const totalPurchaseOrders = await materialOrderService.getNumberOfPurchaseOrders();
         
         return response.render('viewMaterialInventory', {
-            materialInventories
+            materialInventories,
+            lengthOfAllMaterialsInInventory,
+            lengthOfAllMaterialsOrdered,
+            totalPurchaseOrders
         });
 
     } catch (error) {

--- a/application/controllers/materialInventory.js
+++ b/application/controllers/materialInventory.js
@@ -2,13 +2,13 @@ const router = require('express').Router();
 const {verifyJwtToken} = require('../middleware/authorize');
 const materialOrderService = require('../services/materialOrderService');
 
-const MaterialInventoryService = require('../services/materialInventoryService');
+const materialInventoryService = require('../services/materialInventoryService');
 
 router.use(verifyJwtToken);
 
 router.get('/', async (request, response) => {
     try {
-        const materialInventories = await MaterialInventoryService.getAllMaterialInventoryData();
+        const materialInventories = await materialInventoryService.getAllMaterialInventoryData();
         const lengthOfAllMaterialsInInventory = await materialOrderService.getLengthOfAllMaterialsInInventory();
         const lengthOfAllMaterialsOrdered = await materialOrderService.getLengthOfAllMaterialsOrdered();
         const totalPurchaseOrders = await materialOrderService.getNumberOfPurchaseOrders();

--- a/application/controllers/materialInventory.js
+++ b/application/controllers/materialInventory.js
@@ -1,0 +1,24 @@
+const router = require('express').Router();
+const {verifyJwtToken} = require('../middleware/authorize');
+
+const MaterialInventoryService = require('../services/materialInventoryService');
+
+router.use(verifyJwtToken);
+
+router.get('/', async (request, response) => {
+    try {
+        const materialInventories = await MaterialInventoryService.getAllMaterialInventoryData();
+        
+        return response.render('viewMaterialInventory', {
+            materialInventories
+        });
+
+    } catch (error) {
+        console.log(`An error occurred while attempting to load /material-inventory: ${error}`);
+
+        request.flash('errors', ['The following error(s) occurred:', error]);
+        return response.redirect('back');
+    }
+});
+
+module.exports = router;

--- a/application/controllers/materialOrdersController.js
+++ b/application/controllers/materialOrdersController.js
@@ -157,6 +157,10 @@ router.get('/update/:id', async (request, response) => {
 
 router.post('/update/:id', async (request, response) => {
     try {
+        if (!request.body.hasArrived) {
+            request.body.hasArrived = false;
+        }
+
         await MaterialOrderModel.findByIdAndUpdate(request.params.id, request.body).exec();
 
         request.flash('alerts', 'Updated successfully');

--- a/application/index.js
+++ b/application/index.js
@@ -18,40 +18,7 @@ const app = express();
 
 const http = require('http').Server(app);
 const io = require('socket.io')(http);
-
-const PurchaseOrderModel = require('./models/materialOrder');
-
-const materialOrderService = require('./services/materialOrderService')
-
-PurchaseOrderModel.watch().on('change', async (change) => {
-    console.log(`Change to a PurchaseOrder in database ${JSON.stringify(change)}`)
-
-    const purchaseOrder = await PurchaseOrderModel
-        .findById(change.documentKey._id)
-        .populate({path: 'material'})
-        .lean()
-        .exec();
-
-    const materialObjectId = purchaseOrder.material ? purchaseOrder.material._id : null;
-
-    if (!materialObjectId) {
-        return;
-    }
-
-    const lengthOfMaterialOrdered = await materialOrderService.getLengthOfOneMaterialOrdered(materialObjectId);
-    const lengthOfMaterialInStock = await materialOrderService.getLengthOfOneMaterialInInventory(materialObjectId);
-    const lengthOfAllMaterialsInInventory = await materialOrderService.getLengthOfAllMaterialsInInventory();
-    const lengthOfAllMaterialsOrdered = await materialOrderService.getLengthOfAllMaterialsOrdered();
-    const totalPurchaseOrders = await materialOrderService.getNumberOfPurchaseOrders();
-
-    io.emit(materialObjectId, {
-        lengthOfMaterialOrdered,
-        lengthOfMaterialInStock,
-        lengthOfAllMaterialsInInventory,
-        lengthOfAllMaterialsOrdered,
-        totalPurchaseOrders
-    })
-});
+require('./services/socketService')(io);    // Initalize sockets listeners/emitters
 
 app.use(expressLayouts);
 app.use(express.json());

--- a/application/index.js
+++ b/application/index.js
@@ -54,6 +54,7 @@ app.use('/vendors', require('./controllers/vendorController'));
 app.use('/material-orders', require('./controllers/materialOrdersController'));
 app.use('/tickets', require('./controllers/ticketController'));
 app.use('/products', require('./controllers/productController'));
+app.use('/material-inventory', require('./controllers/materialInventory'));
 
 databaseConnection.on('error', (error) => {
     throw new Error(`Error connecting to the database: ${error}`);

--- a/application/index.js
+++ b/application/index.js
@@ -18,7 +18,7 @@ const app = express();
 
 const http = require('http').Server(app);
 const io = require('socket.io')(http);
-require('./services/socketService')(io);    // Initalize sockets listeners/emitters
+require('./services/socketService')(io); // Initalize sockets listeners/emitters
 
 app.use(expressLayouts);
 app.use(express.json());

--- a/application/services/materialInventoryService.js
+++ b/application/services/materialInventoryService.js
@@ -3,7 +3,10 @@ const materialOrderService = require('../services/materialOrderService');
 
 module.exports.getAllMaterialInventoryData = async () => {
     let materialInventories = [];
-    const materials = await MaterialModel.find().exec();
+    const materials = await MaterialModel
+        .find()
+        .lean()
+        .exec();
 
     for (let i = 0; i < materials.length; i++) {
         const material = materials[i];
@@ -12,8 +15,7 @@ module.exports.getAllMaterialInventoryData = async () => {
         const lengthOfMaterialInStock = await materialOrderService.getLengthOfOneMaterialInInventory(material._id);
 
         materialInventories.push({
-            materialName: material.name,
-            materialId: material.materialId,
+            ...material,
             lengthOfMaterialOrdered,
             lengthOfMaterialInStock
         });

--- a/application/services/materialInventoryService.js
+++ b/application/services/materialInventoryService.js
@@ -17,7 +17,7 @@ module.exports.getAllMaterialInventoryData = async () => {
         const purchaseOrdersForMaterial = await materialOrderService.findPurchaseOrdersByMaterial(materialId);
 
         materialInventories.push({
-            ...material,
+            material,
             lengthOfMaterialOrdered,
             lengthOfMaterialInStock,
             purchaseOrdersForMaterial

--- a/application/services/materialInventoryService.js
+++ b/application/services/materialInventoryService.js
@@ -10,14 +10,17 @@ module.exports.getAllMaterialInventoryData = async () => {
 
     for (let i = 0; i < materials.length; i++) {
         const material = materials[i];
+        const materialId = material._id;
 
-        const lengthOfMaterialOrdered = await materialOrderService.getLengthOfOneMaterialOrdered(material._id);
-        const lengthOfMaterialInStock = await materialOrderService.getLengthOfOneMaterialInInventory(material._id);
+        const lengthOfMaterialOrdered = await materialOrderService.getLengthOfOneMaterialOrdered(materialId);
+        const lengthOfMaterialInStock = await materialOrderService.getLengthOfOneMaterialInInventory(materialId);
+        const purchaseOrdersForMaterial = await materialOrderService.findPurchaseOrdersByMaterial(materialId);
 
         materialInventories.push({
             ...material,
             lengthOfMaterialOrdered,
-            lengthOfMaterialInStock
+            lengthOfMaterialInStock,
+            purchaseOrdersForMaterial
         });
     }
 

--- a/application/services/materialInventoryService.js
+++ b/application/services/materialInventoryService.js
@@ -1,20 +1,5 @@
-const MaterialOrderModel = require('../models/materialOrder');
 const MaterialModel = require('../models/material');
-
-async function computeTotalRollsPurchasedForAMaterial(materialId) {
-    const searchQuery = {material: materialId};
-    const materialPurchaseOrders = await MaterialOrderModel
-        .find(searchQuery)
-        .exec();
-    
-    let totalRollsPurchased = 0;
-
-    materialPurchaseOrders.forEach((materialPurchaseOrder) => {
-        totalRollsPurchased += materialPurchaseOrder.totalRolls;
-    });
-
-    return totalRollsPurchased;
-}
+const materialOrderService = require('../services/materialOrderService');
 
 module.exports.getAllMaterialInventoryData = async () => {
     let materialInventories = [];
@@ -23,11 +8,14 @@ module.exports.getAllMaterialInventoryData = async () => {
     for (let i = 0; i < materials.length; i++) {
         const material = materials[i];
 
-        const totalRollsPurchased = await computeTotalRollsPurchasedForAMaterial(material._id);
+        const lengthOfMaterialOrdered = await materialOrderService.getLengthOfOneMaterialOrdered(material._id);
+        const lengthOfMaterialInStock = await materialOrderService.getLengthOfOneMaterialInInventory(material._id);
 
         materialInventories.push({
             materialName: material.name,
-            totalRollsPurchased
+            materialId: material.materialId,
+            lengthOfMaterialOrdered,
+            lengthOfMaterialInStock
         });
     }
 

--- a/application/services/materialInventoryService.js
+++ b/application/services/materialInventoryService.js
@@ -1,0 +1,35 @@
+const MaterialOrderModel = require('../models/materialOrder');
+const MaterialModel = require('../models/material');
+
+async function computeTotalRollsPurchasedForAMaterial(materialId) {
+    const searchQuery = {material: materialId};
+    const materialPurchaseOrders = await MaterialOrderModel
+        .find(searchQuery)
+        .exec();
+    
+    let totalRollsPurchased = 0;
+
+    materialPurchaseOrders.forEach((materialPurchaseOrder) => {
+        totalRollsPurchased += materialPurchaseOrder.totalRolls;
+    });
+
+    return totalRollsPurchased;
+}
+
+module.exports.getAllMaterialInventoryData = async () => {
+    let materialInventories = [];
+    const materials = await MaterialModel.find().exec();
+
+    for (let i = 0; i < materials.length; i++) {
+        const material = materials[i];
+
+        const totalRollsPurchased = await computeTotalRollsPurchasedForAMaterial(material._id);
+
+        materialInventories.push({
+            materialName: material.name,
+            totalRollsPurchased
+        });
+    }
+
+    return materialInventories;
+};

--- a/application/services/materialOrderService.js
+++ b/application/services/materialOrderService.js
@@ -1,0 +1,81 @@
+const MaterialOrderModel = require('../models/materialOrder');
+
+async function getAllPurchaseOrders() {
+    return await MaterialOrderModel
+        .find()
+        .exec();
+}
+
+function getTotalLengthOfMaterial({totalRolls, feetPerRoll}) {
+    return totalRolls * feetPerRoll;
+}
+
+module.exports.getLengthOfOneMaterialOrdered = async (materialId) => {
+    const searchQuery = {
+        material: materialId
+    };
+    const purchaseOrders = await MaterialOrderModel
+        .find(searchQuery)
+        .exec();
+    
+    let totalRollsPurchased = 0;
+
+    purchaseOrders.forEach((purchaseOrder) => {
+        totalRollsPurchased += getTotalLengthOfMaterial(purchaseOrder);
+    });
+
+    return totalRollsPurchased;
+}
+
+module.exports.getLengthOfOneMaterialInInventory = async (materialId) => {
+    const searchQuery = {
+        material: materialId
+    };
+    const purchaseOrders = await MaterialOrderModel
+        .find(searchQuery)
+        .exec();
+    
+    let totalLength = 0;
+
+    purchaseOrders.forEach((purchaseOrder) => {
+        if (purchaseOrder.hasArrived) {
+            totalLength += getTotalLengthOfMaterial(purchaseOrder);
+        }
+    });
+
+    return totalLength;
+}
+
+module.exports.getLengthOfAllMaterialsInInventory = async () => {
+    const purchaseOrders = await getAllPurchaseOrders();
+
+    let totalFeetOnHand = 0;
+
+    purchaseOrders.forEach((purchaseOrder) => {
+        if (purchaseOrder.hasArrived) {
+            totalFeetOnHand += getTotalLengthOfMaterial(purchaseOrder);
+        }
+    });
+
+    return totalFeetOnHand;
+}
+
+module.exports.getLengthOfAllMaterialsOrdered = async () => {
+    const purchaseOrders = await getAllPurchaseOrders();
+
+    let totalFeetThatHasNotArrivedYet = 0;
+
+    purchaseOrders.forEach((purchaseOrder) => {
+        if (!purchaseOrder.hasArrived) {
+            totalFeetThatHasNotArrivedYet += getTotalLengthOfMaterial(purchaseOrder);
+        }
+    });
+
+    return totalFeetThatHasNotArrivedYet;
+};
+
+module.exports.getNumberOfPurchaseOrders = async () => {
+    const purchaseOrders = await getAllPurchaseOrders();
+        
+    return purchaseOrders.length;
+}

--- a/application/services/materialOrderService.js
+++ b/application/services/materialOrderService.js
@@ -25,7 +25,7 @@ module.exports.getLengthOfOneMaterialOrdered = async (materialId) => {
     });
 
     return totalRollsPurchased;
-}
+};
 
 module.exports.getLengthOfOneMaterialInInventory = async (materialId) => {
     const searchQuery = {
@@ -44,7 +44,7 @@ module.exports.getLengthOfOneMaterialInInventory = async (materialId) => {
     });
 
     return totalLength;
-}
+};
 
 module.exports.getLengthOfAllMaterialsInInventory = async () => {
     const purchaseOrders = await getAllPurchaseOrders();
@@ -58,7 +58,7 @@ module.exports.getLengthOfAllMaterialsInInventory = async () => {
     });
 
     return totalFeetOnHand;
-}
+};
 
 module.exports.getLengthOfAllMaterialsOrdered = async () => {
     const purchaseOrders = await getAllPurchaseOrders();
@@ -78,4 +78,4 @@ module.exports.getNumberOfPurchaseOrders = async () => {
     const purchaseOrders = await getAllPurchaseOrders();
         
     return purchaseOrders.length;
-}
+};

--- a/application/services/materialOrderService.js
+++ b/application/services/materialOrderService.js
@@ -1,7 +1,7 @@
-const MaterialOrderModel = require('../models/materialOrder');
+const PurchaseOrderModel = require('../models/materialOrder');
 
 async function getAllPurchaseOrders() {
-    return await MaterialOrderModel
+    return await PurchaseOrderModel
         .find()
         .exec();
 }
@@ -10,13 +10,18 @@ function getTotalLengthOfMaterial({totalRolls, feetPerRoll}) {
     return totalRolls * feetPerRoll;
 }
 
-module.exports.getLengthOfOneMaterialOrdered = async (materialId) => {
+module.exports.findPurchaseOrdersByMaterial = async (materialId) => {
     const searchQuery = {
         material: materialId
     };
-    const purchaseOrders = await MaterialOrderModel
+
+    return await PurchaseOrderModel
         .find(searchQuery)
         .exec();
+};
+
+module.exports.getLengthOfOneMaterialOrdered = async (materialId) => {
+    const purchaseOrders = await this.findPurchaseOrdersByMaterial(materialId);
     
     let totalRollsPurchased = 0;
 
@@ -31,7 +36,7 @@ module.exports.getLengthOfOneMaterialInInventory = async (materialId) => {
     const searchQuery = {
         material: materialId
     };
-    const purchaseOrders = await MaterialOrderModel
+    const purchaseOrders = await PurchaseOrderModel
         .find(searchQuery)
         .exec();
     

--- a/application/services/socketService.js
+++ b/application/services/socketService.js
@@ -13,6 +13,10 @@ module.exports = function(io){
             .lean()
             .exec();
 
+        if (!purchaseOrder) {
+            return;
+        }
+
         const materialObjectId = purchaseOrder.material ? purchaseOrder.material._id : null;
 
         if (!materialObjectId) {

--- a/application/services/socketService.js
+++ b/application/services/socketService.js
@@ -34,7 +34,8 @@ module.exports = function(io){
             lengthOfMaterialInStock,
             lengthOfAllMaterialsInInventory,
             lengthOfAllMaterialsOrdered,
-            totalPurchaseOrders
+            totalPurchaseOrders,
+            purchaseOrder
         });
     });
 };

--- a/application/services/socketService.js
+++ b/application/services/socketService.js
@@ -1,0 +1,36 @@
+const PurchaseOrderModel = require('../models/materialOrder');
+const materialOrderService = require('../services/materialOrderService')
+
+module.exports = function(io){
+   console.log('Initializing Sockets...');
+
+   PurchaseOrderModel.watch().on('change', async (change) => {
+    console.log(`Change to a PurchaseOrder in database ${JSON.stringify(change)}`)
+
+    const purchaseOrder = await PurchaseOrderModel
+        .findById(change.documentKey._id)
+        .populate({path: 'material'})
+        .lean()
+        .exec();
+
+    const materialObjectId = purchaseOrder.material ? purchaseOrder.material._id : null;
+
+    if (!materialObjectId) {
+        return;
+    }
+
+    const lengthOfMaterialOrdered = await materialOrderService.getLengthOfOneMaterialOrdered(materialObjectId);
+    const lengthOfMaterialInStock = await materialOrderService.getLengthOfOneMaterialInInventory(materialObjectId);
+    const lengthOfAllMaterialsInInventory = await materialOrderService.getLengthOfAllMaterialsInInventory();
+    const lengthOfAllMaterialsOrdered = await materialOrderService.getLengthOfAllMaterialsOrdered();
+    const totalPurchaseOrders = await materialOrderService.getNumberOfPurchaseOrders();
+
+    io.emit(materialObjectId, {
+        lengthOfMaterialOrdered,
+        lengthOfMaterialInStock,
+        lengthOfAllMaterialsInInventory,
+        lengthOfAllMaterialsOrdered,
+        totalPurchaseOrders
+    })
+});
+}

--- a/application/services/socketService.js
+++ b/application/services/socketService.js
@@ -1,36 +1,36 @@
 const PurchaseOrderModel = require('../models/materialOrder');
-const materialOrderService = require('../services/materialOrderService')
+const materialOrderService = require('../services/materialOrderService');
 
 module.exports = function(io){
-   console.log('Initializing Sockets...');
+    console.log('Initializing Sockets...');
 
-   PurchaseOrderModel.watch().on('change', async (change) => {
-    console.log(`Change to a PurchaseOrder in database: ${JSON.stringify(change)}`)
+    PurchaseOrderModel.watch().on('change', async (change) => {
+        console.log(`Change to a PurchaseOrder in database: ${JSON.stringify(change)}`);
 
-    const purchaseOrder = await PurchaseOrderModel
-        .findById(change.documentKey._id)
-        .populate({path: 'material'})
-        .lean()
-        .exec();
+        const purchaseOrder = await PurchaseOrderModel
+            .findById(change.documentKey._id)
+            .populate({path: 'material'})
+            .lean()
+            .exec();
 
-    const materialObjectId = purchaseOrder.material ? purchaseOrder.material._id : null;
+        const materialObjectId = purchaseOrder.material ? purchaseOrder.material._id : null;
 
-    if (!materialObjectId) {
-        return;
-    }
+        if (!materialObjectId) {
+            return;
+        }
 
-    const lengthOfMaterialOrdered = await materialOrderService.getLengthOfOneMaterialOrdered(materialObjectId);
-    const lengthOfMaterialInStock = await materialOrderService.getLengthOfOneMaterialInInventory(materialObjectId);
-    const lengthOfAllMaterialsInInventory = await materialOrderService.getLengthOfAllMaterialsInInventory();
-    const lengthOfAllMaterialsOrdered = await materialOrderService.getLengthOfAllMaterialsOrdered();
-    const totalPurchaseOrders = await materialOrderService.getNumberOfPurchaseOrders();
+        const lengthOfMaterialOrdered = await materialOrderService.getLengthOfOneMaterialOrdered(materialObjectId);
+        const lengthOfMaterialInStock = await materialOrderService.getLengthOfOneMaterialInInventory(materialObjectId);
+        const lengthOfAllMaterialsInInventory = await materialOrderService.getLengthOfAllMaterialsInInventory();
+        const lengthOfAllMaterialsOrdered = await materialOrderService.getLengthOfAllMaterialsOrdered();
+        const totalPurchaseOrders = await materialOrderService.getNumberOfPurchaseOrders();
 
-    io.emit(materialObjectId, {
-        lengthOfMaterialOrdered,
-        lengthOfMaterialInStock,
-        lengthOfAllMaterialsInInventory,
-        lengthOfAllMaterialsOrdered,
-        totalPurchaseOrders
-    })
-});
-}
+        io.emit(materialObjectId, {
+            lengthOfMaterialOrdered,
+            lengthOfMaterialInStock,
+            lengthOfAllMaterialsInInventory,
+            lengthOfAllMaterialsOrdered,
+            totalPurchaseOrders
+        });
+    });
+};

--- a/application/services/socketService.js
+++ b/application/services/socketService.js
@@ -5,7 +5,7 @@ module.exports = function(io){
    console.log('Initializing Sockets...');
 
    PurchaseOrderModel.watch().on('change', async (change) => {
-    console.log(`Change to a PurchaseOrder in database ${JSON.stringify(change)}`)
+    console.log(`Change to a PurchaseOrder in database: ${JSON.stringify(change)}`)
 
     const purchaseOrder = await PurchaseOrderModel
         .findById(change.documentKey._id)

--- a/application/views/partials/navbarMain.ejs
+++ b/application/views/partials/navbarMain.ejs
@@ -1,6 +1,7 @@
 <nav class="navbar-main">
     <div class="column column-left">
         <ul class="full-width flex-center-left-row main-navbar-links">
+            <li class="navbar-links"><a href='/material-inventory' class="flex-center-center-row">Inventory</a></li>
             <li class="navbar-links"><a href='/tickets' class="flex-center-center-row"><svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-grid"><rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect><rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect></svg>Tickets</a></li>
             <li class="navbar-links"><a href='/material-orders' class="flex-center-center-row"><svg xmlns="http://www.w3.org/2000/svg" width="20px" height="20px" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-layers"><polygon points="12 2 2 7 12 12 22 7 12 2"></polygon><polyline points="2 17 12 22 22 17"></polyline><polyline points="2 12 12 17 22 12"></polyline></svg>Material</a></li>
             <li class="navbar-links" id="recipe-dropdown-trigger">

--- a/application/views/updateMaterialOrder.ejs
+++ b/application/views/updateMaterialOrder.ejs
@@ -19,7 +19,10 @@
                                 <option value="">-</option>
                                 <% if (typeof materials != 'undefined') { %>
                                     <% materials.forEach(material => { %>
-                                        <% const isSelected = material.id == materialOrder.material._id ? 'selected' : ''; %>
+                                        <% let isSelected = false %>
+                                        <%  if (materialOrder.material) { %>
+                                            <% isSelected = material.id == materialOrder.material._id ? 'selected' : ''; %>
+                                        <% } %>
                                         <option value="<%= material.id %>" <%= isSelected %>><%= material.name || 'N/A' %> </option>
                                     <% }) %>
                                 <% } %>

--- a/application/views/updateMaterialOrder.ejs
+++ b/application/views/updateMaterialOrder.ejs
@@ -70,7 +70,7 @@
                     <div class="field-label-wrapper half-width">
                         <span>Arrived:</span>
                         <label class="checkbox-label-wrapper" for="hasArrived">
-                            <input type="checkbox" id="hasArrived" name="hasArrived" <% if (materialOrder.hasArrived) { %>checked="checked"<% } else { %>value="false"<% } %>>
+                            <input data-val="true" value="true" type="checkbox" id="hasArrived" name="hasArrived" <% if (materialOrder.hasArrived) { %>checked="checked"<% } %>>
                             <span class="checkmark"></span>
                         </label>
                     </div>

--- a/application/views/viewMaterialInventory.ejs
+++ b/application/views/viewMaterialInventory.ejs
@@ -18,9 +18,11 @@
 
 <div id="material-inventories">
     <% materialInventories && materialInventories.forEach(materialInventory => { %>
-        <div id="<%= materialInventory._id %>">
-            <p>Material Id: <span class='material-id'><%= materialInventory.materialId || 'N/A' %></span></p>
-            <p>Material Name: <span class='material-name'><%= materialInventory.name || 'N/A' %></span></p>
+        <% const {material} = materialInventory; %>
+
+        <div id="<%= material._id %>">
+            <p>Material Id: <span class='material-id'><%= material.materialId || 'N/A' %></span></p>
+            <p>Material Name: <span class='material-name'><%= material.name || 'N/A' %></span></p>
             <p>Length in Inventory: <span class='material-length-in-stock'><%= materialInventory.lengthOfMaterialInStock %></span></p>
             <p>Length Ordered: <span class='material-length-ordered'><%= materialInventory.lengthOfMaterialOrdered %></span></p>
         </div>
@@ -46,7 +48,7 @@
 
 <script>    
     const socket = io();
-    const materialIdsAsString = '<%= materialInventories.map((material) => {return material._id}) %>';
+    const materialIdsAsString = '<%= materialInventories.map(({material}) => {return material._id}) %>';
     const materialIdsAsArray = materialIdsAsString.split(',');
 
     materialIdsAsArray.forEach((materialObjectId) => {

--- a/application/views/viewMaterialInventory.ejs
+++ b/application/views/viewMaterialInventory.ejs
@@ -5,9 +5,9 @@
 <br>
 
 <div>
-    <p>Length in Inventory: <%= lengthOfAllMaterialsInInventory || 'N/A' %> feet</p>
-    <p>Length on Order: <%= lengthOfAllMaterialsOrdered || 'N/A' %> feet</p>
-    <p>Total POs: <%= totalPurchaseOrders || 'N/A' %></p>
+    <p>Length in Inventory: <span class='total-length-of-material-in-inventory'><%= lengthOfAllMaterialsInInventory || 'N/A' %></span> feet</p>
+    <p>Length on Order: <span class='total-length-of-material-ordered'><%= lengthOfAllMaterialsOrdered || 'N/A' %></span> feet</p>
+    <p>Total POs: <span class='total-purchase-ordered'><%= totalPurchaseOrders || 'N/A' %></span></p>
 </div>
 
 <br>
@@ -19,10 +19,10 @@
 <div id="material-inventories">
     <% materialInventories && materialInventories.forEach(materialInventory => { %>
         <div id="<%= materialInventory._id %>">
-            <p class='material-id'>Material Id: <%= materialInventory.materialId || 'N/A' %></p>
-            <p class='material-name'>Material Name: <%= materialInventory.name || 'N/A' %></p>
-            <p class='material-length-in-stock'>Length in Inventory: <%= materialInventory.lengthOfMaterialInStock %> feet</p>
-            <p class='material-length-ordered'>Length Ordered: <%= materialInventory.lengthOfMaterialOrdered %> feet</p>
+            <p>Material Id: <span class='material-id'><%= materialInventory.materialId || 'N/A' %></span></p>
+            <p>Material Name: <span class='material-name'><%= materialInventory.name || 'N/A' %></span></p>
+            <p>Length in Inventory: <span class='material-length-in-stock'><%= materialInventory.lengthOfMaterialInStock %></span> feet</p>
+            <p>Length Ordered: <span class='material-length-ordered'><%= materialInventory.lengthOfMaterialOrdered %></span> feet</p>
         </div>
 
         <br>
@@ -33,23 +33,31 @@
 
 <script src="/socket.io/socket.io.js"></script>
 
-<script>
-    function handlePurchaseOrderChangeEvent(purchaseOrderId, purchaseOrder) {
-      console.log(`A PurchaseOrder has been Created/Updated/Deleted in the database: ${purchaseOrderId} - ${JSON.stringify(purchaseOrder)}`);
-    }
-    
+<script>    
     const socket = io();
     const materialIdsAsString = '<%= materialInventories.map((material) => {return material._id}) %>';
     const materialIdsAsArray = materialIdsAsString.split(',');
 
-    console.log(materialIdsAsString);
-    console.log(materialIdsAsArray);
-
     materialIdsAsArray.forEach((materialObjectId) => {
         console.log(`creating socket listener for materialObjectId = ${materialObjectId}`);
 
-        socket.on(materialObjectId, function(purchaseOrder) {
-          handlePurchaseOrderChangeEvent(materialObjectId, purchaseOrder);
+        socket.on(materialObjectId, function(materialInventoryInformation) {
+            const {
+                lengthOfMaterialOrder, 
+                lengthOfMaterialInStock,
+                lengthOfAllMaterialsInInventory,
+                lengthOfAllMaterialsOrdered,
+                totalPurchaseOrders
+            } = materialInventoryInformation;
+
+            console.log(`lengthOfMaterialOrder => ${lengthOfMaterialOrder}; lengthOfMaterialInStock => ${lengthOfMaterialInStock}`);
+            
+            $(`#${materialObjectId} .material-length-in-stock`).text(lengthOfMaterialInStock);
+            $(`#${materialObjectId} .material-length-ordered`).text(lengthOfMaterialOrder);
+
+            $(`.total-length-of-material-in-inventory`).text(lengthOfAllMaterialsInInventory);
+            $(`.total-length-of-material-ordered`).text(lengthOfAllMaterialsOrdered);
+            $(`.total-purchase-ordered`).text(totalPurchaseOrders);
         });
     })
 </script>

--- a/application/views/viewMaterialInventory.ejs
+++ b/application/views/viewMaterialInventory.ejs
@@ -42,22 +42,22 @@
         console.log(`creating socket listener for materialObjectId = ${materialObjectId}`);
 
         socket.on(materialObjectId, function(materialInventoryInformation) {
+            console.log(`socket.on('${materialObjectId}') received; Data => ${JSON.stringify(materialInventoryInformation)}`);
+
             const {
-                lengthOfMaterialOrder, 
-                lengthOfMaterialInStock,
                 lengthOfAllMaterialsInInventory,
                 lengthOfAllMaterialsOrdered,
-                totalPurchaseOrders
-            } = materialInventoryInformation;
-
-            console.log(`lengthOfMaterialOrder => ${lengthOfMaterialOrder}; lengthOfMaterialInStock => ${lengthOfMaterialInStock}`);
-            
-            $(`#${materialObjectId} .material-length-in-stock`).text(lengthOfMaterialInStock);
-            $(`#${materialObjectId} .material-length-ordered`).text(lengthOfMaterialOrder);
+                totalPurchaseOrders,
+                lengthOfMaterialInStock,
+                lengthOfMaterialOrdered
+            } = materialInventoryInformation
 
             $(`.total-length-of-material-in-inventory`).text(lengthOfAllMaterialsInInventory);
             $(`.total-length-of-material-ordered`).text(lengthOfAllMaterialsOrdered);
             $(`.total-purchase-ordered`).text(totalPurchaseOrders);
+
+            $(`#${materialObjectId} .material-length-in-stock`).text(lengthOfMaterialInStock);
+            $(`#${materialObjectId} .material-length-ordered`).text(lengthOfMaterialOrdered);
         });
     })
 </script>

--- a/application/views/viewMaterialInventory.ejs
+++ b/application/views/viewMaterialInventory.ejs
@@ -3,13 +3,26 @@
 </h1>
 
 <br>
+
+<div>
+    <p>Length in Inventory: <%= lengthOfAllMaterialsInInventory || 'N/A' %> feet</p>
+    <p>Length on Order: <%= lengthOfAllMaterialsOrdered || 'N/A' %> feet</p>
+    <p>Total POs: <%= totalPurchaseOrders || 'N/A' %></p>
+</div>
+
 <br>
 
 <h2>Material Inventory Information:</h2>
 
-<% materialInventories && materialInventories.forEach(materialInventory => { %>
+<br>
 
-    <h5> Material Name: <%= materialInventory.materialName %> </h3>
-    <h5> Total Rolls Purchased: <%= materialInventory.totalRollsPurchased %> </h3>
+<% materialInventories && materialInventories.forEach(materialInventory => { %>
+    <div>
+        <p>Material Id: <%= materialInventory.materialId || 'N/A' %></p>
+        <p>Material Name: <%= materialInventory.materialName || 'N/A' %></p>
+        <p>Length in Inventory: <%= materialInventory.lengthOfMaterialInStock %> feet</p>
+        <p>Length Ordered: <%= materialInventory.lengthOfMaterialOrdered %> feet</p>
+    </div>
+
     <br>
 <% }) %>

--- a/application/views/viewMaterialInventory.ejs
+++ b/application/views/viewMaterialInventory.ejs
@@ -1,0 +1,15 @@
+<h1>
+    Welcome to the Material Inventory Page
+</h1>
+
+<br>
+<br>
+
+<h2>Material Inventory Information:</h2>
+
+<% materialInventories && materialInventories.forEach(materialInventory => { %>
+
+    <h5> Material Name: <%= materialInventory.materialName %> </h3>
+    <h5> Total Rolls Purchased: <%= materialInventory.totalRollsPurchased %> </h3>
+    <br>
+<% }) %>

--- a/application/views/viewMaterialInventory.ejs
+++ b/application/views/viewMaterialInventory.ejs
@@ -16,13 +16,40 @@
 
 <br>
 
-<% materialInventories && materialInventories.forEach(materialInventory => { %>
-    <div>
-        <p>Material Id: <%= materialInventory.materialId || 'N/A' %></p>
-        <p>Material Name: <%= materialInventory.materialName || 'N/A' %></p>
-        <p>Length in Inventory: <%= materialInventory.lengthOfMaterialInStock %> feet</p>
-        <p>Length Ordered: <%= materialInventory.lengthOfMaterialOrdered %> feet</p>
-    </div>
+<div id="material-inventories">
+    <% materialInventories && materialInventories.forEach(materialInventory => { %>
+        <div id="<%= materialInventory._id %>">
+            <p class='material-id'>Material Id: <%= materialInventory.materialId || 'N/A' %></p>
+            <p class='material-name'>Material Name: <%= materialInventory.name || 'N/A' %></p>
+            <p class='material-length-in-stock'>Length in Inventory: <%= materialInventory.lengthOfMaterialInStock %> feet</p>
+            <p class='material-length-ordered'>Length Ordered: <%= materialInventory.lengthOfMaterialOrdered %> feet</p>
+        </div>
 
-    <br>
-<% }) %>
+        <br>
+    <% }) %>
+</div>
+
+<span id="how-cool"></span>
+
+<script src="/socket.io/socket.io.js"></script>
+
+<script>
+    function handlePurchaseOrderChangeEvent(purchaseOrderId, purchaseOrder) {
+      console.log(`A PurchaseOrder has been Created/Updated/Deleted in the database: ${purchaseOrderId} - ${JSON.stringify(purchaseOrder)}`);
+    }
+    
+    const socket = io();
+    const materialIdsAsString = '<%= materialInventories.map((material) => {return material._id}) %>';
+    const materialIdsAsArray = materialIdsAsString.split(',');
+
+    console.log(materialIdsAsString);
+    console.log(materialIdsAsArray);
+
+    materialIdsAsArray.forEach((materialObjectId) => {
+        console.log(`creating socket listener for materialObjectId = ${materialObjectId}`);
+
+        socket.on(materialObjectId, function(purchaseOrder) {
+          handlePurchaseOrderChangeEvent(materialObjectId, purchaseOrder);
+        });
+    })
+</script>

--- a/application/views/viewMaterialInventory.ejs
+++ b/application/views/viewMaterialInventory.ejs
@@ -5,8 +5,8 @@
 <br>
 
 <div>
-    <p>Length in Inventory: <span class='total-length-of-material-in-inventory'><%= lengthOfAllMaterialsInInventory || 'N/A' %></span> feet</p>
-    <p>Length on Order: <span class='total-length-of-material-ordered'><%= lengthOfAllMaterialsOrdered || 'N/A' %></span> feet</p>
+    <p>Feet on Hand: <span class='total-length-of-material-in-inventory'><%= lengthOfAllMaterialsInInventory || 'N/A' %></span></p>
+    <p>Feet on Order: <span class='total-length-of-material-ordered'><%= lengthOfAllMaterialsOrdered || 'N/A' %></span></p>
     <p>Total POs: <span class='total-purchase-ordered'><%= totalPurchaseOrders || 'N/A' %></span></p>
 </div>
 
@@ -21,15 +21,26 @@
         <div id="<%= materialInventory._id %>">
             <p>Material Id: <span class='material-id'><%= materialInventory.materialId || 'N/A' %></span></p>
             <p>Material Name: <span class='material-name'><%= materialInventory.name || 'N/A' %></span></p>
-            <p>Length in Inventory: <span class='material-length-in-stock'><%= materialInventory.lengthOfMaterialInStock %></span> feet</p>
-            <p>Length Ordered: <span class='material-length-ordered'><%= materialInventory.lengthOfMaterialOrdered %></span> feet</p>
+            <p>Length in Inventory: <span class='material-length-in-stock'><%= materialInventory.lengthOfMaterialInStock %></span></p>
+            <p>Length Ordered: <span class='material-length-ordered'><%= materialInventory.lengthOfMaterialOrdered %></span></p>
         </div>
 
         <br>
+
+        <div>
+            <% materialInventory.purchaseOrdersForMaterial.forEach((purchaseOrder) => { %>
+                <div class="<%= purchaseOrder._id %>"> 
+                    <p>PO Number: <span class="po-number"><%= purchaseOrder.purchaseOrderNumber ?? 'N/A' %></span></p>
+                    <p>Arrival Date: <span class="po-arrival-date"><%= purchaseOrder.arrivalDate && purchaseOrder.arrivalDate.toLocaleString('en-US', {year: 'numeric', month: 'numeric', day: 'numeric', timeZone: 'UTC'}) || 'N/A' %></span></p>
+                    <p>Feet: <span class="po-total-length"><%= purchaseOrder.feetPerRoll * purchaseOrder.totalRolls ?? 'N/A' %></span></p>
+                </div>
+                <br>
+            <% }) %>
+        </div>
+
+        <p>================================================================</p>
     <% }) %>
 </div>
-
-<span id="how-cool"></span>
 
 <script src="/socket.io/socket.io.js"></script>
 
@@ -49,7 +60,9 @@
                 lengthOfAllMaterialsOrdered,
                 totalPurchaseOrders,
                 lengthOfMaterialInStock,
-                lengthOfMaterialOrdered
+                lengthOfMaterialOrdered,
+                purchaseOrdersForMaterial,
+                purchaseOrder
             } = materialInventoryInformation
 
             $(`.total-length-of-material-in-inventory`).text(lengthOfAllMaterialsInInventory);
@@ -58,6 +71,14 @@
 
             $(`#${materialObjectId} .material-length-in-stock`).text(lengthOfMaterialInStock);
             $(`#${materialObjectId} .material-length-ordered`).text(lengthOfMaterialOrdered);
+
+            $(`.${purchaseOrder._id} .po-number`).text(purchaseOrder.purchaseOrderNumber);
+            
+            const purchaseOrderArrivalDate = new Date(purchaseOrder.arrivalDate).toLocaleString('en-US', {year: 'numeric', month: 'numeric', day: 'numeric', timeZone: 'UTC'}).substring(0, 10)
+            $(`.${purchaseOrder._id} .po-arrival-date`).text(purchaseOrderArrivalDate);
+            
+            const purchaseOrderTotalLength = purchaseOrder.feetPerRoll * purchaseOrder.totalRolls;
+            $(`.${purchaseOrder._id} .po-total-length`).text(purchaseOrderTotalLength);
         });
     })
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1043,6 +1043,11 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@socket.io/component-emitter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+      "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -1098,6 +1103,16 @@
       "requires": {
         "@babel/types": "^7.3.0"
       }
+    },
+    "@types/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-XW/Aa8APYr6jSVVA1y/DEIZX0/GMKLEVekNG727R8cs56ahETkRAy/3DR7+fJyh7oUgGwNQaRfXCun0+KbWY7Q=="
+    },
+    "@types/cors": {
+      "version": "2.8.12",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.12.tgz",
+      "integrity": "sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw=="
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
@@ -1560,6 +1575,11 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog=="
     },
     "bcryptjs": {
       "version": "2.4.3",
@@ -2096,6 +2116,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2389,6 +2418,48 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "engine.io": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.2.0.tgz",
+      "integrity": "sha512-4KzwW3F3bk+KlzSOY57fj/Jx6LyRQ1nbcyIadehl+AnXjKT7gDO0ORdRi/84ixvMKTym6ZKuxvbzN62HDDU1Lg==",
+      "requires": {
+        "@types/cookie": "^0.4.1",
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.4.1",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.0.3",
+        "ws": "~8.2.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "ws": {
+          "version": "8.2.3",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
+          "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA=="
+        }
+      }
+    },
+    "engine.io-parser": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.0.4.tgz",
+      "integrity": "sha512-+nVFp+5z1E3HcToEnO7ZIj3g+3k9389DvWtvJZz0T6/eOCPIyyxehFcedoYrZQrp0LgQbD9pPXhpMBKMd5QURg=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -6129,6 +6200,63 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
+    },
+    "socket.io": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.5.2.tgz",
+      "integrity": "sha512-6fCnk4ARMPZN448+SQcnn1u8OHUC72puJcNtSgg2xS34Cu7br1gQ09YKkO1PFfDn/wyUE9ZgMAwosJed003+NQ==",
+      "requires": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "debug": "~4.3.2",
+        "engine.io": "~6.2.0",
+        "socket.io-adapter": "~2.4.0",
+        "socket.io-parser": "~4.2.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "socket.io-adapter": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.4.0.tgz",
+      "integrity": "sha512-W4N+o69rkMEGVuk2D/cvca3uYsvGlMwsySWV447y99gUPghxq42BxqLNMndb+a1mm/5/7NeXVQS7RLa2XyXvYg=="
+    },
+    "socket.io-parser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.1.tgz",
+      "integrity": "sha512-V4GrkLy+HeF1F/en3SpUaM+7XxYXpuMUWLGde1kSSh5nQMN4hLrbPIkD+otwh6q9R6NOQBN4AMaOZ2zVjui82g==",
+      "requires": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "socks": {
       "version": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "mongodb-memory-server": "8.3.0",
     "mongoose": "6.2.4",
     "multer": "1.4.4",
+    "socket.io": "4.5.2",
     "xml2json": "0.12.0"
   }
 }

--- a/test/services/materialInventoryService.spec.js
+++ b/test/services/materialInventoryService.spec.js
@@ -11,7 +11,6 @@ describe('materialInventoryService test suite', () => {
         findFunction, 
         leanFunction,
         materialsInDatabase;
-
         
     afterEach(() => {
         jest.resetAllMocks();

--- a/test/services/materialInventoryService.spec.js
+++ b/test/services/materialInventoryService.spec.js
@@ -75,7 +75,7 @@ describe('materialInventoryService test suite', () => {
             expect(materials.length).toBe(1);
             expect(materials).toEqual([
                 {
-                    ...materialsInDatabase[0],
+                    material: materialsInDatabase[0],
                     lengthOfMaterialOrdered: expectedLengthOfMaterialOrdered,
                     lengthOfMaterialInStock: expectedLengthOfMaterialInInventory
                 }

--- a/test/services/materialInventoryService.spec.js
+++ b/test/services/materialInventoryService.spec.js
@@ -1,19 +1,25 @@
 const materialInventoryService = require('../../application/services/materialInventoryService');
 const mockMaterialModel = require('../../application/models/material');
+const mockMaterialOrderService = require('../../application/services/materialOrderService');
+const chance = require('chance').Chance();
 
 jest.mock('../../application/models/material');
+jest.mock('../../application/services/materialOrderService');
 
 describe('materialInventoryService test suite', () => {
     let execFunction,
         findFunction, 
-        leanFunction;
+        leanFunction,
+        materialsInDatabase;
 
-    afterEach(() => {
-        jest.resetAllMocks();
-    });
-
-    beforeEach(() => {
-        execFunction = jest.fn();
+        
+        afterEach(() => {
+            jest.resetAllMocks();
+        });
+        
+        beforeEach(() => {
+        materialsInDatabase = [];
+        execFunction = jest.fn().mockResolvedValue(materialsInDatabase);
         leanFunction = jest.fn().mockImplementation(() => {
             return {
                 exec: execFunction
@@ -33,12 +39,47 @@ describe('materialInventoryService test suite', () => {
             await expect(materialInventoryService.getAllMaterialInventoryData()).resolves.not.toThrowError();
         });        
         
-        it ('should not throw error', async () => {
+        it ('should search for materials from database', async () => {
             await materialInventoryService.getAllMaterialInventoryData();
 
             expect(findFunction).toHaveBeenCalledTimes(1);
             expect(leanFunction).toHaveBeenCalledTimes(1);
             expect(execFunction).toHaveBeenCalledTimes(1);
         });
+
+        it ('should return empty array when no materials are found by query', async () => {
+            materialsInDatabase = [];
+        
+            const materials = await materialInventoryService.getAllMaterialInventoryData();
+
+            expect(materials).toBeDefined();
+            expect(materials.length).toBe(0);
+        });
+
+        it ('should return correct data', async () => {
+            materialsInDatabase = [
+                {
+                    [chance.string()]: chance.string()
+                }
+            ];
+            const expectedLengthOfMaterialOrdered = 87;
+            const expectedLengthOfMaterialInInventory = 23;
+            execFunction = jest.fn().mockResolvedValue(materialsInDatabase);
+
+            mockMaterialOrderService.getLengthOfOneMaterialOrdered.mockReturnValue(expectedLengthOfMaterialOrdered)
+            mockMaterialOrderService.getLengthOfOneMaterialInInventory.mockReturnValue(expectedLengthOfMaterialInInventory)
+        
+            const materials = await materialInventoryService.getAllMaterialInventoryData();
+
+            expect(materials).toBeDefined();
+            expect(materials.length).toBe(1);
+            expect(materials).toEqual([
+                {
+                    ...materialsInDatabase[0],
+                    lengthOfMaterialOrdered: expectedLengthOfMaterialOrdered,
+                    lengthOfMaterialInStock: expectedLengthOfMaterialInInventory
+            }
+        ]);
+        })
     })
 });

--- a/test/services/materialInventoryService.spec.js
+++ b/test/services/materialInventoryService.spec.js
@@ -13,22 +13,22 @@ describe('materialInventoryService test suite', () => {
         materialsInDatabase;
 
         
-        afterEach(() => {
-            jest.resetAllMocks();
-        });
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
         
-        beforeEach(() => {
+    beforeEach(() => {
         materialsInDatabase = [];
         execFunction = jest.fn().mockResolvedValue(materialsInDatabase);
         leanFunction = jest.fn().mockImplementation(() => {
             return {
                 exec: execFunction
-            }
+            };
         });
         findFunction = jest.fn().mockImplementation(() => {
             return {
                 lean: leanFunction
-            }
+            };
         });
 
         mockMaterialModel.find.mockImplementation(findFunction);
@@ -53,7 +53,7 @@ describe('materialInventoryService test suite', () => {
             const materials = await materialInventoryService.getAllMaterialInventoryData();
 
             expect(materials).toBeDefined();
-            expect(materials.length).toBe(0);
+            expect(materials.length).toBe(0); // eslint-disable-line no-magic-numbers
         });
 
         it ('should return correct data', async () => {
@@ -66,8 +66,8 @@ describe('materialInventoryService test suite', () => {
             const expectedLengthOfMaterialInInventory = 23;
             execFunction = jest.fn().mockResolvedValue(materialsInDatabase);
 
-            mockMaterialOrderService.getLengthOfOneMaterialOrdered.mockReturnValue(expectedLengthOfMaterialOrdered)
-            mockMaterialOrderService.getLengthOfOneMaterialInInventory.mockReturnValue(expectedLengthOfMaterialInInventory)
+            mockMaterialOrderService.getLengthOfOneMaterialOrdered.mockReturnValue(expectedLengthOfMaterialOrdered);
+            mockMaterialOrderService.getLengthOfOneMaterialInInventory.mockReturnValue(expectedLengthOfMaterialInInventory);
         
             const materials = await materialInventoryService.getAllMaterialInventoryData();
 
@@ -78,8 +78,8 @@ describe('materialInventoryService test suite', () => {
                     ...materialsInDatabase[0],
                     lengthOfMaterialOrdered: expectedLengthOfMaterialOrdered,
                     lengthOfMaterialInStock: expectedLengthOfMaterialInInventory
-            }
-        ]);
-        })
-    })
+                }
+            ]);
+        });
+    });
 });

--- a/test/services/materialInventoryService.spec.js
+++ b/test/services/materialInventoryService.spec.js
@@ -1,0 +1,44 @@
+const materialInventoryService = require('../../application/services/materialInventoryService');
+const mockMaterialModel = require('../../application/models/material');
+
+jest.mock('../../application/models/material');
+
+describe('materialInventoryService test suite', () => {
+    let execFunction,
+        findFunction, 
+        leanFunction;
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    beforeEach(() => {
+        execFunction = jest.fn();
+        leanFunction = jest.fn().mockImplementation(() => {
+            return {
+                exec: execFunction
+            }
+        });
+        findFunction = jest.fn().mockImplementation(() => {
+            return {
+                lean: leanFunction
+            }
+        });
+
+        mockMaterialModel.find.mockImplementation(findFunction);
+    });
+
+    describe('getAllMaterialInventoryData()', () => {
+        it ('should not throw error', async () => {
+            await expect(materialInventoryService.getAllMaterialInventoryData()).resolves.not.toThrowError();
+        });        
+        
+        it ('should not throw error', async () => {
+            await materialInventoryService.getAllMaterialInventoryData();
+
+            expect(findFunction).toHaveBeenCalledTimes(1);
+            expect(leanFunction).toHaveBeenCalledTimes(1);
+            expect(execFunction).toHaveBeenCalledTimes(1);
+        });
+    })
+});

--- a/test/services/materialOrderService.spec.js
+++ b/test/services/materialOrderService.spec.js
@@ -7,13 +7,15 @@ jest.mock('../../application/models/materialOrder');
 describe('materialOrderService test suite', () => {
     let purchaseOrdersInDatabase,
         execFunction,
-        findFunction;
+        findFunction,
+        materialId;
 
     afterEach(() => {
         jest.resetAllMocks();
     });
 
     beforeEach(() => {
+        materialId = chance.string();
         purchaseOrdersInDatabase = [];
         execFunction = jest.fn().mockResolvedValue(purchaseOrdersInDatabase);
         findFunction = jest.fn().mockImplementation(() => {
@@ -107,8 +109,6 @@ describe('materialOrderService test suite', () => {
     });
 
     describe('getLengthOfOneMaterialInInventory()', () => {
-        const materialId = chance.string();
-
         it('should not throw error if purchase order is not found using the provided materialId', async () => {
             await expect(materialOrderService.getLengthOfOneMaterialInInventory(materialId)).resolves.not.toThrowError();   
         });
@@ -139,8 +139,6 @@ describe('materialOrderService test suite', () => {
     });
 
     describe('getLengthOfOneMaterialOrdered()', () => {
-        const materialId = chance.string();
-
         it('should not throw error if purchase order is not found using the provided materialId', async () => {
             await expect(materialOrderService.getLengthOfOneMaterialOrdered(materialId)).resolves.not.toThrowError();   
         });
@@ -168,6 +166,30 @@ describe('materialOrderService test suite', () => {
             const actualLength = await materialOrderService.getLengthOfOneMaterialOrdered(materialId);
 
             expect(actualLength).toBe(expectedLength);
+        });
+    });
+
+    describe('findPurchaseOrdersByMaterial()', () => {
+        it('should not throw error if purchase order is not found using the provided materialId', async () => {
+            await expect(materialOrderService.findPurchaseOrdersByMaterial(materialId)).resolves.not.toThrowError();   
+        });
+
+        it('should return length of 0 if no purchase order is found for the given materialId', async () => {
+            const expectedNumberOfPurchaseOrdersFound = 0;
+
+            const purchaseOrdersFound = await materialOrderService.findPurchaseOrdersByMaterial(materialId);
+
+            expect(purchaseOrdersFound.length).toBe(expectedNumberOfPurchaseOrdersFound);
+        });
+
+        it('should return the correct number of purchaseOrders queried for using materialId', async () => {
+            purchaseOrdersInDatabase = chance.n(buildPurchaseOrderObject, chance.integer({min: 1, max: 100}));
+            const expectedLength = purchaseOrdersInDatabase.length;
+            execFunction = jest.fn().mockResolvedValue(purchaseOrdersInDatabase);
+
+            const purchaseOrdersFound = await materialOrderService.findPurchaseOrdersByMaterial(materialId);
+
+            expect(purchaseOrdersFound.length).toBe(expectedLength);
         });
     });
 });

--- a/test/services/materialOrderService.spec.js
+++ b/test/services/materialOrderService.spec.js
@@ -1,0 +1,193 @@
+const materialOrderService = require('../../application/services/materialOrderService');
+const mockPurchaseOrderModel = require('../../application/models/materialOrder');
+const chance = require('chance').Chance();
+
+jest.mock('../../application/models/materialOrder');
+
+describe('materialOrderService test suite', () => {
+    let purchaseOrdersInDatabase,
+        execFunction,
+        findFunction;
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    beforeEach(() => {
+        purchaseOrdersInDatabase = [];
+        execFunction = jest.fn().mockResolvedValue(purchaseOrdersInDatabase);
+        findFunction = jest.fn().mockImplementation(() => {
+            return {
+                exec: execFunction
+            };
+        });
+
+        mockPurchaseOrderModel.find.mockImplementation(findFunction);
+    });
+
+    describe('getNumberOfPurchaseOrders()', () => {
+        it('should not throw errors', async () => {
+            await expect(materialOrderService.getNumberOfPurchaseOrders()).resolves.not.toThrowError();   
+        });
+        
+        it('should query the database for purchase orders', async () => {
+            await materialOrderService.getNumberOfPurchaseOrders();
+
+            expect(findFunction).toHaveBeenCalledTimes(1);
+            expect(execFunction).toHaveBeenCalledTimes(1);
+        });
+
+        it('should return the number of purchaseOrders in the database', async () => {
+            const expectedNumberOfPurchaseOrders = chance.integer({min: 1, max: 100});
+            purchaseOrdersInDatabase = generatePurchaseOrders(expectedNumberOfPurchaseOrders);
+            execFunction = jest.fn().mockResolvedValue(purchaseOrdersInDatabase);
+
+            const actualNumberOfPurchaseOrders = await materialOrderService.getNumberOfPurchaseOrders();
+
+            console.log(`actualNumberOfPurchaseOrders +> ${actualNumberOfPurchaseOrders}`);
+
+            expect(actualNumberOfPurchaseOrders).toBe(expectedNumberOfPurchaseOrders);
+        });
+    });
+
+    describe('getLengthOfAllMaterialsOrdered()', () => {
+        it('should not throw errors', async () => {
+            await expect(materialOrderService.getLengthOfAllMaterialsOrdered()).resolves.not.toThrowError();   
+        });
+
+        it('should return 0 when no purchase orders exist in the database', async () => {
+            const expectedLengthOfPurchasedMaterial = 0;
+
+            const actualLengthOfPurchasedMaterial = await materialOrderService.getLengthOfAllMaterialsOrdered();
+
+            expect(actualLengthOfPurchasedMaterial).toBe(expectedLengthOfPurchasedMaterial);
+        });
+
+        it('should return length of materials purchased', async () => {
+            purchaseOrdersInDatabase = [
+                buildPurchaseOrderObject(),
+                buildPurchaseOrderObject()
+            ];
+            const expectedLengthOfPurchasedMaterial = 
+                (purchaseOrdersInDatabase[0].totalRolls * purchaseOrdersInDatabase[0].feetPerRoll)
+                + (purchaseOrdersInDatabase[1].totalRolls * purchaseOrdersInDatabase[1].feetPerRoll);
+            execFunction = jest.fn().mockResolvedValue(purchaseOrdersInDatabase);
+
+            const actualLengthOfPurchasedMaterial = await materialOrderService.getLengthOfAllMaterialsOrdered();
+
+            expect(actualLengthOfPurchasedMaterial).toBe(expectedLengthOfPurchasedMaterial);
+        });
+    });
+
+    describe('getLengthOfAllMaterialsInInventory()', () => {
+        it('should not throw errors', async () => {
+            await expect(materialOrderService.getLengthOfAllMaterialsInInventory()).resolves.not.toThrowError();   
+        });
+
+        it('should return 0 when no purchase orders exist in the database', async () => {
+            const expectedLengthOfPurchasedMaterial = 0;
+
+            const actualLengthOfPurchasedMaterial = await materialOrderService.getLengthOfAllMaterialsInInventory();
+
+            expect(actualLengthOfPurchasedMaterial).toBe(expectedLengthOfPurchasedMaterial);
+        });
+
+        it('should return length of materials purchased that have arrived', async () => {
+            purchaseOrdersInDatabase = [
+                buildPurchaseOrderObject({hasArrived: true}),
+                buildPurchaseOrderObject({hasArrived: false})
+            ];
+            const expectedLengthOfPurchasedMaterial = purchaseOrdersInDatabase[0].totalRolls * purchaseOrdersInDatabase[0].feetPerRoll;
+            execFunction = jest.fn().mockResolvedValue(purchaseOrdersInDatabase);
+
+            const actualLengthOfPurchasedMaterial = await materialOrderService.getLengthOfAllMaterialsInInventory();
+
+            expect(actualLengthOfPurchasedMaterial).toBe(expectedLengthOfPurchasedMaterial);
+        });
+    });
+
+    describe('getLengthOfOneMaterialInInventory()', () => {
+        const materialId = chance.string();
+
+        it('should not throw error if purchase order is not found using the provided materialId', async () => {
+            await expect(materialOrderService.getLengthOfOneMaterialInInventory(materialId)).resolves.not.toThrowError();   
+        });
+
+        it('should return length of 0 if no purchase order is found for the given materialId', async () => {
+            const expectedLength = 0;
+
+            const actualLength = await materialOrderService.getLengthOfOneMaterialInInventory(materialId);
+
+            expect(actualLength).toBe(expectedLength);
+        });
+
+        it('should return the correct length of material in inventory from purchaseOrders queried for using materialId', async () => {
+            purchaseOrdersInDatabase = [
+                buildPurchaseOrderObject({hasArrived: true}),
+                buildPurchaseOrderObject({hasArrived: false}),
+                buildPurchaseOrderObject({hasArrived: true})
+            ];
+            const expectedLength = 
+                (purchaseOrdersInDatabase[0].totalRolls * purchaseOrdersInDatabase[0].feetPerRoll)
+                + (purchaseOrdersInDatabase[2].totalRolls * purchaseOrdersInDatabase[2].feetPerRoll);;
+            execFunction = jest.fn().mockResolvedValue(purchaseOrdersInDatabase);
+
+            const actualLength = await materialOrderService.getLengthOfOneMaterialInInventory(materialId);
+
+            expect(actualLength).toBe(expectedLength);
+        });
+    });
+
+    describe('getLengthOfOneMaterialOrdered()', () => {
+        const materialId = chance.string();
+
+        it('should not throw error if purchase order is not found using the provided materialId', async () => {
+            await expect(materialOrderService.getLengthOfOneMaterialOrdered(materialId)).resolves.not.toThrowError();   
+        });
+
+        it('should return length of 0 if no purchase order is found for the given materialId', async () => {
+            const expectedLength = 0;
+
+            const actualLength = await materialOrderService.getLengthOfOneMaterialOrdered(materialId);
+
+            expect(actualLength).toBe(expectedLength);
+        });
+
+        it('should return the correct length of material in inventory from purchaseOrders queried for using materialId', async () => {
+            purchaseOrdersInDatabase = [
+                buildPurchaseOrderObject({hasArrived: chance.bool()}),
+                buildPurchaseOrderObject({hasArrived: chance.bool()}),
+                buildPurchaseOrderObject({hasArrived: chance.bool()})
+            ];
+            const expectedLength = 
+                (purchaseOrdersInDatabase[0].totalRolls * purchaseOrdersInDatabase[0].feetPerRoll)
+                + (purchaseOrdersInDatabase[1].totalRolls * purchaseOrdersInDatabase[1].feetPerRoll)
+                + (purchaseOrdersInDatabase[2].totalRolls * purchaseOrdersInDatabase[2].feetPerRoll);;
+            execFunction = jest.fn().mockResolvedValue(purchaseOrdersInDatabase);
+
+            const actualLength = await materialOrderService.getLengthOfOneMaterialOrdered(materialId);
+
+            expect(actualLength).toBe(expectedLength);
+        });
+    });
+});
+
+
+function generatePurchaseOrders(numberOfPurchaseOrdersToGenerate) {
+    let purchaseOrders = [];
+
+    for (let i=0; i < numberOfPurchaseOrdersToGenerate; i++) {
+        const purchaseOrder = {};
+        purchaseOrders.push(purchaseOrder);
+    }
+
+    return purchaseOrders;
+}
+
+function buildPurchaseOrderObject(additionalAttributes) {
+    return {
+        totalRolls: chance.integer({min: 1}),
+        feetPerRoll: chance.integer({min: 1}),
+        ...additionalAttributes
+    };
+}


### PR DESCRIPTION
# Description

The main thing this PR does is add a new view `/material-inventory` page (file `viewMaterialInventory.ejs`).

This page displays the length of materials that have been purchased (aka `materialOrder` objects, also known as `purchaseOrder` objects - the terms are used interchangably).

This page is meant to be viewed in order to determine how much (in feet of length) material has been ordered and how much of it has arrived and is sitting in inventory.

sockets were used thoroughly in this PR in order to update values displayed on `/material-inventory` without the need for a page refresh. See the video in this descriptions "verification" section to see those real-time updates in action.

## Verification

![add-material-inventory-view](https://user-images.githubusercontent.com/42784674/194779696-82d87ad8-fb25-40d8-a5b4-9194d9aab1cc.gif)

> New view `/material-inventory` page was added in this PR. Also, websockets were used to make data on that page update in real-time (without page refresh)
