### PR TITLE
Minor Functionality Bug Fixes

### DIFF
--- a/application/controllers/materialInventory.js
+++ b/application/controllers/materialInventory.js
@@ -23,7 +23,7 @@ router.get('/', async (request, response) => {
     } catch (error) {
         console.log(`An error occurred while attempting to load /material-inventory: ${error}`);
 
-        request.flash('errors', ['The following error(s) occurred:', error]);
+        request.flash('errors', [`The following error occurred: ${error}`]);
         return response.redirect('back');
     }
 });

--- a/application/services/materialInventoryService.js
+++ b/application/services/materialInventoryService.js
@@ -1,4 +1,5 @@
 const MaterialModel = require('../models/material');
+const PurchaseOrderModel  = require('../models/materialOrder');
 const materialOrderService = require('../services/materialOrderService');
 
 module.exports.getAllMaterialInventoryData = async () => {
@@ -14,7 +15,16 @@ module.exports.getAllMaterialInventoryData = async () => {
 
         const lengthOfMaterialOrdered = await materialOrderService.getLengthOfOneMaterialOrdered(materialId);
         const lengthOfMaterialInStock = await materialOrderService.getLengthOfOneMaterialInInventory(materialId);
-        const purchaseOrdersForMaterial = await materialOrderService.findPurchaseOrdersByMaterial(materialId);
+
+        const searchQuery = {
+            $and:[
+                {material: materialId},
+                {hasArrived: false},
+            ]};
+    
+        const purchaseOrdersForMaterial = await PurchaseOrderModel
+            .find(searchQuery)
+            .exec();
 
         materialInventories.push({
             material,

--- a/application/services/materialInventoryService.js
+++ b/application/services/materialInventoryService.js
@@ -1,5 +1,4 @@
 const MaterialModel = require('../models/material');
-const PurchaseOrderModel  = require('../models/materialOrder');
 const materialOrderService = require('../services/materialOrderService');
 
 module.exports.getAllMaterialInventoryData = async () => {
@@ -15,16 +14,7 @@ module.exports.getAllMaterialInventoryData = async () => {
 
         const lengthOfMaterialOrdered = await materialOrderService.getLengthOfOneMaterialOrdered(materialId);
         const lengthOfMaterialInStock = await materialOrderService.getLengthOfOneMaterialInInventory(materialId);
-
-        const searchQuery = {
-            $and:[
-                {material: materialId},
-                {hasArrived: false},
-            ]};
-    
-        const purchaseOrdersForMaterial = await PurchaseOrderModel
-            .find(searchQuery)
-            .exec();
+        const purchaseOrdersForMaterial = await materialOrderService.findPurchaseOrdersByMaterialThatHaveNotArrived(materialId);
 
         materialInventories.push({
             material,

--- a/application/services/materialOrderService.js
+++ b/application/services/materialOrderService.js
@@ -10,7 +10,7 @@ function getTotalLengthOfMaterial({totalRolls, feetPerRoll}) {
     return totalRolls * feetPerRoll;
 }
 
-module.exports.findPurchaseOrdersByMaterial = async (materialId) => {
+async function findPurchaseOrdersByMaterial(materialId) {
     const searchQuery = {
         material: materialId
     };
@@ -20,8 +20,20 @@ module.exports.findPurchaseOrdersByMaterial = async (materialId) => {
         .exec();
 };
 
+module.exports.findPurchaseOrdersByMaterialThatHaveNotArrived = async (materialId) => {
+    const searchQuery = {
+        $and:[
+            {material: materialId},
+            {hasArrived: false},
+        ]};
+
+    return await PurchaseOrderModel
+        .find(searchQuery)
+        .exec();
+};
+
 module.exports.getLengthOfOneMaterialOrdered = async (materialId) => {
-    const purchaseOrders = await this.findPurchaseOrdersByMaterial(materialId);
+    const purchaseOrders = await findPurchaseOrdersByMaterial(materialId);
     
     let totalRollsPurchased = 0;
 

--- a/test/services/materialInventoryService.spec.js
+++ b/test/services/materialInventoryService.spec.js
@@ -61,12 +61,14 @@ describe('materialInventoryService test suite', () => {
                     [chance.string()]: chance.string()
                 }
             ];
+            const purchaseOrdersInDatabase = [];
             const expectedLengthOfMaterialOrdered = 87;
             const expectedLengthOfMaterialInInventory = 23;
             execFunction = jest.fn().mockResolvedValue(materialsInDatabase);
 
             mockMaterialOrderService.getLengthOfOneMaterialOrdered.mockReturnValue(expectedLengthOfMaterialOrdered);
             mockMaterialOrderService.getLengthOfOneMaterialInInventory.mockReturnValue(expectedLengthOfMaterialInInventory);
+            mockMaterialOrderService.findPurchaseOrdersByMaterialThatHaveNotArrived.mockReturnValue(purchaseOrdersInDatabase);
         
             const materials = await materialInventoryService.getAllMaterialInventoryData();
 
@@ -76,7 +78,8 @@ describe('materialInventoryService test suite', () => {
                 {
                     material: materialsInDatabase[0],
                     lengthOfMaterialOrdered: expectedLengthOfMaterialOrdered,
-                    lengthOfMaterialInStock: expectedLengthOfMaterialInInventory
+                    lengthOfMaterialInStock: expectedLengthOfMaterialInInventory,
+                    purchaseOrdersForMaterial: purchaseOrdersInDatabase
                 }
             ]);
         });

--- a/test/services/materialOrderService.spec.js
+++ b/test/services/materialOrderService.spec.js
@@ -113,6 +113,16 @@ describe('materialOrderService test suite', () => {
             await expect(materialOrderService.getLengthOfOneMaterialInInventory(materialId)).resolves.not.toThrowError();   
         });
 
+        it('should use the correct query when performing the search', async () => {
+            const expectedQuery = {
+                material: materialId
+            };
+
+            await materialOrderService.getLengthOfOneMaterialInInventory(materialId);
+
+            expect(JSON.stringify(findFunction.mock.calls[0][0])).toBe(JSON.stringify(expectedQuery))
+        });
+
         it('should return length of 0 if no purchase order is found for the given materialId', async () => {
             const expectedLength = 0;
 
@@ -143,6 +153,16 @@ describe('materialOrderService test suite', () => {
             await expect(materialOrderService.getLengthOfOneMaterialOrdered(materialId)).resolves.not.toThrowError();   
         });
 
+        it('should use the correct query when performing the search', async () => {
+            const expectedQuery = {
+                material: materialId
+            };
+
+            await materialOrderService.getLengthOfOneMaterialOrdered(materialId);
+
+            expect(JSON.stringify(findFunction.mock.calls[0][0])).toBe(JSON.stringify(expectedQuery))
+        });
+
         it('should return length of 0 if no purchase order is found for the given materialId', async () => {
             const expectedLength = 0;
 
@@ -169,15 +189,28 @@ describe('materialOrderService test suite', () => {
         });
     });
 
-    describe('findPurchaseOrdersByMaterial()', () => {
+    describe('findPurchaseOrdersByMaterialThatHaveNotArrived()', () => {
         it('should not throw error if purchase order is not found using the provided materialId', async () => {
-            await expect(materialOrderService.findPurchaseOrdersByMaterial(materialId)).resolves.not.toThrowError();   
+            await expect(materialOrderService.findPurchaseOrdersByMaterialThatHaveNotArrived(materialId)).resolves.not.toThrowError();   
+        });        
+        
+        it('should use the correct query when performing the search', async () => {
+            const expectedQuery = {
+                $and:[
+                    {material: materialId},
+                    {hasArrived: false},
+                ]
+            };
+
+            await materialOrderService.findPurchaseOrdersByMaterialThatHaveNotArrived(materialId);
+
+            expect(JSON.stringify(findFunction.mock.calls[0][0])).toBe(JSON.stringify(expectedQuery))
         });
 
         it('should return length of 0 if no purchase order is found for the given materialId', async () => {
             const expectedNumberOfPurchaseOrdersFound = 0;
 
-            const purchaseOrdersFound = await materialOrderService.findPurchaseOrdersByMaterial(materialId);
+            const purchaseOrdersFound = await materialOrderService.findPurchaseOrdersByMaterialThatHaveNotArrived(materialId);
 
             expect(purchaseOrdersFound.length).toBe(expectedNumberOfPurchaseOrdersFound);
         });
@@ -187,7 +220,7 @@ describe('materialOrderService test suite', () => {
             const expectedLength = purchaseOrdersInDatabase.length;
             execFunction = jest.fn().mockResolvedValue(purchaseOrdersInDatabase);
 
-            const purchaseOrdersFound = await materialOrderService.findPurchaseOrdersByMaterial(materialId);
+            const purchaseOrdersFound = await materialOrderService.findPurchaseOrdersByMaterialThatHaveNotArrived(materialId);
 
             expect(purchaseOrdersFound.length).toBe(expectedLength);
         });

--- a/test/services/materialOrderService.spec.js
+++ b/test/services/materialOrderService.spec.js
@@ -120,7 +120,7 @@ describe('materialOrderService test suite', () => {
 
             await materialOrderService.getLengthOfOneMaterialInInventory(materialId);
 
-            expect(JSON.stringify(findFunction.mock.calls[0][0])).toBe(JSON.stringify(expectedQuery))
+            expect(JSON.stringify(findFunction.mock.calls[0][0])).toBe(JSON.stringify(expectedQuery));
         });
 
         it('should return length of 0 if no purchase order is found for the given materialId', async () => {
@@ -160,7 +160,7 @@ describe('materialOrderService test suite', () => {
 
             await materialOrderService.getLengthOfOneMaterialOrdered(materialId);
 
-            expect(JSON.stringify(findFunction.mock.calls[0][0])).toBe(JSON.stringify(expectedQuery))
+            expect(JSON.stringify(findFunction.mock.calls[0][0])).toBe(JSON.stringify(expectedQuery));
         });
 
         it('should return length of 0 if no purchase order is found for the given materialId', async () => {
@@ -204,7 +204,7 @@ describe('materialOrderService test suite', () => {
 
             await materialOrderService.findPurchaseOrdersByMaterialThatHaveNotArrived(materialId);
 
-            expect(JSON.stringify(findFunction.mock.calls[0][0])).toBe(JSON.stringify(expectedQuery))
+            expect(JSON.stringify(findFunction.mock.calls[0][0])).toBe(JSON.stringify(expectedQuery));
         });
 
         it('should return length of 0 if no purchase order is found for the given materialId', async () => {


### PR DESCRIPTION
## Description

After merging #110 it was noticed that all purchaseOrders were being displayed on the `/material-inventory` page for each material.

It was decided that only purchaseOrder objects whose attribute `hasArrived = false` should be displayed.

This PR fixes that issue.

Also, a mis-formatted error message was also uncovered and fixed with a line of code