### PR TITLE
Update Attribute  `prePrintingNotes` on `product` Object

### DIFF
--- a/application/models/product.js
+++ b/application/models/product.js
@@ -210,7 +210,8 @@ const schema = new Schema({
         alias: 'StockNotes'
     },
     prePrintingNotes: {
-        type: [String],
+        type: String,
+        required: false,
         alias: 'Notes'
     },
     printingNotes: {

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -35,7 +35,7 @@ describe('validation', () => {
             MachineCount: String(chance.floating({min: 0})),
             FinishNotes: chance.string(),
             StockNotes: chance.string(),
-            Notes: [chance.string(), chance.string()],
+            Notes: chance.string(),
             Hidden_Notes: chance.string(),
             NoColors: chance.pickone(Object.keys(idToColorEnum)),
             LabelsPer_: String(chance.integer({min: 0})),
@@ -592,11 +592,10 @@ describe('validation', () => {
             expect(error).toBe(undefined);
         });
 
-        it('should be an array of Strings', () => {
+        it('should have a string datatype', () => {
             const product = new ProductModel(productAttributes);
 
-            expect(product.prePrintingNotes[0]).toEqual(expect.any(String));
-            expect(product.prePrintingNotes[1]).toEqual(expect.any(String));
+            expect(product.prePrintingNotes).toEqual(expect.any(String));
         });
     });
     describe('attribute: printingNotes (aka Hidden_Notes)', () => {


### PR DESCRIPTION
# Description

This PR updates the attribute `prePrintingNotes`.

It was determined that the datatype of this attribute was invalid and this PR fixes the issue.