### PR TITLE
Add/Update Attributes and Validations Around `Ticket` and `Product` Database Objects

### DIFF
--- a/application/controllers/ticketController.js
+++ b/application/controllers/ticketController.js
@@ -111,7 +111,6 @@ router.get('/update/:id', async (request, response) => {
         const departmentNames = Object.keys(subDepartmentsGroupedByDepartment);
 
         const ticketDestination = ticket.destination;
-        const selectedPrintingType = ticket.printingType;
         const selectedDepartment = ticketDestination && ticketDestination.department;
         const selectedSubDepartment = ticketDestination && ticketDestination.subDepartment;
         const selectedMaterial = ticket.primaryMaterial;
@@ -124,7 +123,6 @@ router.get('/update/:id', async (request, response) => {
             ticket,
             materialIds,
             departmentNames,
-            selectedPrintingType,
             selectedDepartment,
             selectedSubDepartment,
             subDepartments,

--- a/application/enums/idToColorEnum.js
+++ b/application/enums/idToColorEnum.js
@@ -1,0 +1,11 @@
+module.exports.idToColorEnum = {
+    1: 'Black',
+    2: 'Black & White',
+    3: 'EPM',
+    4: 'CMYK',
+    5: 'CMYK + W',
+    6: 'CMYK OV',
+    7: 'CMYK OV + W',
+    8: 'CMYK + W×2',
+    9: 'CMYK OV + W×2',
+};

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -101,7 +101,7 @@ const schema = new Schema({
     },
     hotFolder: {
         type: String,
-        required: false,
+        required: true,
         default: function() {
             return hotFolders[this.primaryMaterial];
         },
@@ -241,7 +241,7 @@ const schema = new Schema({
     },
     finishType: {
         type: String,
-        required: false,
+        required: true,
         alias: 'FinishType'
     },
     price: {
@@ -306,7 +306,7 @@ const schema = new Schema({
     },
     labelRepeat: {
         type: Number,
-        required: false,
+        required: true,
         alias: 'LabelRepeat'
     },
     overRun: {

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -12,6 +12,7 @@ URL_VALIDATION_REGEX = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0
 
 const NUMBER_OF_PENNIES_IN_A_DOLLAR = 100;
 const NUMBER_OF_DECIMAL_PLACES_IN_CURRENCY = 2;
+const FRAME_REPEAT_SCALAR = 25.4;
 
 function cannotBeFalsy(value) {
     if (!value) {
@@ -311,6 +312,7 @@ const schema = new Schema({
         type: Number,
         min: 0,
         max: 100,
+        default: 0,
         set: function (overRun) {
             return overRun / 100; // eslint-disable-line no-magic-numbers
         },
@@ -363,33 +365,72 @@ const schema = new Schema({
     },
     labelsPerFrame: {
         type: Number,
+        min: 1,
         required: true,
         default: function() {
-            return this.labelsAround * this.labelsAcross;
+            return Math.floor(this.labelsAround * this.labelsAcross);
         }
     },
     measureAcross: {
         type: Number,
         required: true,
         default: function() {
-            return this.labelsAcross + this.matrixAcross;
+            const decimalPositionToRound = 4;
+            const measureAcrossBeforeRounding = this.labelsAcross + this.matrixAcross;
+            return roundValueToNearestDecimalPlace(measureAcrossBeforeRounding, decimalPositionToRound);
         }
     },
     measureAround: {
         type: Number,
         required: true,
         default: function() {
-            return this.labelsAround + this.matrixAround;
+            const decimalPositionToRound = 4;
+            const measureAroundBeforeRounding = this.labelsAround + this.matrixAround;
+            return roundValueToNearestDecimalPlace(measureAroundBeforeRounding, decimalPositionToRound);
         }
     },
     framesPlusOverRun: {
         type: Number,
         required: true,
         default: function() {
-            return (this.frameCount * this.overRun) + this.frameCount;
+            return Math.ceil((this.frameCount * this.overRun) + this.frameCount);
+        }
+    },
+    topBottomBleed: {
+        type: Number,
+        required: true,
+        default: function() {
+            const decimalPositionToRound = 4;
+            const topBottomBleedBeforeRound = this.matrixAcross / 2; // eslint-disable-line no-magic-numbers
+            return roundValueToNearestDecimalPlace(topBottomBleedBeforeRound, decimalPositionToRound);
+        }
+    },
+    leftRightBleed: {
+        type: Number,
+        required: true,
+        default: function() {
+            const decimalPositionToRound = 4;
+            const leftRightBleedBeforeRound = this.matrixAround / 2; // eslint-disable-line no-magic-numbers
+            return roundValueToNearestDecimalPlace(leftRightBleedBeforeRound, decimalPositionToRound);
+        }
+    },
+    frameRepeat: {
+        type: Number,
+        required: true,
+        default: function() {
+            const frameRepeatBeforeRounding = this.labelsAround * this.labelRepeat * FRAME_REPEAT_SCALAR;
+            const frameRepeatRoundedUpToSecondDecimalPlace = (Math.ceil(frameRepeatBeforeRounding * 100) / 100); // eslint-disable-line no-magic-numbers
+            return frameRepeatRoundedUpToSecondDecimalPlace;
         }
     }
 }, { timestamps: true });
+
+function roundValueToNearestDecimalPlace(unRoundedValue, decimalPositionToRound) {
+    const precision = Math.pow(10, decimalPositionToRound); // eslint-disable-line no-magic-numbers
+
+    return Math.round(unRoundedValue * precision) / precision;
+}
+
 
 const Product = mongoose.model('Product', schema);
 

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -311,7 +311,7 @@ const schema = new Schema({
         min: 0,
         max: 100,
         set: function (overRun) {
-            return overRun / 100;
+            return overRun / 100; // eslint-disable-line no-magic-numbers
         },
         required: false,
         alias: 'OverRun'

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -170,11 +170,13 @@ const schema = new Schema({
     },
     matrixAcross: {
         type: Number,
+        min: 0,
         required: true,
         alias: 'ColSpace'
     },
     matrixAround: {
         type: Number,
+        min: 0,
         required: true,
         alias: 'RowSpace'
     },
@@ -350,6 +352,20 @@ const schema = new Schema({
         type: String,
         required: true,
         alias: 'ToolingNotes'
+    },
+    labelsPerFrame: {
+        type: Number,
+        required: true,
+        default: function() {
+            return this.labelsAround * this.labelsAcross;
+        }
+    },
+    measureAcross: {
+        type: Number,
+        required: true,
+        default: function() {
+            return this.labelsAcross + this.matrixAcross;
+        }
     }
 }, { timestamps: true });
 

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -345,6 +345,11 @@ const schema = new Schema({
         type: String,
         required: false,
         alias: 'StockNum'
+    },
+    toolingNotes: {
+        type: String,
+        required: true,
+        alias: 'ToolingNotes'
     }
 }, { timestamps: true });
 

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -363,7 +363,7 @@ const schema = new Schema({
     },
     toolingNotes: {
         type: String,
-        required: true,
+        required: false,
         alias: 'ToolingNotes'
     },
     frameCount: {

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -300,6 +300,11 @@ const schema = new Schema({
         required: function() {
             return this.finishType && this.finishType.toUpperCase() === 'ROLL';
         }
+    },
+    labelRepeat: {
+        type: Number,
+        required: false,
+        alias: 'LabelRepeat'
     }
 }, { timestamps: true });
 

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -305,6 +305,16 @@ const schema = new Schema({
         type: Number,
         required: false,
         alias: 'LabelRepeat'
+    },
+    overRun: {
+        type: Number,
+        min: 0,
+        max: 100,
+        set: function (overRun) {
+            return overRun / 100;
+        },
+        required: false,
+        alias: 'OverRun'
     }
 }, { timestamps: true });
 

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -222,10 +222,9 @@ const schema = new Schema({
             }
         ],
         set: function (integerRepresentingAColor) {
-            const nameOfColor = numberToColorEnum[integerRepresentingAColor];
-            return nameOfColor ? nameOfColor : '';
+            return numberToColorEnum[integerRepresentingAColor];
         },
-        required: false,
+        required: true,
         alias: 'NoColors'
     },
     labelsPerRoll: {
@@ -353,6 +352,15 @@ const schema = new Schema({
         required: true,
         alias: 'ToolingNotes'
     },
+    frameCount: {
+        type: Number,
+        required: true,
+        min: 0,
+        set: function(frameCount) {
+            return Math.ceil(frameCount);
+        },
+        alias: 'MachineCount'
+    },
     labelsPerFrame: {
         type: Number,
         required: true,
@@ -365,6 +373,20 @@ const schema = new Schema({
         required: true,
         default: function() {
             return this.labelsAcross + this.matrixAcross;
+        }
+    },
+    measureAround: {
+        type: Number,
+        required: true,
+        default: function() {
+            return this.labelsAround + this.matrixAround;
+        }
+    },
+    framesPlusOverRun: {
+        type: Number,
+        required: true,
+        default: function() {
+            return (this.frameCount * this.overRun) + this.frameCount;
         }
     }
 }, { timestamps: true });

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -320,6 +320,11 @@ const schema = new Schema({
         type: String,
         required: false,
         alias: 'ColorDescr'
+    },
+    coreDiameter: {
+        type: Number,
+        required: true,
+        alias: 'CoreDiameter'
     }
 }, { timestamps: true });
 

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -315,6 +315,11 @@ const schema = new Schema({
         },
         required: false,
         alias: 'OverRun'
+    },
+    varnish: {
+        type: String,
+        required: false,
+        alias: 'ColorDescr'
     }
 }, { timestamps: true });
 

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -330,6 +330,21 @@ const schema = new Schema({
         type: Number,
         required: true,
         alias: 'NoLabAcrossFin'
+    },
+    shippingAttention: {
+        type: String,
+        required: false,
+        alias: 'ShipAttn'
+    },
+    dieCuttingMarriedMaterial: {
+        type: String,
+        required: false,
+        alias: 'StockNum3'
+    },
+    dieCuttingFinish: {
+        type: String,
+        required: false,
+        alias: 'StockNum'
     }
 }, { timestamps: true });
 

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -217,6 +217,7 @@ const schema = new Schema({
     },
     numberOfColors: {
         type: String,
+        required: true,
         validate : [
             {
                 validator : validateColor,
@@ -226,7 +227,6 @@ const schema = new Schema({
         set: function (integerRepresentingAColor) {
             return numberToColorEnum[integerRepresentingAColor];
         },
-        required: true,
         alias: 'NoColors'
     },
     labelsPerRoll: {
@@ -490,7 +490,7 @@ const schema = new Schema({
     },
     deltaRepeat: {
         type: Number,
-        required: false,
+        required: true,
         default: function(){
             return this.labelRepeat;
         }

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -273,7 +273,7 @@ const schema = new Schema({
         required: false,
         alias: 'ToolNo2'
     },
-    Tool_NumberAround: {
+    toolNumberAround: {
         type: Number,
         validate : [
             {
@@ -285,12 +285,12 @@ const schema = new Schema({
                 message: 'Tool Number Around cannot be negative'
             }
         ],
-        required: false,
-        alias: 'toolNumberAround'
+        required: true,
+        alias: 'Tool_NumberAround'
     },
-    Plate_ID: {
+    plateId: {
         type: String,
-        alias: 'plateId'
+        alias: 'Plate_ID'
     },
     totalWindingRolls: {
         type: Number,
@@ -315,7 +315,9 @@ const schema = new Schema({
         max: 100,
         default: 0,
         set: function (overRun) {
-            return overRun / 100; // eslint-disable-line no-magic-numbers
+            const decimalPositionToRound = 2;
+            const overRunBeforeRounding = overRun / 100; // eslint-disable-line no-magic-numbers
+            return roundValueToNearestDecimalPlace(overRunBeforeRounding, decimalPositionToRound);
         },
         required: false,
         alias: 'OverRun'
@@ -467,8 +469,25 @@ const schema = new Schema({
             const numberOfRollsBeforeRounding = this.totalFeet / FEET_PER_ROLL;
             return roundValueToNearestDecimalPlace(numberOfRollsBeforeRounding, decimalPositionToRound);
         }
+    },
+    rotoRepeat: {
+        type: Number,
+        required: true,
+        default: function() {
+            const decimalPositionToRound = 3;
+            const rotoRepeatBeforeRounding = this.labelRepeat * this.toolNumberAround;
+            return roundValueToNearestDecimalPlace(rotoRepeatBeforeRounding, decimalPositionToRound);
+        }
+    },
+    deltaRepeat: {
+        type: Number,
+        required: false,
+        default: function(){
+            return this.labelRepeat;
+        }
     }
 }, { timestamps: true });
+
 
 function roundValueToNearestDecimalPlace(unRoundedValue, decimalPositionToRound) {
     const precision = Math.pow(10, decimalPositionToRound); // eslint-disable-line no-magic-numbers

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -325,6 +325,11 @@ const schema = new Schema({
         type: Number,
         required: true,
         alias: 'CoreDiameter'
+    },
+    numberAcross: {
+        type: Number,
+        required: true,
+        alias: 'NoLabAcrossFin'
     }
 }, { timestamps: true });
 

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 const MaterialModel = require('../models/material');
 const {hotFolders, getUniqueHotFolders} = require('../enums/hotFolderEnum');
+const {idToColorEnum: numberToColorEnum} = require('../enums/idToColorEnum');
 const {getAllDepartments} = require('../enums/departmentsEnum');
 
 // For help deciphering these regex expressions, visit: https://regexr.com/
@@ -60,6 +61,10 @@ function validateCornerRadius(cornerRadius) {
 
 function validateUrl(url) {
     return URL_VALIDATION_REGEX.test(url);
+}
+
+function validateColor(nameOfColor) {
+    return Object.values(numberToColorEnum).includes(nameOfColor);
 }
 
 const alertSchema = new Schema({
@@ -207,12 +212,17 @@ const schema = new Schema({
         alias: 'Hidden_Notes'
     },
     numberOfColors: {
-        type: Number,
-        validate : {
-            validator : Number.isInteger,
-            message   : 'Number of Colors must be an integer'
+        type: String,
+        validate : [
+            {
+                validator : validateColor,
+                message   : 'Number of Colors does not map to any color'
+            }
+        ],
+        set: function (integerRepresentingAColor) {
+            const nameOfColor = numberToColorEnum[integerRepresentingAColor];
+            return nameOfColor ? nameOfColor : '';
         },
-        min: 0,
         required: false,
         alias: 'NoColors'
     },

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -330,11 +330,20 @@ const schema = new Schema({
     coreDiameter: {
         type: Number,
         required: true,
+        set: function(coreDiameter) {
+            const decimalPositionToRound = 4;
+
+            return roundValueToNearestDecimalPlace(coreDiameter, decimalPositionToRound);
+        },
         alias: 'CoreDiameter'
     },
     numberAcross: {
         type: Number,
         required: true,
+        validate : {
+            validator : Number.isInteger,
+            message   : '"NoLabAcrossFin" (aka "Number Across") must be an integer'
+        },
         alias: 'NoLabAcrossFin'
     },
     shippingAttention: {

--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -263,8 +263,8 @@ const ticketSchema = new Schema({
     },
     customerName: {
         type: String,
-        alias: 'Company',
-        required: false,
+        required: true,
+        alias: 'Company'
     },
 }, { timestamps: true });
 

--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -7,10 +7,15 @@ const MaterialModel = require('../models/material');
 
 // For help deciphering these regex expressions, visit: https://regexr.com/
 TICKET_NUMBER_REGEX = /^\d{1,}$/;
+const EMAIL_VALIDATION_REGEX = /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/;
 
 function stringOnlyContainsDigits(ticketNumber) {
     return TICKET_NUMBER_REGEX.test(ticketNumber);
 }
+
+const validateEmail = function(email) {
+    return EMAIL_VALIDATION_REGEX.test(email);
+};
 
 function destinationsAreValid(destination) {
     const department = destination.department;
@@ -222,6 +227,7 @@ const ticketSchema = new Schema({
     shippingEmailAddress: {
         type: String,
         required: false,
+        validate: [validateEmail, '"ShipAttn_EmailAddress" must be a valid email address'],
         alias: 'ShipAttn_EmailAddress'
     },
     billingState: {

--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -257,7 +257,7 @@ const ticketSchema = new Schema({
     },
     customerName: {
         type: String,
-        alias: 'CustomerCompany',
+        alias: 'Company',
         required: false,
     },
 }, { timestamps: true });

--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -156,7 +156,7 @@ const ticketSchema = new Schema({
     },
     priority: {
         type: String,
-        required: true,
+        required: false,
         alias: 'Priority'
     },
     billingZipCode: {

--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -255,9 +255,11 @@ const ticketSchema = new Schema({
             return sum;
         }
     },
-    labelRepeat: {
-
-    }
+    customerName: {
+        type: String,
+        alias: 'CustomerCompany',
+        required: false,
+    },
 }, { timestamps: true });
 
 ticketSchema.pre('save', function(next) {

--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -112,20 +112,6 @@ const ticketSchema = new Schema({
         required: false,
         validate: [destinationsAreValid, 'Invalid Department/Sub-department combination']
     },
-    printingType: {
-        type: String,
-        required: false,
-        enum: [
-            'CMYK',
-            'CMYK + W',
-            'BLANKS',
-            'CMYK OV + W',
-            'BLACK ONLY',
-            'EPM',
-            'BLACK & WHITE',
-            'CMYK OV',
-        ]
-    },
     products: {
         type: [productSchema],
     },
@@ -268,6 +254,9 @@ const ticketSchema = new Schema({
             }
             return sum;
         }
+    },
+    labelRepeat: {
+
     }
 }, { timestamps: true });
 

--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -250,6 +250,7 @@ const ticketSchema = new Schema({
     },
     totalWindingRolls: {
         type: Number,
+        required: true,
         default: function() {
             let sum = 0; // eslint-disable-line no-magic-numbers
 

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -36,17 +36,6 @@ $( document ).ready(function() {
         updateTicket(ticketAttributes, ticketId);
     });
 
-    $('#printing-type-selection').change(function() {
-        const selectedPrintingType = $('#printing-type-selection').val();
-        const ticketId = $('#department-notes').data('ticket-id');
-
-        const ticketAttributes = {
-            printingType: selectedPrintingType
-        };
-        
-        updateTicket(ticketAttributes, ticketId);
-    });
-
     $('#department-selection').change(function() {
         const selectedDepartment = $('#department-selection').val();
         const ticketId = $('#department-notes').data('ticket-id');

--- a/application/services/ticketService.js
+++ b/application/services/ticketService.js
@@ -38,7 +38,8 @@ function parseTicketAttributesOffOfProducts(product) {
         ShippingInstruc: product.ShippingInstruc,
         ShipVia: product.ShipVia,
         ShipAttn_EmailAddress: product.ShipAttn_EmailAddress,
-        BillState: product.BillState
+        BillState: product.BillState,
+        Company: product.Company
     };
 }
 

--- a/application/views/updateTicket.ejs
+++ b/application/views/updateTicket.ejs
@@ -27,21 +27,6 @@
         </div>
 
         <div class="form-group">
-            <label for="printing-type-selection">Printing Type</label>
-            <select name="printingType" id="printing-type-selection" data-ticket-id="<%= ticket.id %>">
-                <option value=""><%= '-' %></option>
-                <option value="CMYK" <%= selectedPrintingType === 'CMYK' ? 'selected' : '' %>><%= 'CMYK' %></option>
-                <option value="CMYK + W" <%= selectedPrintingType === 'CMYK + W' ? 'selected' : '' %>><%= 'CMYK + W' %></option>
-                <option value="BLANKS" <%= selectedPrintingType === 'BLANKS' ? 'selected' : '' %>><%= 'Blanks' %></option>
-                <option value="CMYK OV + W" <%= selectedPrintingType === 'CMYK OV + W' ? 'selected' : '' %>><%= 'CMYK OV + W' %></option>
-                <option value="BLACK ONLY" <%= selectedPrintingType === 'BLACK ONLY' ? 'selected' : '' %>><%= 'Black Only' %></option>
-                <option value="EPM" <%= selectedPrintingType === 'EPM' ? 'selected' : '' %>><%= 'EPM' %></option>
-                <option value="BLACK & WHITE" <%= selectedPrintingType === 'BLACK & WHITE' ? 'selected' : '' %>><%= 'Black & White' %></option>
-                <option value="CMYK OV" <%= selectedPrintingType === 'CMYK OV' ? 'selected' : '' %>><%= 'CMYK OV' %></option>
-            </select>
-        </div>
-
-        <div class="form-group">
             <label for="department-selection">Department:</label>
             <select name="destination[department]" id="department-selection" data-ticket-id="<%= ticket.id %>">
                 <option value=""><%= '-' %></option>

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -832,13 +832,13 @@ describe('validation', () => {
             expect(product.toolNumberAround).toBeDefined();
         });
 
-        it('should pass validation if attribute is missing', () => {
+        it('should fail validation if attribute is missing', () => {
             delete productAttributes.Tool_NumberAround;
             const product = new ProductModel(productAttributes);
 
             const error = product.validateSync();
 
-            expect(error).toBe(undefined);
+            expect(error).not.toBe(undefined);
         });
 
         it('should fail if attribute is not an integer', () => {
@@ -1189,9 +1189,20 @@ describe('validation', () => {
             const overRun = chance.integer({min: OVERRUN_MIN, max: OVERRUN_MAX});
             const overRunAsPercentage = overRun / 100; // eslint-disable-line no-magic-numbers
             productAttributes.OverRun = overRun;
+
             const product = new ProductModel(productAttributes);
 
             expect(product.overRun).toBe(overRunAsPercentage);
+        });
+
+        it('should convert attribute from floating point to percent', () => {
+            const overRun = 97.5;
+            const expectedOverRun = 0.98; // eslint-disable-line no-magic-numbers
+            productAttributes.OverRun = overRun;
+
+            const product = new ProductModel(productAttributes);
+
+            expect(product.overRun).toBe(expectedOverRun);
         });
     });
 
@@ -1533,8 +1544,9 @@ describe('validation', () => {
         it('should be calculated and rounded to the fourth decimal place correctly (test 1)', () => {
             const matrixAcross = 10.8888888888;
             productAttributes.ColSpace = matrixAcross;
-            const product = new ProductModel(productAttributes);
             const expectedTopBottomBleed = 5.4444;
+
+            const product = new ProductModel(productAttributes);
 
             expect(product.topBottomBleed).toEqual(expectedTopBottomBleed);
         });
@@ -1542,8 +1554,9 @@ describe('validation', () => {
         it('should be calculated and rounded to the fourth decimal place correctly (test 2)', () => {
             const matrixAcross = 10.001111111;
             productAttributes.ColSpace = matrixAcross;
-            const product = new ProductModel(productAttributes);
             const expectedTopBottomBleed = 5.0006;
+
+            const product = new ProductModel(productAttributes);
 
             expect(product.topBottomBleed).toEqual(expectedTopBottomBleed);
         });
@@ -1551,8 +1564,9 @@ describe('validation', () => {
         it('should be calculated and rounded to the fourth decimal place correctly (test 3)', () => {
             const matrixAcross = 10.9999999999;
             productAttributes.ColSpace = matrixAcross;
-            const product = new ProductModel(productAttributes);
             const expectedTopBottomBleed = 5.5000;
+
+            const product = new ProductModel(productAttributes);
 
             expect(product.topBottomBleed).toEqual(expectedTopBottomBleed);
         });
@@ -1574,8 +1588,9 @@ describe('validation', () => {
         it('should be calculated and rounded to the fourth decimal place correctly (test 1)', () => {
             const matrixAround = 4.7777777;
             productAttributes.RowSpace = matrixAround;
-            const product = new ProductModel(productAttributes);
             const expectedLeftRightBleed = 2.3889;
+
+            const product = new ProductModel(productAttributes);
 
             expect(product.leftRightBleed).toEqual(expectedLeftRightBleed);
         });
@@ -1583,8 +1598,9 @@ describe('validation', () => {
         it('should be calculated and rounded to the fourth decimal place correctly (test 2)', () => {
             const matrixAround = 3.862475;
             productAttributes.RowSpace = matrixAround;
-            const product = new ProductModel(productAttributes);
             const expectedLeftRightBleed = 1.9312;
+
+            const product = new ProductModel(productAttributes);
 
             expect(product.leftRightBleed).toEqual(expectedLeftRightBleed);
         });
@@ -1592,8 +1608,9 @@ describe('validation', () => {
         it('should be calculated and rounded to the fourth decimal place correctly (test 3)', () => {
             const matrixAround = 10.9999999999;
             productAttributes.RowSpace = matrixAround;
-            const product = new ProductModel(productAttributes);
             const expectedLeftRightBleed = 5.5000;
+
+            const product = new ProductModel(productAttributes);
 
             expect(product.leftRightBleed).toEqual(expectedLeftRightBleed);
         });
@@ -1616,6 +1633,7 @@ describe('validation', () => {
             productAttributes.NoAround = 1;
             productAttributes.LabelRepeat = .01;
             const expectedFrameRepeat = 0.26; // eslint-disable-line no-magic-numbers
+
             const product = new ProductModel(productAttributes);
 
             expect(product.frameRepeat).toEqual(Number(expectedFrameRepeat));
@@ -1624,6 +1642,7 @@ describe('validation', () => {
         it('should be calculated and rounded up (math.ceil) to the second decimal place correctly (test 2)', () => {
             const frameRepeatBeforeRounding = productAttributes.NoAround * productAttributes.LabelRepeat * FRAME_REPEAT_SCALAR;
             const expectedFrameRepeatAfterRoundingUpToSecondDecimalPlace = (Math.ceil(frameRepeatBeforeRounding * 100) / 100); // eslint-disable-line no-magic-numbers
+
             const product = new ProductModel(productAttributes);
 
             expect(product.frameRepeat).toEqual(Number(expectedFrameRepeatAfterRoundingUpToSecondDecimalPlace));
@@ -1647,6 +1666,7 @@ describe('validation', () => {
             delete productAttributes.ColorDescr;
             delete productAttributes.FinishType;
             const expectedExtraFrames = 25;
+
             const product = new ProductModel(productAttributes);
 
             expect(product.extraFrames).toEqual(expectedExtraFrames);
@@ -1656,6 +1676,7 @@ describe('validation', () => {
             productAttributes.ColorDescr = 'Anything UV';
             delete productAttributes.FinishType;
             const expectedExtraFrames = 75;
+
             const product = new ProductModel(productAttributes);
 
             expect(product.extraFrames).toEqual(expectedExtraFrames);
@@ -1665,6 +1686,7 @@ describe('validation', () => {
             delete productAttributes.ColorDescr;
             productAttributes.FinishType = 'Sheeted';
             const expectedExtraFrames = 125;
+
             const product = new ProductModel(productAttributes);
 
             expect(product.extraFrames).toEqual(expectedExtraFrames);
@@ -1674,6 +1696,7 @@ describe('validation', () => {
             productAttributes.ColorDescr = 'Anything UV';
             productAttributes.FinishType = 'Sheeted';
             const expectedExtraFrames = 175;
+
             const product = new ProductModel(productAttributes);
 
             expect(product.extraFrames).toEqual(expectedExtraFrames);
@@ -1739,9 +1762,9 @@ describe('validation', () => {
         it('should be calculated correctly (test 1)', () => {
             const totalFeet = 5001;
             productAttributes.totalFeet = totalFeet;
+            const expectedNumberOfRolls = 1.00;
 
             const product = new ProductModel(productAttributes);
-            const expectedNumberOfRolls = 1.00;
 
             expect(product.numberOfRolls).toEqual(expectedNumberOfRolls);
         });
@@ -1749,20 +1772,87 @@ describe('validation', () => {
         it('should be calculated correctly (test 2)', () => {
             const totalFeet = 9862;
             productAttributes.totalFeet = totalFeet;
+            const expectedNumberOfRolls = 1.97;
 
             const product = new ProductModel(productAttributes);
-            const expectedNumberOfRolls = 1.97;
 
             expect(product.numberOfRolls).toEqual(expectedNumberOfRolls);
         });        
         it('should be calculated correctly (test 3)', () => {
             const totalFeet = 977686;
             productAttributes.totalFeet = totalFeet;
-
-            const product = new ProductModel(productAttributes);
             const expectedNumberOfRolls = 195.54;
 
+            const product = new ProductModel(productAttributes);
+
             expect(product.numberOfRolls).toEqual(expectedNumberOfRolls);
+        });
+    });
+
+    describe('attribute: rotoRepeat', () => {
+        it('should contain attribute', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.rotoRepeat).toBeDefined();
+        });
+
+        it('should be of type Number', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.rotoRepeat).toEqual(expect.any(Number));
+        });
+        
+        it('should be calculated correctly (test 1)', () => {
+            productAttributes.LabelRepeat = 0.99999;
+            productAttributes.Tool_NumberAround = 0.3344334;
+            const expectedRotoRepeat = 0.334;
+
+            const product = new ProductModel(productAttributes);
+
+            expect(product.rotoRepeat).toEqual(expectedRotoRepeat);
+        });
+
+        it('should be calculated correctly (test 2)', () => {
+            productAttributes.LabelRepeat = 7.0009;
+            productAttributes.Tool_NumberAround = 1.0001;
+            const expectedRotoRepeat = 7.002;
+
+            const product = new ProductModel(productAttributes);
+
+            expect(product.rotoRepeat).toEqual(expectedRotoRepeat);
+        });
+     
+        it('should be calculated correctly (test 2)', () => {
+            productAttributes.LabelRepeat = 0.00001;
+            productAttributes.Tool_NumberAround = 0.00009;
+
+            const product = new ProductModel(productAttributes);
+            const expectedRotoRepeat = 0.000;
+
+            expect(product.rotoRepeat).toEqual(expectedRotoRepeat);
+        });
+    });
+
+    describe('attribute: deltaRepeat', () => {
+        it('should contain attribute', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.deltaRepeat).toBeDefined();
+        });
+
+        it('should be of type Number', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.deltaRepeat).toEqual(expect.any(Number));
+        });
+        
+        it('should have its value equal to the "labelRepeat" attribute', () => {
+            const expectedValue = chance.floating({min: 0.1});
+            productAttributes.LabelRepeat = expectedValue;
+
+            const product = new ProductModel(productAttributes);
+
+            expect(product.deltaRepeat).toEqual(expectedValue);
         });
     });
 });

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -45,7 +45,8 @@ describe('validation', () => {
             Plate_ID: chance.string(),
             alerts: [],
             LabelRepeat: String(chance.floating({min: 0.1})),
-            OverRun: String(chance.integer({min: OVERRUN_MIN, max: OVERRUN_MAX}))
+            OverRun: String(chance.integer({min: OVERRUN_MIN, max: OVERRUN_MAX})),
+            ColorDescr: chance.string()
         };
     });
 
@@ -1157,6 +1158,29 @@ describe('validation', () => {
             const product = new ProductModel(productAttributes);
 
             expect(product.overRun).toBe(overRunAsPercentage);
+        });
+    });
+
+    describe('attribute: varnish', () => {
+        it('should contain attribute', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.varnish).toBeDefined();
+        });
+
+        it('should be of type Number', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.varnish).toEqual(expect.any(String));
+        });
+        
+        it('should pass validation if attribute is not defined', () => {
+            delete productAttributes.ColorDescr;
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+
+            expect(error).not.toBeDefined();
         });
     });
 });

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -31,6 +31,7 @@ describe('validation', () => {
             RowSpace: String(chance.floating({min: 0})),
             Description: chance.string(),
             OrderQuantity: String(chance.integer({min: 0})),
+            MachineCount: String(chance.floating({min: 0})),
             FinishNotes: chance.string(),
             StockNotes: chance.string(),
             Notes: [chance.string(), chance.string()],
@@ -592,6 +593,7 @@ describe('validation', () => {
             expect(product.printingNotes).toEqual(expect.any(String));
         });
     });
+
     describe('attribute: numberOfColors (aka NoColors)', () => {
         it('should contain attribute', () => {
             const product = new ProductModel(productAttributes);
@@ -620,13 +622,13 @@ describe('validation', () => {
             expect(error).not.toBe(undefined);
         });
 
-        it('should pass validation if attribute is missing', () => {
+        it('should fail validation if attribute is missing', () => {
             delete productAttributes.NoColors;
             const product = new ProductModel(productAttributes);
 
             const error = product.validateSync();
 
-            expect(error).toBe(undefined);
+            expect(error).not.toBe(undefined);
         });
 
         it('should be of type Number', () => {
@@ -1355,6 +1357,47 @@ describe('validation', () => {
         });
     });
 
+    describe('attribute: frameCount (aka MachineCount)', () => {
+        it('should contain attribute', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.frameCount).toBeDefined();
+        });
+
+        it('should be of type Number', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.frameCount).toEqual(expect.any(Number));
+        });
+        
+        it('should fail validation if attribute is not defined', () => {
+            delete productAttributes.MachineCount;
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+
+            expect(error).toBeDefined();
+        });
+
+        it('should round up floating point to nearest whole number', () => {
+            const frameCount = chance.floating({min: 1});
+            productAttributes.MachineCount = frameCount;
+
+            const product = new ProductModel(productAttributes);
+
+            expect(product.frameCount).toBe(Math.ceil(frameCount))
+        });
+
+        it('should fail validation if attribute is negative', () => {
+            productAttributes.MachineCount = chance.floating({max: -1});
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+
+            expect(error).toBeDefined();
+        });
+    });
+
     describe('attribute: labelsPerFrame', () => {
         it('should contain attribute', () => {
             const product = new ProductModel(productAttributes);
@@ -1402,6 +1445,52 @@ describe('validation', () => {
             const product = new ProductModel(productAttributes);
 
             expect(product.measureAcross).toEqual(labelsAcross + matrixAcross);
+        });
+    });
+
+    describe('attribute: measureAround', () => {
+        it('should contain attribute', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.measureAround).toBeDefined();
+        });
+
+        it('should be of type Number', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.measureAround).toEqual(expect.any(Number));
+        });
+        
+        it('should be calculated correctly', () => {
+            const labelsAround = chance.floating({min: 0.1});
+            const matrixAround = chance.floating({min: 0});
+            productAttributes.NoAround = labelsAround;
+            productAttributes.RowSpace = matrixAround;
+
+            const product = new ProductModel(productAttributes);
+
+            expect(product.measureAround).toEqual(labelsAround + matrixAround);
+        });
+    });
+
+    describe('attribute: framesPlusOverRun', () => {
+        it('should contain attribute', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.framesPlusOverRun).toBeDefined();
+        });
+
+        it('should be of type Number', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.framesPlusOverRun).toEqual(expect.any(Number));
+        });
+        
+        it('should be calculated correctly', () => {
+            const product = new ProductModel(productAttributes);
+            const expectedFramesPlusOverRun = (product.frameCount * product.overRun) + product.frameCount;
+
+            expect(product.framesPlusOverRun).toEqual(expectedFramesPlusOverRun);
         });
     });
 });

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -48,7 +48,10 @@ describe('validation', () => {
             OverRun: String(chance.integer({min: OVERRUN_MIN, max: OVERRUN_MAX})),
             ColorDescr: String(chance.string()),
             CoreDiameter: String(chance.integer()),
-            NoLabAcrossFin: String(chance.integer())
+            NoLabAcrossFin: String(chance.integer()),
+            ShipAttn: chance.string(),
+            StockNum3: chance.string(),
+            StockNum: chance.string()
         };
     });
 
@@ -180,7 +183,7 @@ describe('validation', () => {
             expect(error).toBe(undefined);
         });
 
-        it('should be of type Object', () => {
+        it('should be of type String', () => {
             const product = new ProductModel(productAttributes);
 
             expect(product.uvFinish).toEqual(expect.any(String));
@@ -648,7 +651,7 @@ describe('validation', () => {
             expect(error).not.toBe(undefined);
         });
 
-        it('should be of type String', () => {
+        it('should be of type Number', () => {
             const product = new ProductModel(productAttributes);
 
             expect(product.labelsPerRoll).toEqual(expect.any(Number));
@@ -1170,7 +1173,7 @@ describe('validation', () => {
             expect(product.varnish).toBeDefined();
         });
 
-        it('should be of type Number', () => {
+        it('should be of type String', () => {
             const product = new ProductModel(productAttributes);
 
             expect(product.varnish).toEqual(expect.any(String));
@@ -1229,6 +1232,84 @@ describe('validation', () => {
             const error = product.validateSync();
 
             expect(error).toBeDefined();
+        });
+    });
+
+    describe('attribute: shippingAttention', () => {
+        it('should contain attribute', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.shippingAttention).toBeDefined();
+        });
+
+        it('should be of type String', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.shippingAttention).toEqual(expect.any(String));
+        });
+        
+        it('should pass validation if attribute is not defined', () => {
+            delete productAttributes.ShipAttn;
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+
+            expect(error).not.toBeDefined();
+        });
+
+        it('should pass validation if attribute is empty', () => {
+            productAttributes.ShipAttn = '';
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+
+            expect(error).not.toBeDefined();
+        });
+    });
+
+    describe('attribute: dieCuttingMarriedMaterial', () => {
+        it('should contain attribute', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.dieCuttingMarriedMaterial).toBeDefined();
+        });
+
+        it('should be of type String', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.dieCuttingMarriedMaterial).toEqual(expect.any(String));
+        });
+        
+        it('should pass validation if attribute is not defined', () => {
+            delete productAttributes.StockNum3;
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+
+            expect(error).not.toBeDefined();
+        });
+    });
+
+    describe('attribute: dieCuttingFinish', () => {
+        it('should contain attribute', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.dieCuttingFinish).toBeDefined();
+        });
+
+        it('should be of type String', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.dieCuttingFinish).toEqual(expect.any(String));
+        });
+        
+        it('should pass validation if attribute is not defined', () => {
+            delete productAttributes.StockNum;
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+
+            expect(error).not.toBeDefined();
         });
     });
 });

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -27,8 +27,8 @@ describe('validation', () => {
             NoAround: String(chance.floating({min: 0.1})),
             CornerRadius: String(chance.floating({min: 0, max: 0.99})),
             FinalUnwind: chance.string(),
-            ColSpace: String(chance.floating()),
-            RowSpace: String(chance.floating()),
+            ColSpace: String(chance.floating({min: 0})),
+            RowSpace: String(chance.floating({min: 0})),
             Description: chance.string(),
             OrderQuantity: String(chance.integer({min: 0})),
             FinishNotes: chance.string(),
@@ -402,6 +402,15 @@ describe('validation', () => {
             expect(error).not.toBe(undefined);
         });
 
+        it('should fail validation if attribute negative', () => {
+            productAttributes.ColSpace = chance.floating({max: -0.1});
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+
+            expect(error).not.toBe(undefined);
+        });
+
         it('should be of type Number', () => {
             const product = new ProductModel(productAttributes);
 
@@ -428,6 +437,15 @@ describe('validation', () => {
             const product = new ProductModel(productAttributes);
 
             expect(product.matrixAround).toEqual(expect.any(Number));
+        });
+
+        it('should fail validation if attribute negative', () => {
+            productAttributes.RowSpace = chance.floating({max: -0.1});
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+
+            expect(error).not.toBe(undefined);
         });
     });
     describe('attribute: description (aka Description)', () => {
@@ -1334,6 +1352,56 @@ describe('validation', () => {
             const error = product.validateSync();
 
             expect(error).toBeDefined();
+        });
+    });
+
+    describe('attribute: labelsPerFrame', () => {
+        it('should contain attribute', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.labelsPerFrame).toBeDefined();
+        });
+
+        it('should be of type Number', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.labelsPerFrame).toEqual(expect.any(Number));
+        });
+        
+        it('should be calculated correctly', () => {
+            const labelsAcross = chance.floating({min: 0.1});
+            const labelsAround = chance.floating({min: 0.1});
+            productAttributes.NoAround = labelsAround;
+            productAttributes.NoAcross = labelsAcross;
+
+            const product = new ProductModel(productAttributes);
+
+            expect(product.labelsPerFrame).toEqual(labelsAcross * labelsAround);
+        });
+    });
+
+    describe('attribute: measureAcross', () => {
+        it('should contain attribute', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.measureAcross).toBeDefined();
+        });
+
+        it('should be of type Number', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.measureAcross).toEqual(expect.any(Number));
+        });
+        
+        it('should be calculated correctly', () => {
+            const labelsAcross = chance.floating({min: 0.1});
+            const matrixAcross = chance.floating({min: 0.1});
+            productAttributes.NoAcross = labelsAcross;
+            productAttributes.ColSpace = matrixAcross;
+
+            const product = new ProductModel(productAttributes);
+
+            expect(product.measureAcross).toEqual(labelsAcross + matrixAcross);
         });
     });
 });

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -40,7 +40,8 @@ describe('validation', () => {
             ToolNo2: chance.pickone(validProductDies),
             Tool_NumberAround: String(chance.integer({min: 0})),
             Plate_ID: chance.string(),
-            alerts: []
+            alerts: [],
+            LabelRepeat: String(chance.floating({min: 0.1}))
         };
     });
 
@@ -1079,6 +1080,29 @@ describe('validation', () => {
             const error = product.validateSync();
 
             expect(error).toBeDefined();
+        });
+    });
+
+    describe('attribute: labelRepeat', () => {
+        it('should contain attribute', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.labelRepeat).toBeDefined();
+        });
+
+        it('should be of type Number', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.LabelRepeat).toEqual(expect.any(Number));
+        });
+        
+        it('should pass validation if attribute is not defined', () => {
+            delete productAttributes.LabelRepeat;
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+
+            expect(error).not.toBeDefined();
         });
     });
 });

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -46,7 +46,8 @@ describe('validation', () => {
             alerts: [],
             LabelRepeat: String(chance.floating({min: 0.1})),
             OverRun: String(chance.integer({min: OVERRUN_MIN, max: OVERRUN_MAX})),
-            ColorDescr: chance.string()
+            ColorDescr: chance.string(),
+            CoreDiameter: chance.integer()
         };
     });
 
@@ -1181,6 +1182,29 @@ describe('validation', () => {
             const error = product.validateSync();
 
             expect(error).not.toBeDefined();
+        });
+    });
+
+    describe('attribute: coreDiameter', () => {
+        it('should contain attribute', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.coreDiameter).toBeDefined();
+        });
+
+        it('should be of type Number', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.coreDiameter).toEqual(expect.any(Number));
+        });
+        
+        it('should fail validation if attribute is not defined', () => {
+            delete productAttributes.CoreDiameter;
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+
+            expect(error).toBeDefined();
         });
     });
 });

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -1155,7 +1155,7 @@ describe('validation', () => {
 
         it('should convert attribute from integer to percent', () => {
             const overRun = chance.integer({min: OVERRUN_MIN, max: OVERRUN_MAX});
-            const overRunAsPercentage = overRun / 100;
+            const overRunAsPercentage = overRun / 100; // eslint-disable-line no-magic-numbers
             productAttributes.OverRun = overRun;
             const product = new ProductModel(productAttributes);
 

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -46,8 +46,9 @@ describe('validation', () => {
             alerts: [],
             LabelRepeat: String(chance.floating({min: 0.1})),
             OverRun: String(chance.integer({min: OVERRUN_MIN, max: OVERRUN_MAX})),
-            ColorDescr: chance.string(),
-            CoreDiameter: chance.integer()
+            ColorDescr: String(chance.string()),
+            CoreDiameter: String(chance.integer()),
+            NoLabAcrossFin: String(chance.integer())
         };
     });
 
@@ -1200,6 +1201,29 @@ describe('validation', () => {
         
         it('should fail validation if attribute is not defined', () => {
             delete productAttributes.CoreDiameter;
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+
+            expect(error).toBeDefined();
+        });
+    });
+
+    describe('attribute: numberAcross', () => {
+        it('should contain attribute', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.numberAcross).toBeDefined();
+        });
+
+        it('should be of type Number', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.numberAcross).toEqual(expect.any(Number));
+        });
+        
+        it('should fail validation if attribute is not defined', () => {
+            delete productAttributes.NoLabAcrossFin;
             const product = new ProductModel(productAttributes);
 
             const error = product.validateSync();

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -1629,4 +1629,140 @@ describe('validation', () => {
             expect(product.frameRepeat).toEqual(Number(expectedFrameRepeatAfterRoundingUpToSecondDecimalPlace));
         });
     });
+
+    describe('attribute: extraFrames', () => {
+        it('should contain attribute', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.extraFrames).toBeDefined();
+        });
+
+        it('should be of type Number', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.extraFrames).toEqual(expect.any(Number));
+        });
+        
+        it('should be calculated correctly (test 1)', () => {
+            delete productAttributes.ColorDescr;
+            delete productAttributes.FinishType;
+            const expectedExtraFrames = 25;
+            const product = new ProductModel(productAttributes);
+
+            expect(product.extraFrames).toEqual(expectedExtraFrames);
+        });
+
+        it('should be calculated correctly (test 2)', () => {
+            productAttributes.ColorDescr = 'Anything UV';
+            delete productAttributes.FinishType;
+            const expectedExtraFrames = 75;
+            const product = new ProductModel(productAttributes);
+
+            expect(product.extraFrames).toEqual(expectedExtraFrames);
+        });
+
+        it('should be calculated correctly (test 3)', () => {
+            delete productAttributes.ColorDescr;
+            productAttributes.FinishType = 'Sheeted';
+            const expectedExtraFrames = 125;
+            const product = new ProductModel(productAttributes);
+
+            expect(product.extraFrames).toEqual(expectedExtraFrames);
+        });
+
+        it('should be calculated correctly (test 3)', () => {
+            productAttributes.ColorDescr = 'Anything UV';
+            productAttributes.FinishType = 'Sheeted';
+            const expectedExtraFrames = 175;
+            const product = new ProductModel(productAttributes);
+
+            expect(product.extraFrames).toEqual(expectedExtraFrames);
+        });
+    });
+
+    describe('attribute: totalFrames', () => {
+        it('should contain attribute', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.totalFrames).toBeDefined();
+        });
+
+        it('should be of type Number', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.totalFrames).toEqual(expect.any(Number));
+        });
+        
+        it('should be calculated correctly', () => {
+            const product = new ProductModel(productAttributes);
+            const expectedTotalFrames = product.framesPlusOverRun + product.extraFrames;
+
+            expect(product.totalFrames).toEqual(expectedTotalFrames);
+        });
+    });
+
+    describe('attribute: totalFeet', () => {
+        it('should contain attribute', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.totalFeet).toBeDefined();
+        });
+
+        it('should be of type Number', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.totalFeet).toEqual(expect.any(Number));
+        });
+        
+        it('should be calculated correctly', () => {
+            const inchesPerFoot = 12;
+            const product = new ProductModel(productAttributes);
+            const expectedTotalFeet = (product.measureAround * product.labelsAround * product.totalFrames) / inchesPerFoot;
+
+            expect(product.totalFeet).toEqual(expectedTotalFeet);
+        });
+    });
+
+    describe('attribute: numberOfRolls', () => {
+        it('should contain attribute', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.numberOfRolls).toBeDefined();
+        });
+
+        it('should be of type Number', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.numberOfRolls).toEqual(expect.any(Number));
+        });
+        
+        it('should be calculated correctly (test 1)', () => {
+            const totalFeet = 5001;
+            productAttributes.totalFeet = totalFeet;
+
+            const product = new ProductModel(productAttributes);
+            const expectedNumberOfRolls = 1.00;
+
+            expect(product.numberOfRolls).toEqual(expectedNumberOfRolls);
+        });
+
+        it('should be calculated correctly (test 2)', () => {
+            const totalFeet = 9862;
+            productAttributes.totalFeet = totalFeet;
+
+            const product = new ProductModel(productAttributes);
+            const expectedNumberOfRolls = 1.97;
+
+            expect(product.numberOfRolls).toEqual(expectedNumberOfRolls);
+        });        
+        it('should be calculated correctly (test 3)', () => {
+            const totalFeet = 977686;
+            productAttributes.totalFeet = totalFeet;
+
+            const product = new ProductModel(productAttributes);
+            const expectedNumberOfRolls = 195.54;
+
+            expect(product.numberOfRolls).toEqual(expectedNumberOfRolls);
+        });
+    });
 });

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -1253,7 +1253,7 @@ describe('validation', () => {
 
         it('should round to the correct decimal position', () => {
             productAttributes.CoreDiameter = 99.00005;
-            const expectedCoreDiameter = 99.0001
+            const expectedCoreDiameter = 99.0001;
 
             const product = new ProductModel(productAttributes);
 

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -155,13 +155,13 @@ describe('validation', () => {
             expect(product.primaryMaterial).toBeDefined();
         });
 
-        it('should pass validation if attribute is missing', () => {
+        it('should fail validation if attribute is missing', () => {
             delete productAttributes.StockNum2;
             const product = new ProductModel(productAttributes);
 
             const error = product.validateSync();
 
-            expect(error).toBe(undefined);
+            expect(error).toBeDefined();
         });
 
         it('should be of type String', () => {
@@ -686,13 +686,13 @@ describe('validation', () => {
             expect(product.finishType).toBeDefined();
         });
 
-        it('should NOT fail validation if attribute is missing', () => {
+        it('should fail validation if attribute is missing', () => {
             delete productAttributes.FinishType;
             const product = new ProductModel(productAttributes);
 
             const error = product.validateSync();
 
-            expect(error).toBe(undefined);
+            expect(error).toBeDefined();
         });
     });
     describe('attribute: price (aka PriceM)', () => {

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -1250,6 +1250,15 @@ describe('validation', () => {
 
             expect(error).toBeDefined();
         });
+
+        it('should round to the correct decimal position', () => {
+            productAttributes.CoreDiameter = 99.00005;
+            const expectedCoreDiameter = 99.0001
+
+            const product = new ProductModel(productAttributes);
+
+            expect(product.coreDiameter).toEqual(expectedCoreDiameter);
+        });
     });
 
     describe('attribute: numberAcross (aka NoLabAcrossFin)', () => {
@@ -1267,6 +1276,15 @@ describe('validation', () => {
         
         it('should fail validation if attribute is not defined', () => {
             delete productAttributes.NoLabAcrossFin;
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+
+            expect(error).toBeDefined();
+        });
+
+        it('should fail validation if attribute is not an integer', () => {
+            productAttributes.NoLabAcrossFin = chance.floating({min: 1});
             const product = new ProductModel(productAttributes);
 
             const error = product.validateSync();

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -570,7 +570,7 @@ describe('validation', () => {
         });
 
         it('should pass validation if integer is mapped to the correct color', () => {
-            const colorId = 5;
+            const colorId = chance.pickone(Object.keys(idToColorEnum));
             productAttributes.NoColors = colorId;
             const product = new ProductModel(productAttributes);
 
@@ -600,8 +600,6 @@ describe('validation', () => {
         });
 
         it('should be of type Number', () => {
-            const colorId = 5;
-            productAttributes.numberOfColors = colorId;
             const product = new ProductModel(productAttributes);
 
             expect(product.numberOfColors).toEqual(expect.any(String));

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -1384,13 +1384,13 @@ describe('validation', () => {
             expect(product.toolingNotes).toEqual(expect.any(String));
         });
         
-        it('should fail validation if attribute is not defined', () => {
+        it('should NOT fail validation if attribute is not defined', () => {
             delete productAttributes.ToolingNotes;
             const product = new ProductModel(productAttributes);
 
             const error = product.validateSync();
 
-            expect(error).toBeDefined();
+            expect(error).not.toBeDefined();
         });
     });
 

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -1,6 +1,7 @@
 const chance = require('chance').Chance();
 const ProductModel = require('../../application/models/product');
 const {hotFolders} = require('../../application/enums/hotFolderEnum');
+const {idToColorEnum} = require('../../application/enums/idToColorEnum');
 
 function getRandomNumberOfDigits() {
     return chance.integer({min: 1});
@@ -31,7 +32,7 @@ describe('validation', () => {
             StockNotes: chance.string(),
             Notes: [chance.string(), chance.string()],
             Hidden_Notes: chance.string(),
-            NoColors: String(chance.integer({min: 0})),
+            NoColors: chance.pickone(Object.keys(idToColorEnum)),
             LabelsPer_: String(chance.integer({min: 0})),
             FinishType: chance.string(),
             PriceM: String(chance.integer({min: 0})),
@@ -568,17 +569,20 @@ describe('validation', () => {
             expect(product.numberOfColors).toBeDefined();
         });
 
-        it('should fail if attribute is not an integer', () => {
-            productAttributes.NoColors = chance.floating({fixed: 8});
+        it('should pass validation if integer is mapped to the correct color', () => {
+            const colorId = 5;
+            productAttributes.NoColors = colorId;
             const product = new ProductModel(productAttributes);
 
             const error = product.validateSync();
 
-            expect(error).not.toBe(undefined);
+            expect(error).toBe(undefined);
+            expect(product.numberOfColors).toBe(idToColorEnum[colorId]);
         });
 
-        it('should fail if attribute is less than zero', () => {
-            productAttributes.NoColors = chance.integer({max: 0});
+        it('should fail validation if integer is not mapped to any color', () => {
+            const invalidColorId = 9999999999;
+            productAttributes.NoColors = invalidColorId;
             const product = new ProductModel(productAttributes);
 
             const error = product.validateSync();
@@ -596,11 +600,14 @@ describe('validation', () => {
         });
 
         it('should be of type Number', () => {
+            const colorId = 5;
+            productAttributes.numberOfColors = colorId;
             const product = new ProductModel(productAttributes);
 
-            expect(product.numberOfColors).toEqual(expect.any(Number));
+            expect(product.numberOfColors).toEqual(expect.any(String));
         });
     });
+
     describe('attribute: labelsPerRoll (aka LabelsPer_)', () => {
         it('should contain attribute', () => {
             const product = new ProductModel(productAttributes);
@@ -635,7 +642,7 @@ describe('validation', () => {
             expect(error).not.toBe(undefined);
         });
 
-        it('should be of type Number', () => {
+        it('should be of type String', () => {
             const product = new ProductModel(productAttributes);
 
             expect(product.labelsPerRoll).toEqual(expect.any(Number));

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -51,7 +51,8 @@ describe('validation', () => {
             NoLabAcrossFin: String(chance.integer()),
             ShipAttn: chance.string(),
             StockNum3: chance.string(),
-            StockNum: chance.string()
+            StockNum: chance.string(),
+            ToolingNotes: chance.string()
         };
     });
 
@@ -1093,7 +1094,7 @@ describe('validation', () => {
         });
     });
 
-    describe('attribute: labelRepeat', () => {
+    describe('attribute: labelRepeat (aka LabelRepeat)', () => {
         it('should contain attribute', () => {
             const product = new ProductModel(productAttributes);
 
@@ -1116,7 +1117,7 @@ describe('validation', () => {
         });
     });
 
-    describe('attribute: overRun', () => {
+    describe('attribute: overRun (aka OverRun)', () => {
         it('should contain attribute', () => {
             const product = new ProductModel(productAttributes);
 
@@ -1166,7 +1167,7 @@ describe('validation', () => {
         });
     });
 
-    describe('attribute: varnish', () => {
+    describe('attribute: varnish (aka ColorDescr)', () => {
         it('should contain attribute', () => {
             const product = new ProductModel(productAttributes);
 
@@ -1189,7 +1190,7 @@ describe('validation', () => {
         });
     });
 
-    describe('attribute: coreDiameter', () => {
+    describe('attribute: coreDiameter (aka CoreDiameter)', () => {
         it('should contain attribute', () => {
             const product = new ProductModel(productAttributes);
 
@@ -1212,7 +1213,7 @@ describe('validation', () => {
         });
     });
 
-    describe('attribute: numberAcross', () => {
+    describe('attribute: numberAcross (aka NoLabAcrossFin)', () => {
         it('should contain attribute', () => {
             const product = new ProductModel(productAttributes);
 
@@ -1235,7 +1236,7 @@ describe('validation', () => {
         });
     });
 
-    describe('attribute: shippingAttention', () => {
+    describe('attribute: shippingAttention (aka ShipAttn)', () => {
         it('should contain attribute', () => {
             const product = new ProductModel(productAttributes);
 
@@ -1267,7 +1268,7 @@ describe('validation', () => {
         });
     });
 
-    describe('attribute: dieCuttingMarriedMaterial', () => {
+    describe('attribute: dieCuttingMarriedMaterial (aka StockNum3)', () => {
         it('should contain attribute', () => {
             const product = new ProductModel(productAttributes);
 
@@ -1290,7 +1291,7 @@ describe('validation', () => {
         });
     });
 
-    describe('attribute: dieCuttingFinish', () => {
+    describe('attribute: dieCuttingFinish (aka StockNum)', () => {
         it('should contain attribute', () => {
             const product = new ProductModel(productAttributes);
 
@@ -1310,6 +1311,29 @@ describe('validation', () => {
             const error = product.validateSync();
 
             expect(error).not.toBeDefined();
+        });
+    });
+
+    describe('attribute: toolingNotes (aka ToolingNotes)', () => {
+        it('should contain attribute', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.toolingNotes).toBeDefined();
+        });
+
+        it('should be of type String', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.toolingNotes).toEqual(expect.any(String));
+        });
+        
+        it('should fail validation if attribute is not defined', () => {
+            delete productAttributes.ToolingNotes;
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+
+            expect(error).toBeDefined();
         });
     });
 });

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -7,6 +7,9 @@ function getRandomNumberOfDigits() {
     return chance.integer({min: 1});
 }
 
+const OVERRUN_MIN = 0;
+const OVERRUN_MAX = 100;
+
 describe('validation', () => {
     let productAttributes;
 
@@ -41,7 +44,8 @@ describe('validation', () => {
             Tool_NumberAround: String(chance.integer({min: 0})),
             Plate_ID: chance.string(),
             alerts: [],
-            LabelRepeat: String(chance.floating({min: 0.1}))
+            LabelRepeat: String(chance.floating({min: 0.1})),
+            OverRun: String(chance.integer({min: OVERRUN_MIN, max: OVERRUN_MAX}))
         };
     });
 
@@ -1103,6 +1107,56 @@ describe('validation', () => {
             const error = product.validateSync();
 
             expect(error).not.toBeDefined();
+        });
+    });
+
+    describe('attribute: overRun', () => {
+        it('should contain attribute', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.overRun).toBeDefined();
+        });
+
+        it('should be of type Number', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.overRun).toEqual(expect.any(Number));
+        });
+        
+        it('should pass validation if attribute is not defined', () => {
+            delete productAttributes.OverRun;
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+
+            expect(error).not.toBeDefined();
+        });
+
+        it('should fail validation if overRun is less than 0', () => {
+            productAttributes.OverRun = chance.integer({max: OVERRUN_MIN - 1});
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+
+            expect(error).toBeDefined();
+        });
+
+        it('should fail validation if overRun greater than 100', () => {
+            productAttributes.OverRun = chance.integer({min: OVERRUN_MAX + 1});
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+
+            expect(error).toBeDefined();
+        });
+
+        it('should convert attribute from integer to percent', () => {
+            const overRun = chance.integer({min: OVERRUN_MIN, max: OVERRUN_MAX});
+            const overRunAsPercentage = overRun / 100;
+            productAttributes.OverRun = overRun;
+            const product = new ProductModel(productAttributes);
+
+            expect(product.overRun).toBe(overRunAsPercentage);
         });
     });
 });

--- a/test/models/ticket.spec.js
+++ b/test/models/ticket.spec.js
@@ -775,22 +775,13 @@ describe('validation', () => {
             expect(ticket.Company).toEqual(expect.any(String));
         });
 
-        it('should not fail validation if attribute is missing', () => {
+        it('should fail validation if attribute is missing', () => {
             delete ticketAttributes.Company;
             const ticket = new TicketModel(ticketAttributes);
     
             const error = ticket.validateSync();
     
-            expect(error).toBe(undefined);
-        });
-
-        it('should not fail validation if attribute is blank', () => {
-            ticketAttributes.Company = '';
-            const ticket = new TicketModel(ticketAttributes);
-    
-            const error = ticket.validateSync();
-    
-            expect(error).toBe(undefined);
+            expect(error).toBeDefined();
         });
     });
 });

--- a/test/models/ticket.spec.js
+++ b/test/models/ticket.spec.js
@@ -30,7 +30,8 @@ describe('validation', () => {
             ShipAttn_EmailAddress: chance.string(),
             BillState: chance.string(),
             destination: {},
-            departmentNotes: {}
+            departmentNotes: {},
+            CustomerCompany: chance.string()
         };
     });
 
@@ -749,6 +750,38 @@ describe('validation', () => {
             expect(savedTicket.products[0].primaryMaterial).toBe(savedTicket.primaryMaterial);
             expect(savedTicket.products[1].primaryMaterial).toBe(savedTicket.primaryMaterial);
             expect(savedTicket.products[2].primaryMaterial).toBe(savedTicket.primaryMaterial);
+        });
+    });
+
+    describe('attribute: customerName', () => {
+        it('should contain attribute', () => {
+            const ticket = new TicketModel(ticketAttributes);
+
+            expect(ticket.customerName).toBeDefined();
+        });
+
+        it('should be of type String', () => {
+            const ticket = new TicketModel(ticketAttributes);
+
+            expect(ticket.customerName).toEqual(expect.any(String));
+        });
+
+        it('should not fail validation if attribute is missing', () => {
+            delete ticketAttributes.CustomerCompany;
+            const ticket = new TicketModel(ticketAttributes);
+    
+            const error = ticket.validateSync();
+    
+            expect(error).toBe(undefined);
+        });
+
+        it('should not fail validation if attribute is blank', () => {
+            ticketAttributes.CustomerCompany = '';
+            const ticket = new TicketModel(ticketAttributes);
+    
+            const error = ticket.validateSync();
+    
+            expect(error).toBe(undefined);
         });
     });
 });

--- a/test/models/ticket.spec.js
+++ b/test/models/ticket.spec.js
@@ -27,7 +27,7 @@ describe('validation', () => {
             ShipLocation: chance.string(),
             ShippingInstruc: chance.string(),
             ShipVia: chance.string(),
-            ShipAttn_EmailAddress: chance.string(),
+            ShipAttn_EmailAddress: chance.email(),
             BillState: chance.string(),
             destination: {},
             departmentNotes: {},
@@ -453,6 +453,15 @@ describe('validation', () => {
             const error = ticket.validateSync();
 
             expect(error).toBe(undefined);
+        });
+
+        it('should fail validation if attribute is defined but not a valid email address', () => {
+            ticketAttributes.ShipAttn_EmailAddress = chance.string();
+            const ticket = new TicketModel(ticketAttributes);
+
+            const error = ticket.validateSync();
+
+            expect(error).toBeDefined();
         });
     });
 

--- a/test/models/ticket.spec.js
+++ b/test/models/ticket.spec.js
@@ -31,7 +31,7 @@ describe('validation', () => {
             BillState: chance.string(),
             destination: {},
             departmentNotes: {},
-            CustomerCompany: chance.string()
+            Company: chance.string()
         };
     });
 
@@ -753,21 +753,21 @@ describe('validation', () => {
         });
     });
 
-    describe('attribute: customerName', () => {
+    describe('attribute: Company', () => {
         it('should contain attribute', () => {
             const ticket = new TicketModel(ticketAttributes);
 
-            expect(ticket.customerName).toBeDefined();
+            expect(ticket.Company).toBeDefined();
         });
 
         it('should be of type String', () => {
             const ticket = new TicketModel(ticketAttributes);
 
-            expect(ticket.customerName).toEqual(expect.any(String));
+            expect(ticket.Company).toEqual(expect.any(String));
         });
 
         it('should not fail validation if attribute is missing', () => {
-            delete ticketAttributes.CustomerCompany;
+            delete ticketAttributes.Company;
             const ticket = new TicketModel(ticketAttributes);
     
             const error = ticket.validateSync();
@@ -776,7 +776,7 @@ describe('validation', () => {
         });
 
         it('should not fail validation if attribute is blank', () => {
-            ticketAttributes.CustomerCompany = '';
+            ticketAttributes.Company = '';
             const ticket = new TicketModel(ticketAttributes);
     
             const error = ticket.validateSync();

--- a/test/models/ticket.spec.js
+++ b/test/models/ticket.spec.js
@@ -202,13 +202,13 @@ describe('validation', () => {
             expect(ticket.priority).toBeDefined();
         });
 
-        it('should fail validation if attribute is missing', () => {
+        it('should NOT fail validation if attribute is missing', () => {
             delete ticketAttributes.Priority;
             const ticket = new TicketModel(ticketAttributes);
 
             const error = ticket.validateSync();
 
-            expect(error).not.toBe(undefined);
+            expect(error).toBe(undefined);
         });
 
         it('should be of type String', () => {

--- a/test/models/ticket.spec.js
+++ b/test/models/ticket.spec.js
@@ -29,7 +29,6 @@ describe('validation', () => {
             ShipVia: chance.string(),
             ShipAttn_EmailAddress: chance.string(),
             BillState: chance.string(),
-            printingType: 'BLACK & WHITE',
             destination: {},
             departmentNotes: {}
         };
@@ -512,41 +511,6 @@ describe('validation', () => {
             const ticket = new TicketModel(ticketAttributes);
 
             expect(ticket.totalWindingRolls).toEqual(ticketAttributes.products[0].totalWindingRolls + ticketAttributes.products[1].totalWindingRolls);
-        });
-    });
-
-    describe('attribute: printingType', () => {
-        it('should contain attribute', () => {
-            const ticket = new TicketModel(ticketAttributes);
-
-            expect(ticket.printingType).toBeDefined();
-        });
-
-        it('should pass validation if attribute is missing', () => {
-            delete ticketAttributes.printingType;
-            const ticket = new TicketModel(ticketAttributes);
-
-            const error = ticket.validateSync();
-
-            expect(error).toBe(undefined);
-        });
-
-        it('should fail validation if attribute IS NOT an accepted value', () => {
-            ticketAttributes.printingType = chance.string();
-            const ticket = new TicketModel(ticketAttributes);
-
-            const error = ticket.validateSync();
-
-            expect(error).not.toBe(undefined);
-        });
-
-        it('should pass validation if attribute IS an accepted value', () => {
-            ticketAttributes.printingType = 'CMYK OV + W';
-            const ticket = new TicketModel(ticketAttributes);
-
-            const error = ticket.validateSync();
-
-            expect(error).toBe(undefined);
         });
     });
 

--- a/test/services/ticketService.spec.js
+++ b/test/services/ticketService.spec.js
@@ -105,8 +105,6 @@ describe('ticketService test suite', () => {
         it('should return an object with the correct number of products and charges defined', () => {
             const ticket = ticketService.convertedUploadedTicketDataToProperFormat(rawTicket);
 
-            console.log(`ticket => ${JSON.stringify(ticket)}`);
-
             expect(ticket.products.length).toBe(numberOfProducts);
             expect(ticket.extraCharges.length).toBe(numberOfCharges);
         });

--- a/test/services/ticketService.spec.js
+++ b/test/services/ticketService.spec.js
@@ -147,6 +147,7 @@ describe('ticketService test suite', () => {
         });
 
         it('should generate correct department names', () => {
+            console.log(`allTickets => ${JSON.stringify(allTickets)}`);
             const groupedTicketsByDepartment = ticketService.groupTicketsByDestination(allTickets);
 
             console.log(groupedTicketsByDepartment);


### PR DESCRIPTION
## Description

@LifeByStorm determined that several attributes on `Ticket` and `Product` objects had not yet been added to their respective database schemas. This PR handles adding those attributes, as well as writing validation rules around each.

Also, `printingType` was previously allowed to be set via a front-end dropdown menu, but that is no longer the case, and instead, its value is uploaded manually via the Ticket XML uploads.

Some minor validation rule changes were also found on some pre-existing attributes and were updated in this PR.