### PR TITLE
Update `Varnish` Attribute on `PRODUCT` Object

### DIFF
--- a/application/models/product.js
+++ b/application/models/product.js
@@ -326,7 +326,7 @@ const schema = new Schema({
         type: String,
         required: false,
         set: function(varnish) {
-            const stringToRemove = "C:";
+            const stringToRemove = 'C:';
             return varnish && varnish.replace(stringToRemove, '');
         },
         alias: 'ColorDescr'

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -325,6 +325,10 @@ const schema = new Schema({
     varnish: {
         type: String,
         required: false,
+        set: function(varnish) {
+            const stringToRemove = "C:";
+            return varnish && varnish.replace(stringToRemove, '');
+        },
         alias: 'ColorDescr'
     },
     coreDiameter: {

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -1271,7 +1271,7 @@ describe('validation', () => {
         });
 
         it('should remove "C:" prefix from attribute', () => {
-            const prefixToRemove = "C:";
+            const prefixToRemove = 'C:';
             const varnish = chance.string();
             productAttributes.ColorDescr = prefixToRemove + varnish;
 

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -1270,6 +1270,16 @@ describe('validation', () => {
             expect(error).not.toBeDefined();
         });
 
+        it('should remove "C:" prefix from attribute', () => {
+            const prefixToRemove = "C:";
+            const varnish = chance.string();
+            productAttributes.ColorDescr = prefixToRemove + varnish;
+
+            const product = new ProductModel(productAttributes);
+
+            expect(product.varnish).toBe(varnish);
+        });
+
         it('should trim', () => {
             const varnish = chance.word();
             productAttributes.ColorDescr = varnish + '  ';


### PR DESCRIPTION
# Description

The `varnish` attribute (aka _ColorDescr_) is uploaded via an XML file as a string.

That string contains the prefix "C:".

We don't want to save this prefix to the database, instead, we need to remove it before saving it to the database.

This PR handles doing that.