### PR TITLE
Remove `Charge` Objects During XML File Upload

### DIFF
--- a/application/services/chargeService.js
+++ b/application/services/chargeService.js
@@ -1,1 +1,1 @@
-module.exports.PRODUCT_NUMBER_IS_FOR_AN_EXTRA_CHARGE = /(.*)-([a-z]|[A-Z])$/;
+module.exports.PRODUCT_NUMBER_IS_FOR_AN_EXTRA_CHARGE = /(.*)-([a-z]|[A-Z])*$/;

--- a/test/services/chargeService.spec.js
+++ b/test/services/chargeService.spec.js
@@ -1,0 +1,46 @@
+const chance = require('chance').Chance();
+const {PRODUCT_NUMBER_IS_FOR_AN_EXTRA_CHARGE} = require('../../application/services/chargeService');
+
+describe('chargeService test suite', () => {
+    let productNumber;
+
+    it('should NOT return a regex match', () => {
+        productNumber = chance.word() + `-${chance.integer({min: 0, max: 1000})}`;
+
+        const isAMatch = PRODUCT_NUMBER_IS_FOR_AN_EXTRA_CHARGE.test(productNumber);
+
+        expect(isAMatch).toBe(false);
+    });
+
+    it('should NOT return a regex match', () => {
+        productNumber = chance.word();
+
+        const isAMatch = PRODUCT_NUMBER_IS_FOR_AN_EXTRA_CHARGE.test(productNumber);
+
+        expect(isAMatch).toBe(false);
+    });
+
+    it('should NOT return a regex match', () => {
+        productNumber = chance.word() + '-' + chance.integer({min: 0, max: 1000});
+
+        const isAMatch = PRODUCT_NUMBER_IS_FOR_AN_EXTRA_CHARGE.test(productNumber);
+
+        expect(isAMatch).toBe(false);
+    });
+
+    it('should return a regex match', () => {
+        productNumber = chance.word() + '-' + chance.word();
+
+        const isAMatch = PRODUCT_NUMBER_IS_FOR_AN_EXTRA_CHARGE.test(productNumber);
+
+        expect(isAMatch).toBe(true);
+    });
+
+    it('should NOT return a regex match', () => {
+        productNumber = chance.word() + '-' + chance.word() + '1234';
+
+        const isAMatch = PRODUCT_NUMBER_IS_FOR_AN_EXTRA_CHARGE.test(productNumber);
+
+        expect(isAMatch).toBe(false);
+    });
+});


### PR DESCRIPTION
# Description

Currently, a user can upload an XML file that contains an array of `products`.

However, sometimes one or more of these products is actually a different object called a `charge`.

These charge items need to be manually removed from the products array and previously code was added to do this, however, a bug was discovered with that code, and this PR fixes that bug and adds tests to prevent it from happening again.