### PR TITLE
Trim Leading/Trailing Whitespace on ALL String Attributes Before Saving to Database

### DIFF
--- a/application/enums/priorityEnum.js
+++ b/application/enums/priorityEnum.js
@@ -1,4 +1,4 @@
-const RUSH_FEE = 'Rush Fee';
+const RUSH_FEE = 'Rush';
 const RE_RUN = 'ReRun';
 const HOT = 'Hot';
 const STANDARD = 'Standard';

--- a/application/models/charge.js
+++ b/application/models/charge.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+mongoose.Schema.Types.String.set('trim', true);
 const Schema = mongoose.Schema;
 const {PRODUCT_NUMBER_IS_FOR_AN_EXTRA_CHARGE} = require('../services/chargeService');
 

--- a/application/models/cuttingSetup.js
+++ b/application/models/cuttingSetup.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+mongoose.Schema.Types.String.set('trim', true);
 const Schema = mongoose.Schema;
 
 URL_VALIDATION_REGEX = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?)/;
@@ -20,8 +21,7 @@ const schema = new Schema({
         required: true
     },
     notes: {
-        type: String,
-        trim: true
+        type: String
     },
     finish: {
         type: Schema.Types.ObjectId,
@@ -39,8 +39,7 @@ const schema = new Schema({
     video: {
         type: String,
         validate: [validateUrl, 'Please fill a valid video url'],
-        match: [URL_VALIDATION_REGEX, 'Please fill a valid video url'],
-        trim: true
+        match: [URL_VALIDATION_REGEX, 'Please fill a valid video url']
     },
     difficulty: {
         type: String,
@@ -59,8 +58,7 @@ const schema = new Schema({
         required: true
     },
     alertTextBox: {
-        type: String,
-        trim: true
+        type: String
     },
     defaultMachine: {
         type: Schema.Types.ObjectId,

--- a/application/models/finish.js
+++ b/application/models/finish.js
@@ -1,10 +1,10 @@
 const mongoose = require('mongoose');
+mongoose.Schema.Types.String.set('trim', true);
 const Schema = mongoose.Schema;
 
 const schema = new Schema({
     name: {
         type: String,
-        trim: true,
         required: true,
     },
 }, { timestamps: true });

--- a/application/models/machine.js
+++ b/application/models/machine.js
@@ -1,10 +1,10 @@
 const mongoose = require('mongoose');
+mongoose.Schema.Types.String.set('trim', true);
 const Schema = mongoose.Schema;
 
 const schema = new Schema({
     name: {
         type: String,
-        trim: true,
         required: true
     },
 }, { timestamps: true });

--- a/application/models/material.js
+++ b/application/models/material.js
@@ -1,16 +1,15 @@
 const mongoose = require('mongoose');
+mongoose.Schema.Types.String.set('trim', true);
 const Schema = mongoose.Schema;
 
 const schema = new Schema({
     name: {
         type: String,
-        trim: true,
         required: true
     },
     materialId: {
         type: String,
-        required: true,
-        trim: true
+        required: true
 
     }
 }, { timestamps: true });

--- a/application/models/materialOrder.js
+++ b/application/models/materialOrder.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+mongoose.Schema.Types.String.set('trim', true);
 const Schema = mongoose.Schema;
 
 const TOTAL_ROLLS_MIN = 1;
@@ -75,8 +76,7 @@ const schema = new Schema({
     },
     notes: {
         type: String,
-        required: false,
-        trim: true
+        required: false
     }
 }, { timestamps: true });
 

--- a/application/models/printingSetup.js
+++ b/application/models/printingSetup.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+mongoose.Schema.Types.String.set('trim', true);
 const Schema = mongoose.Schema;
 
 URL_VALIDATION_REGEX = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?)/;
@@ -24,8 +25,7 @@ const schema = new Schema({
         required: true
     },
     notes: {
-        type: String,
-        trim: true
+        type: String
     },
     material: {
         type: Schema.Types.ObjectId,
@@ -35,8 +35,7 @@ const schema = new Schema({
     video: {
         type: String,
         validate: [validateUrl, 'Please fill a valid video url'],
-        match: [URL_VALIDATION_REGEX, 'Please fill a valid video url'],
-        trim: true
+        match: [URL_VALIDATION_REGEX, 'Please fill a valid video url']
     },
     difficulty: {
         type: String,
@@ -50,8 +49,7 @@ const schema = new Schema({
         required: true
     },
     alertTextBox: {
-        type: String,
-        trim: true
+        type: String
     },
     defaultMachine: {
         type: Schema.Types.ObjectId,

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+mongoose.Schema.Types.String.set('trim', true);
 const Schema = mongoose.Schema;
 const MaterialModel = require('../models/material');
 const {hotFolders, getUniqueHotFolders} = require('../enums/hotFolderEnum');
@@ -115,9 +116,8 @@ const schema = new Schema({
         type: String,
         required: true,
         uppercase: true,
-        trim: true,
         alias: 'ProductNumber',
-        validate: [mustNotContainWhitespace, '"ProductNumber" cannot contain whitespace(s)']
+        validate: [mustNotContainWhitespace, '"productNumber" cannot contain whitespace(s)']
     },
     productDie: {
         type: String,
@@ -282,12 +282,9 @@ const schema = new Schema({
             {
                 validator : Number.isInteger,
                 message   : 'Tool Number Around must be an integer'
-            },
-            {
-                validator: numberMustBeGreaterThanZero,
-                message: 'Tool Number Around cannot be negative'
             }
         ],
+        min: 0,
         required: true,
         alias: 'Tool_NumberAround'
     },
@@ -506,7 +503,6 @@ function roundValueToNearestDecimalPlace(unRoundedValue, decimalPositionToRound)
 
     return Math.round(unRoundedValue * precision) / precision;
 }
-
 
 const Product = mongoose.model('Product', schema);
 

--- a/application/models/recipe.js
+++ b/application/models/recipe.js
@@ -1,16 +1,15 @@
 const mongoose = require('mongoose');
+mongoose.Schema.Types.String.set('trim', true);
 const Schema = mongoose.Schema;
 
 const recipeSchema = new Schema({
     designNumber: {
         type: String,
-        trim: true,
         uppercase: true,
         required: true
     },
     dieNumber: {
         type: String,
-        trim: true,
         uppercase: true,
         required: true
     },

--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+mongoose.Schema.Types.String.set('trim', true);
 const Schema = mongoose.Schema;
 const productSchema = require('./product').schema;
 const chargeSchema = require('./charge').schema;
@@ -50,7 +51,7 @@ async function validateMaterialExists(materialId) {
     
     try {
         const material = await MaterialModel.findOne(searchCriteria).exec();
-
+        
         return !material ? false : true;
     } catch (error) {
         return false;

--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -51,7 +51,7 @@ async function validateMaterialExists(materialId) {
     
     try {
         const material = await MaterialModel.findOne(searchCriteria).exec();
-        
+
         return !material ? false : true;
     } catch (error) {
         return false;

--- a/application/models/user.js
+++ b/application/models/user.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+mongoose.Schema.Types.String.set('trim', true);
 const Schema = mongoose.Schema;
 
 const USER = 'USER';
@@ -29,7 +30,6 @@ const checkForSpaces = function(text) {
 const userSchema = new Schema({
     email: {
         type: String,
-        trim: true,
         uppercase: true,
         unique: true,
         required: 'Email address is required',
@@ -58,7 +58,6 @@ const userSchema = new Schema({
     username: {
         type: String,
         unique: true,
-        trim: true,
         validate: [{
             validator: checkForSpaces, 
             msg: 'Your username must not contain spaces'
@@ -66,21 +65,17 @@ const userSchema = new Schema({
         sparse: true
     },
     fullName: {
-        type: String,
-        trim: true
+        type: String
     },
     jobRole: {
-        type: String,
-        trim: true
+        type: String
     },
     phoneNumber: {
         type: String,
-        trim: true,
         validate: [validatePhone, 'Your phone number must be 10 digits and/or formatted correctly']
     },
     birthDate: {
-        type: Date,
-        trim: true
+        type: Date
     }
 }, { timestamps: true });
 

--- a/application/models/vendor.js
+++ b/application/models/vendor.js
@@ -1,10 +1,10 @@
 const mongoose = require('mongoose');
+mongoose.Schema.Types.String.set('trim', true);
 const Schema = mongoose.Schema;
 
 const schema = new Schema({
     name: {
         type: String,
-        trim: true,
         required: true
     },
 }, { timestamps: true });

--- a/application/models/windingSetup.js
+++ b/application/models/windingSetup.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+mongoose.Schema.Types.String.set('trim', true);
 const Schema = mongoose.Schema;
 
 URL_VALIDATION_REGEX = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?)/;
@@ -20,19 +21,16 @@ const schema = new Schema({
         required: true
     },
     notes: {
-        type: String,
-        trim: true
+        type: String
     },
     video: {
         type: String,
         validate: [validateUrl, 'Please fill a valid video url'],
-        match: [URL_VALIDATION_REGEX, 'Please fill a valid video url'],
-        trim: true
+        match: [URL_VALIDATION_REGEX, 'Please fill a valid video url']
     },
     watchOutFor: {
         type: [{
             type: String,
-            trim: true,
             uppercase: true
         }],
         enum: [
@@ -58,8 +56,7 @@ const schema = new Schema({
         type: Boolean
     },
     alertTextBox: {
-        type: String,
-        trim: true
+        type: String
     },
     defaultMachine: {
         type: Schema.Types.ObjectId,

--- a/test/models/charge.spec.js
+++ b/test/models/charge.spec.js
@@ -19,6 +19,14 @@ describe('validation', () => {
             expect(charge.productNumber).toBeDefined();
         });
 
+        it('should trim whitespace', () => {
+            const productNumberWithoutWhitespace = chance.word();
+            chargeAttributes.ProductNumber = ' ' + productNumberWithoutWhitespace + '  ';
+            const charge = new ChargeModel(chargeAttributes);
+
+            expect(charge.productNumber).toBe(productNumberWithoutWhitespace);
+        });
+
         it('should fail validation if attribute does not exist', () => {
             delete chargeAttributes.ProductNumber;
             const charge = new ChargeModel(chargeAttributes);

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -73,6 +73,14 @@ describe('validation', () => {
             expect(product.productNumber).toBeDefined();
         });
 
+        it('should trim whitespace', () => {
+            const productNumberWithoutWhitespace = chance.word().toUpperCase();
+            productAttributes.ProductNumber = ' ' + productNumberWithoutWhitespace + '  ';
+            const product = new ProductModel(productAttributes);
+
+            expect(product.productNumber).toBe(productNumberWithoutWhitespace);
+        });
+
         it('should NOT fail validation', () => {
             productAttributes.ProductNumber = chance.word();
             const product = new ProductModel(productAttributes);
@@ -539,6 +547,14 @@ describe('validation', () => {
             expect(product.windingNotes).toBeDefined();
         });
 
+        it('should contain attribute', () => {
+            const finishNotes = chance.word();
+            productAttributes.FinishNotes = ' ' + finishNotes + '  ';
+            const product = new ProductModel(productAttributes);
+
+            expect(product.windingNotes).toBe(finishNotes);
+        });
+
         it('should pass validation if attribute is missing', () => {
             delete productAttributes.FinishNotes;
             const product = new ProductModel(productAttributes);
@@ -875,6 +891,15 @@ describe('validation', () => {
             const error = product.validateSync();
 
             expect(error).not.toBe(undefined);
+        });
+
+        it('should pass validation if 0 is used', () => {
+            productAttributes.Tool_NumberAround = 0;
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+
+            expect(error).toBe(undefined);
         });
 
         it('should be of type Number', () => {
@@ -1243,6 +1268,14 @@ describe('validation', () => {
             const error = product.validateSync();
 
             expect(error).not.toBeDefined();
+        });
+
+        it('should trim', () => {
+            const varnish = chance.word();
+            productAttributes.ColorDescr = varnish + '  ';
+            const product = new ProductModel(productAttributes);
+
+            expect(product.varnish).toEqual(varnish);
         });
     });
 

--- a/test/models/ticket.spec.js
+++ b/test/models/ticket.spec.js
@@ -51,8 +51,16 @@ describe('validation', () => {
             expect(ticket.ticketNumber).toBeDefined();
         });
 
+        it('should trim whitespace', () => {
+            const ticketNumberWithoutWhitespace = chance.word();
+            ticketAttributes.TicketNumber = ' ' + ticketNumberWithoutWhitespace + '   ';
+            const ticket = new TicketModel(ticketAttributes);
+
+            expect(ticket.ticketNumber).toBe(ticketNumberWithoutWhitespace);
+        });
+
         it('should fail if ticketNumber does not contain ONLY digits', () => {
-            const validTicketNumber = chance.integer({min: 0});
+            const validTicketNumber = String(chance.integer({min: 0}));
             const invalidTicketNumber = validTicketNumber + chance.word();
             ticketAttributes.TicketNumber = invalidTicketNumber;
             const ticket = new TicketModel(ticketAttributes);

--- a/test/models/user.spec.js
+++ b/test/models/user.spec.js
@@ -168,7 +168,7 @@ describe('validation', () => {
 
         it('should trim whitespace', () => {
             const birthDate = chance.date({string: true});
-            userAttributes.birthDate = ' ' + birthDate + ' ';
+            userAttributes.birthDate = '  ' + birthDate + ' ';
             const user = new UserModel(userAttributes);
 
             user.validateSync();

--- a/test/models/windingSetup.spec.js
+++ b/test/models/windingSetup.spec.js
@@ -86,6 +86,15 @@ describe('validation', () => {
     
             expect(error).not.toBe(undefined);
         });
+
+        it('should trim extra whitespace', () => {
+            const videoUrlWithoutWhitespace = chance.url();
+            windingSetupAttributes.video = '  ' + videoUrlWithoutWhitespace + ' ';
+
+            const windingSetup = new WindingSetupModel(windingSetupAttributes);
+    
+            expect(windingSetup.video).toBe(videoUrlWithoutWhitespace);
+        });
     });
 
     describe('"watchOutFor" attribute', () => {


### PR DESCRIPTION
# Description

This PR ensures that any string attribute stored in the mongDb database has its leading and trailing whitespace removed prior to being saved.

This trim functionality is offered as a [configuration rule in mongoose](https://thecodebarbarian.com/whats-new-in-mongoose-59-schematype-default-options-and-per-document-populate.html).

After this PR, any string attributes added to any of the existing database tables will be trimmed by default.