### PR TITLE
Add Department/SubDepartment Validation Rule

### DIFF
--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -33,6 +33,10 @@ function destinationsAreValid(destination) {
         return false;
     }
 
+    if (department) {
+        return subDepartmentsGroupedByDepartment[department].includes(subDepartment);
+    }
+    
     return true;
 }
 

--- a/test/models/ticket.spec.js
+++ b/test/models/ticket.spec.js
@@ -650,6 +650,22 @@ describe('validation', () => {
 
             expect(error).toBe(undefined);
         });
+
+        it('should fail validation if subDepartment is not a valid subdepartment for the provided department', () => {
+            const orderPrepDepartment = 'ORDER-PREP';
+            const billingSubDepartment = 'READY FOR BILLING';
+    
+            ticketAttributes.destination = {
+                department: orderPrepDepartment,
+                subDepartment: billingSubDepartment
+            };
+    
+            const ticket = new TicketModel(ticketAttributes);
+    
+            const error = ticket.validateSync();
+    
+            expect(error).not.toBe(undefined);
+        });
     });
 
     describe('attribute: departmentNotes', () => {


### PR DESCRIPTION
# Description

Currently on a `Ticket` object, a user is allowed to defined a `subDepartment` and a `department`.

The department a user defines must be one string from a list of allowed strings.

Then, based on which department the user selects, the user must select an allowed subDepartment from a list.

The allowed subDepartments are dependent on which department the user has selected... However, I discovered that this validation rule was not enforced.

This PR adds a test case and updates the validation to cover this scenario.