### PR TITLE
Rename all Usages of `SubDepartment` to `DepartmentStatus`

### DIFF
--- a/application/controllers/ticketController.js
+++ b/application/controllers/ticketController.js
@@ -69,13 +69,13 @@ router.post('/update/:ticketId/notes', async (request, response) => {
     return response.json({});
 });
 
-router.post('/find-subdepartments', (request, response) => {
+router.post('/find-department-statuses', (request, response) => {
     const departmentName = request.body.departmentName;
-    const subDepartments = departmentStatusesGroupedByDepartment[departmentName];
+    const departmentStatuses = departmentStatusesGroupedByDepartment[departmentName];
 
     try {
-        if (!subDepartments) {
-            throw new Error(`No subdepartments found for the department named "${departmentName}"`);
+        if (!departmentStatuses) {
+            throw new Error(`No departmentStatuses found for the department named "${departmentName}"`);
         }
     } catch (error) {
         return response.json({
@@ -84,7 +84,7 @@ router.post('/find-subdepartments', (request, response) => {
     }
 
     return response.json({
-        subDepartments
+        departmentStatuses: departmentStatuses
     });
 });
 
@@ -112,10 +112,10 @@ router.get('/update/:id', async (request, response) => {
 
         const ticketDestination = ticket.destination;
         const selectedDepartment = ticketDestination && ticketDestination.department;
-        const selectedSubDepartment = ticketDestination && ticketDestination.subDepartment;
+        const selectedDepartmentStatus = ticketDestination && ticketDestination.departmentStatus;
         const selectedMaterial = ticket.primaryMaterial;
 
-        const subDepartments = departmentStatusesGroupedByDepartment ? departmentStatusesGroupedByDepartment[selectedDepartment] : undefined;
+        const departmentStatuses = departmentStatusesGroupedByDepartment ? departmentStatusesGroupedByDepartment[selectedDepartment] : undefined;
 
         const materialIds = materials.map(material => material.materialId);
 
@@ -124,8 +124,8 @@ router.get('/update/:id', async (request, response) => {
             materialIds,
             departmentNames,
             selectedDepartment,
-            selectedSubDepartment,
-            subDepartments,
+            selectedDepartmentStatus: selectedDepartmentStatus,
+            departmentStatuses: departmentStatuses,
             selectedMaterial
         });
     } catch (error) {

--- a/application/controllers/ticketController.js
+++ b/application/controllers/ticketController.js
@@ -8,7 +8,7 @@ const ticketService = require('../services/ticketService');
 const TicketModel = require('../models/ticket');
 const mongooseService = require('../services/mongooseService');
 const MaterialModel = require('../models/material');
-const {subDepartmentsGroupedByDepartment} = require('../enums/departmentsEnum');
+const {departmentStatusesGroupedByDepartment} = require('../enums/departmentsEnum');
 
 router.use(verifyJwtToken);
 
@@ -71,7 +71,7 @@ router.post('/update/:ticketId/notes', async (request, response) => {
 
 router.post('/find-subdepartments', (request, response) => {
     const departmentName = request.body.departmentName;
-    const subDepartments = subDepartmentsGroupedByDepartment[departmentName];
+    const subDepartments = departmentStatusesGroupedByDepartment[departmentName];
 
     try {
         if (!subDepartments) {
@@ -108,14 +108,14 @@ router.get('/update/:id', async (request, response) => {
     try {
         const ticket = await TicketModel.findById(request.params.id).exec();
         const materials = await MaterialModel.find().exec();
-        const departmentNames = Object.keys(subDepartmentsGroupedByDepartment);
+        const departmentNames = Object.keys(departmentStatusesGroupedByDepartment);
 
         const ticketDestination = ticket.destination;
         const selectedDepartment = ticketDestination && ticketDestination.department;
         const selectedSubDepartment = ticketDestination && ticketDestination.subDepartment;
         const selectedMaterial = ticket.primaryMaterial;
 
-        const subDepartments = subDepartmentsGroupedByDepartment ? subDepartmentsGroupedByDepartment[selectedDepartment] : undefined;
+        const subDepartments = departmentStatusesGroupedByDepartment ? departmentStatusesGroupedByDepartment[selectedDepartment] : undefined;
 
         const materialIds = materials.map(material => material.materialId);
 

--- a/application/enums/departmentsEnum.js
+++ b/application/enums/departmentsEnum.js
@@ -1,4 +1,4 @@
-// subDepartments
+// departmentStatuses
 const NEEDS_ATTENTION = 'NEEDS ATTENTION';
 const SEND_TO_CUSTOMER = 'SEND TO CUSTOMER';
 const WAITING_ON_APPROVAL = 'WAITING ON APPROVAL';
@@ -96,14 +96,14 @@ module.exports.departmentStatusesGroupedByDepartment = {
     [COMPLETE_DEPARTMENT]: []
 };
 
-module.exports.getAllSubDepartments = () => {
-    let allSubDepartments = [];
+module.exports.getAllDepartmentStatuses = () => {
+    let allDepartmentStatuses = [];
 
-    Object.values(this.departmentStatusesGroupedByDepartment).forEach((subDepartmentsForOneDepartment) => {
-        allSubDepartments.push(...subDepartmentsForOneDepartment);
+    Object.values(this.departmentStatusesGroupedByDepartment).forEach((departmentStatusesForOneDepartment) => {
+        allDepartmentStatuses.push(...departmentStatusesForOneDepartment);
     });
 
-    return allSubDepartments;
+    return allDepartmentStatuses;
 };
 
 module.exports.getAllDepartments = () => {

--- a/application/enums/departmentsEnum.js
+++ b/application/enums/departmentsEnum.js
@@ -37,7 +37,7 @@ const SHIPPING_DEPARTMENT = 'SHIPPING';
 const BILLING_DEPARTMENT = 'BILLING';
 const COMPLETE_DEPARTMENT = 'COMPLETED';
 
-module.exports.subDepartmentsGroupedByDepartment = {
+module.exports.departmentStatusesGroupedByDepartment = {
     [ORDER_PREP_DEPARTMENT]: [
         NEEDS_ATTENTION,
         SEND_TO_CUSTOMER,
@@ -99,7 +99,7 @@ module.exports.subDepartmentsGroupedByDepartment = {
 module.exports.getAllSubDepartments = () => {
     let allSubDepartments = [];
 
-    Object.values(this.subDepartmentsGroupedByDepartment).forEach((subDepartmentsForOneDepartment) => {
+    Object.values(this.departmentStatusesGroupedByDepartment).forEach((subDepartmentsForOneDepartment) => {
         allSubDepartments.push(...subDepartmentsForOneDepartment);
     });
 
@@ -107,5 +107,5 @@ module.exports.getAllSubDepartments = () => {
 };
 
 module.exports.getAllDepartments = () => {
-    return Object.keys(this.subDepartmentsGroupedByDepartment);
+    return Object.keys(this.departmentStatusesGroupedByDepartment);
 };

--- a/application/enums/departmentsEnum.js
+++ b/application/enums/departmentsEnum.js
@@ -109,3 +109,18 @@ module.exports.getAllDepartmentStatuses = () => {
 module.exports.getAllDepartments = () => {
     return Object.keys(this.departmentStatusesGroupedByDepartment);
 };
+
+module.exports.getAllDepartmentsWithDepartmentStatuses = () => {
+    let departmentsWithAtLeastOneDepartmentStatus = [];
+    let allDepartments = this.getAllDepartments();
+
+    allDepartments.forEach((department) => {
+        const containsAtLeastOneDepartmentStatus = this.departmentStatusesGroupedByDepartment[department].length > 0; // eslint-disable-line no-magic-numbers
+
+        if (containsAtLeastOneDepartmentStatus) {
+            departmentsWithAtLeastOneDepartmentStatus.push(department);
+        }
+    });
+
+    return departmentsWithAtLeastOneDepartmentStatus;
+};

--- a/application/models/WorkflowStep.js
+++ b/application/models/WorkflowStep.js
@@ -1,10 +1,10 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
-const {subDepartmentsGroupedByDepartment, getAllDepartments} = require('../enums/departmentsEnum');
+const {departmentStatusesGroupedByDepartment, getAllDepartments} = require('../enums/departmentsEnum');
 
 function isDepartmentAndDepartmentStatusCombinationValid() {
     const lengthOfEmptyArray = 0;
-    const allowedStatuses = subDepartmentsGroupedByDepartment[this.department];
+    const allowedStatuses = departmentStatusesGroupedByDepartment[this.department];
     const noDepartmentStatusesExistForThisDepartment = allowedStatuses.length === lengthOfEmptyArray;
 
     if (noDepartmentStatusesExistForThisDepartment) {

--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -3,7 +3,7 @@ mongoose.Schema.Types.String.set('trim', true);
 const Schema = mongoose.Schema;
 const productSchema = require('./product').schema;
 const chargeSchema = require('./charge').schema;
-const {departmentStatusesGroupedByDepartment, getAllSubDepartments} = require('../enums/departmentsEnum');
+const {departmentStatusesGroupedByDepartment, getAllDepartmentStatuses} = require('../enums/departmentsEnum');
 const {standardPriority, getAllPriorities} = require('../enums/priorityEnum');
 const MaterialModel = require('../models/material');
 
@@ -21,8 +21,8 @@ const validateEmail = function(email) {
 
 function destinationsAreValid(destination) {
     const department = destination.department;
-    const subDepartment = destination.subDepartment;
-    const oneAttributeIsDefinedButNotTheOther = (department && !subDepartment) || (!department && subDepartment);
+    const departmentStatus = destination.departmentStatus;
+    const oneAttributeIsDefinedButNotTheOther = (department && !departmentStatus) || (!department && departmentStatus);
     const isInCompletedState = department === 'COMPLETED';
 
     if (isInCompletedState) {
@@ -34,7 +34,7 @@ function destinationsAreValid(destination) {
     }
 
     if (department) {
-        return departmentStatusesGroupedByDepartment[department].includes(subDepartment);
+        return departmentStatusesGroupedByDepartment[department].includes(departmentStatus);
     }
     
     return true;
@@ -44,8 +44,8 @@ function departmentIsValid(department) {
     return Object.keys(departmentStatusesGroupedByDepartment).includes(department);
 }
 
-function subDepartmentIsValid(subDepartment) {
-    return getAllSubDepartments().includes(subDepartment);
+function departmentStatusIsValid(departmentStatus) {
+    return getAllDepartmentStatuses().includes(departmentStatus);
 }
 
 async function validateMaterialExists(materialId) {
@@ -97,9 +97,9 @@ const destinationSchema = new Schema({
         type: String,
         validate: [departmentIsValid, 'The provided department "{VALUE}" is not accepted']
     },
-    subDepartment: {
+    departmentStatus: {
         type: String,
-        validate: [subDepartmentIsValid, 'The provided sub-department "{VALUE}" is not accepted']
+        validate: [departmentStatusIsValid, 'The provided departmentStatus "{VALUE}" is not accepted']
     }
 }, { timestamps: true });
 

--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -121,7 +121,7 @@ const ticketSchema = new Schema({
     destination: {
         type: destinationSchema,
         required: false,
-        validate: [destinationsAreValid, 'Invalid Department/Sub-department combination']
+        validate: [destinationsAreValid, 'Invalid Department/departmentStatus combination']
     },
     products: {
         type: [productSchema],

--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -3,7 +3,7 @@ mongoose.Schema.Types.String.set('trim', true);
 const Schema = mongoose.Schema;
 const productSchema = require('./product').schema;
 const chargeSchema = require('./charge').schema;
-const {subDepartmentsGroupedByDepartment, getAllSubDepartments} = require('../enums/departmentsEnum');
+const {departmentStatusesGroupedByDepartment, getAllSubDepartments} = require('../enums/departmentsEnum');
 const {standardPriority, getAllPriorities} = require('../enums/priorityEnum');
 const MaterialModel = require('../models/material');
 
@@ -34,14 +34,14 @@ function destinationsAreValid(destination) {
     }
 
     if (department) {
-        return subDepartmentsGroupedByDepartment[department].includes(subDepartment);
+        return departmentStatusesGroupedByDepartment[department].includes(subDepartment);
     }
     
     return true;
 }
 
 function departmentIsValid(department) {
-    return Object.keys(subDepartmentsGroupedByDepartment).includes(department);
+    return Object.keys(departmentStatusesGroupedByDepartment).includes(department);
 }
 
 function subDepartmentIsValid(subDepartment) {

--- a/application/public/css/main.css
+++ b/application/public/css/main.css
@@ -3253,7 +3253,7 @@ a.storm {
 
 .departments-dropdown,
 .list-dropdown,
-.sub-department-dropdown,
+.department-status-dropdown,
 .duration-dropdown-options {
   z-index: -10;
   position: absolute;
@@ -3269,7 +3269,7 @@ a.storm {
 }
 .departments-dropdown.active,
 .list-dropdown.active,
-.sub-department-dropdown.active {
+.department-status-dropdown.active {
   display: block;
   left: 0;
   z-index: 444;

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -55,15 +55,15 @@ $( document ).ready(function() {
         updateTicket(ticketAttributes, ticketId);
     });
 
-    $('#subdepartment-selection').change(function() {
+    $('#department-status-selection').change(function() {
         const selectedDepartment = $('#department-selection').val();
-        const selectedSubDepartment = $('#subdepartment-selection').val();
+        const selectedDepartmentStatus = $('#department-status-selection').val();
         const ticketId = $('#department-notes').data('ticket-id');
 
         const ticketAttributes = {
             destination: {
                 department: selectedDepartment,
-                subDepartment: selectedSubDepartment
+                departmentStatus: selectedDepartmentStatus
             }
         };
 
@@ -96,9 +96,9 @@ $( document ).ready(function() {
         });
     });
 
-    function populateSubDepartmentsDropdown(departmentName) {
+    function populateDepartmentStatusesDropdown(departmentName) {
         $.ajax({
-            url: '/tickets/find-subdepartments',
+            url: '/tickets/find-department-statuses',
             type: 'POST',
             data: {
                 departmentName: departmentName
@@ -107,14 +107,14 @@ $( document ).ready(function() {
                 if (response.error) {
                     alert(`An error occurred: ${response.error}`);
                 } else {
-                    const subDepartments = response.subDepartments;
-                    const subDepartmentDropdown = $('#subdepartment-selection');
+                    const departmentStatuses = response.departmentStatuses;
+                    const departmentStatusDropdown = $('#department-status-selection');
 
-                    subDepartmentDropdown.empty();
-                    subDepartmentDropdown.append($('<option />').val('').text('-'));
+                    departmentStatusDropdown.empty();
+                    departmentStatusDropdown.append($('<option />').val('').text('-'));
 
-                    subDepartments.forEach((subDepartment) => {
-                        subDepartmentDropdown.append($('<option />').val(subDepartment).text(subDepartment));
+                    departmentStatuses.forEach((departmentStatus) => {
+                        departmentStatusDropdown.append($('<option />').val(departmentStatus).text(departmentStatus));
                     });
                 }
             },
@@ -131,7 +131,7 @@ $( document ).ready(function() {
         if (!selectedDepartmentName) {
             return;
         }
-        populateSubDepartmentsDropdown(selectedDepartmentName);
+        populateDepartmentStatusesDropdown(selectedDepartmentName);
     });
 
     $('.proof-upload').on('change', function() {

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -594,11 +594,11 @@ $( document ).ready(function() {
 
     $('.move-to-department-trigger ul li').click(function(){
         event.preventDefault();
-        $('.sub-department-dropdown').addClass('active');
+        $('.department-status-dropdown').addClass('active');
     });
 
     $('.sub-drpdwn-back-btn').click(function() {
-        $('.sub-department-dropdown').removeClass('active');
+        $('.department-status-dropdown').removeClass('active');
     });
 
     $('.notification-option').click(function() {

--- a/application/services/ticketService.js
+++ b/application/services/ticketService.js
@@ -88,22 +88,22 @@ module.exports.groupTicketsByDestination = (tickets) => {
 
     tickets.forEach((ticket) => {
         const department = ticket.destination ? ticket.destination.department : undefined;
-        const subDepartment = ticket.destination ? ticket.destination.subDepartment : undefined;
+        const departmentStatus = ticket.destination ? ticket.destination.departmentStatus : undefined;
 
-        if (department && subDepartment) {
+        if (department && departmentStatus) {
             const isFirstTicketFoundForThisDepartment = !ticketsGroupedByDestination[department];
 
             if (isFirstTicketFoundForThisDepartment) {
                 ticketsGroupedByDestination[department] = {};
             }
 
-            const isFirstTicketFoundForThisSubDepartment = !ticketsGroupedByDestination[department][subDepartment];
+            const isFirstTicketFoundForThisDepartmentStatus = !ticketsGroupedByDestination[department][departmentStatus];
 
-            if (isFirstTicketFoundForThisSubDepartment) {
-                ticketsGroupedByDestination[department][subDepartment] = [];
+            if (isFirstTicketFoundForThisDepartmentStatus) {
+                ticketsGroupedByDestination[department][departmentStatus] = [];
             }
 
-            ticketsGroupedByDestination[department][subDepartment].push(ticket);
+            ticketsGroupedByDestination[department][departmentStatus].push(ticket);
         }
     });
     

--- a/application/views/updateTicket.ejs
+++ b/application/views/updateTicket.ejs
@@ -38,12 +38,12 @@
                 <% } %>
             </select>
 
-            <label for="subdepartment-selection">SubDepartment:</label>
-            <select name="destination[subDepartment]" id="subdepartment-selection" data-ticket-id="<%= ticket.id %>">
-                <% if (typeof subDepartments != 'undefined') { %>
-                    <% subDepartments.forEach(subDepartmentName => { %>
-                        <% const isSelected = subDepartmentName == selectedSubDepartment ? 'selected' : ''; %>
-                        <option value="<%= subDepartmentName %>" <%= isSelected %>><%= subDepartmentName || 'N/A' %></option>
+            <label for="department-status-selection">departmentStatus:</label>
+            <select name="destination[departmentStatus]" id="department-status-selection" data-ticket-id="<%= ticket.id %>">
+                <% if (typeof departmentStatuses != 'undefined') { %>
+                    <% departmentStatuses.forEach(departmentStatus => { %>
+                        <% const isSelected = departmentStatus == selectedDepartmentStatus ? 'selected' : ''; %>
+                        <option value="<%= departmentStatus %>" <%= isSelected %>><%= departmentStatus || 'N/A' %></option>
                     <% }) %>
                 <% } else { %>
                     <option value=""><%= 'Please Select a Department First' %></option>

--- a/application/views/viewOneTicket.ejs
+++ b/application/views/viewOneTicket.ejs
@@ -1,3 +1,3 @@
 <p>Ticket Number: <%= ticket.ticketNumber || 'N/A' %></p>
 <p>Department: <%= ticket.destination && ticket.destination.department || 'N/A' %></p>
-<p>Sub Department: <%= ticket.destination && ticket.destination.departmentStatus || 'N/A' %></p>
+<p>Department Status: <%= ticket.destination && ticket.destination.departmentStatus || 'N/A' %></p>

--- a/application/views/viewOneTicket.ejs
+++ b/application/views/viewOneTicket.ejs
@@ -1,3 +1,3 @@
 <p>Ticket Number: <%= ticket.ticketNumber || 'N/A' %></p>
 <p>Department: <%= ticket.destination && ticket.destination.department || 'N/A' %></p>
-<p>Sub Department: <%= ticket.destination && ticket.destination.subDepartment || 'N/A' %></p>
+<p>Sub Department: <%= ticket.destination && ticket.destination.departmentStatus || 'N/A' %></p>

--- a/application/views/viewTickets.ejs
+++ b/application/views/viewTickets.ejs
@@ -231,11 +231,11 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
-                                    <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of sub-departments that correspond with the main department-->
+                                    <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
                                     <ul>
                                       <li>Department Status A</li>
                                       <li>Department Status B</li>
@@ -404,7 +404,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -552,7 +552,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -702,7 +702,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -851,7 +851,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -1014,7 +1014,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -1169,7 +1169,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -1320,7 +1320,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -1472,7 +1472,7 @@
                                         <li>Billing</li>
                                       </ul>
                                     </div>
-                                    <div class='sub-department-dropdown'>
+                                    <div class='department-status-dropdown'>
                                       <div class='department-dropdown-header flex-bottom-space-between-row'>
                                         <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                       </div>
@@ -1625,7 +1625,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -1788,7 +1788,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -1939,7 +1939,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -2090,7 +2090,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -2252,7 +2252,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -2407,7 +2407,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -2557,7 +2557,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -2707,7 +2707,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -2857,7 +2857,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -3020,7 +3020,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -3175,7 +3175,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -3325,7 +3325,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -3475,7 +3475,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -3625,7 +3625,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -3775,7 +3775,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -3938,7 +3938,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -4093,7 +4093,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -4244,7 +4244,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -4407,7 +4407,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -4558,7 +4558,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -4708,7 +4708,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -4859,7 +4859,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
@@ -5019,7 +5019,7 @@
                                       <li>Billing</li>
                                     </ul>
                                   </div>
-                                  <div class='sub-department-dropdown'>
+                                  <div class='department-status-dropdown'>
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>

--- a/application/views/viewTickets.ejs
+++ b/application/views/viewTickets.ejs
@@ -235,11 +235,11 @@
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
-                                    <!-- #409 Gavin This the list of sub departments. We would want to populate this with list of sub-departments that correspond with the main department-->
+                                    <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of sub-departments that correspond with the main department-->
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                     <!-- End Gavin Target -->
                                   </div>
@@ -249,11 +249,11 @@
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
-                                    <!-- #410 Gavin This a list of the sub departments of the current department that the ticket is in. -->
+                                    <!-- #410 Gavin This a list of the department statuss of the current department that the ticket is in. -->
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                     <!-- End Gavin Target -->
                                   </div>
@@ -409,9 +409,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -421,9 +421,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -557,9 +557,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -569,9 +569,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -707,9 +707,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -719,9 +719,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -856,9 +856,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -868,9 +868,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -1019,9 +1019,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -1031,9 +1031,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -1174,9 +1174,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -1186,9 +1186,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -1325,9 +1325,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -1337,9 +1337,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -1477,9 +1477,9 @@
                                         <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                       </div>
                                       <ul>
-                                        <li>Sub Department A</li>
-                                        <li>Sub Department B</li>
-                                        <li>Sub Department C</li>
+                                        <li>Department Status A</li>
+                                        <li>Department Status B</li>
+                                        <li>Department Status C</li>
                                       </ul>
                                     </div>
                                   </li>
@@ -1489,9 +1489,9 @@
                                         <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                       </div>
                                       <ul>
-                                        <li>Sub Department A</li>
-                                        <li>Sub Department B</li>
-                                        <li>Sub Department C</li>
+                                        <li>Department Status A</li>
+                                        <li>Department Status B</li>
+                                        <li>Department Status C</li>
                                       </ul>
                                     </div>
                                   </li>
@@ -1630,9 +1630,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -1642,9 +1642,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -1793,9 +1793,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -1805,9 +1805,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -1944,9 +1944,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -1956,9 +1956,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -2095,9 +2095,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -2107,9 +2107,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -2257,9 +2257,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -2269,9 +2269,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -2412,9 +2412,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -2424,9 +2424,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -2562,9 +2562,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -2574,9 +2574,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -2712,9 +2712,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -2724,9 +2724,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -2862,9 +2862,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -2874,9 +2874,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -3025,9 +3025,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -3037,9 +3037,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -3180,9 +3180,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -3192,9 +3192,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -3330,9 +3330,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -3342,9 +3342,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -3480,9 +3480,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -3492,9 +3492,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -3630,9 +3630,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -3642,9 +3642,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -3780,9 +3780,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -3792,9 +3792,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -3943,9 +3943,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -3955,9 +3955,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -4098,9 +4098,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -4110,9 +4110,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -4249,9 +4249,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -4261,9 +4261,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -4412,9 +4412,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -4424,9 +4424,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -4563,9 +4563,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -4575,9 +4575,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -4713,9 +4713,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -4725,9 +4725,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -4864,9 +4864,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -4876,9 +4876,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -4959,7 +4959,7 @@
         <% const numberOfBillingTickets = Object.values(billingTicketsGroupedByDepartmentStatus).flat().length %>
       <!-- Billing Department -->
       <div class='department-wrapper' data-department="BILLING">
-        <h2>Billing Department (TODO Storm: this second's subdepartments appear incorrect) - <span class='text-blue' id='departmentTotalTickets'><%= numberOfBillingTickets %></span></h2>
+        <h2>Billing Department (TODO Storm: this second's departmentStatuses appear incorrect) - <span class='text-blue' id='departmentTotalTickets'><%= numberOfBillingTickets %></span></h2>
 
         <% if (true) { %>  <!-- TODO: This section is an invalid billing section, storm needs to update it -->
           <div class='department-section department-section-a'>
@@ -5024,9 +5024,9 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>
@@ -5036,9 +5036,9 @@
                                       <span class='drpdwn-title'>Choose List</span><span class="drpdwn-back-btn">Back</span>
                                     </div>
                                     <ul>
-                                      <li>Sub Department A</li>
-                                      <li>Sub Department B</li>
-                                      <li>Sub Department C</li>
+                                      <li>Department Status A</li>
+                                      <li>Department Status B</li>
+                                      <li>Department Status C</li>
                                     </ul>
                                   </div>
                                 </li>

--- a/application/views/viewTickets.ejs
+++ b/application/views/viewTickets.ejs
@@ -87,60 +87,60 @@
 
     </div>
 
-    <% const orderPrepTicketsGroupedBySubDepartment = ticketsGroupedByDestination['ORDER-PREP'] %>
-    <% const artPrepTicketsGroupedBySubDepartment = ticketsGroupedByDestination['ART-PREP'] %>
-    <% const prePressTicketsGroupedBySubDepartment = ticketsGroupedByDestination['PRE-PRESS'] %>
-    <% const printingTicketsGroupedBySubDepartment = ticketsGroupedByDestination['PRINTING'] %>
-    <% const cuttingTicketsGroupedBySubDepartment = ticketsGroupedByDestination['CUTTING'] %>
-    <% const windingTicketsGroupedBySubDepartment = ticketsGroupedByDestination['WINDING'] %>
-    <% const shippingTicketsGroupedBySubDepartment = ticketsGroupedByDestination['SHIPPING'] %>
-    <% const billingTicketsGroupedBySubDepartment = ticketsGroupedByDestination['BILLING'] %>
+    <% const orderPrepTicketsGroupedByDepartmentStatus = ticketsGroupedByDestination['ORDER-PREP'] %>
+    <% const artPrepTicketsGroupedByDepartmentStatus = ticketsGroupedByDestination['ART-PREP'] %>
+    <% const prePressTicketsGroupedByDepartmentStatus = ticketsGroupedByDestination['PRE-PRESS'] %>
+    <% const printingTicketsGroupedByDepartmentStatus = ticketsGroupedByDestination['PRINTING'] %>
+    <% const cuttingTicketsGroupedByDepartmentStatus = ticketsGroupedByDestination['CUTTING'] %>
+    <% const windingTicketsGroupedByDepartmentStatus = ticketsGroupedByDestination['WINDING'] %>
+    <% const shippingTicketsGroupedByDepartmentStatus = ticketsGroupedByDestination['SHIPPING'] %>
+    <% const billingTicketsGroupedByDepartmentStatus = ticketsGroupedByDestination['BILLING'] %>
 
-    <% const orderPrepNeedsAttentionTickets = orderPrepTicketsGroupedBySubDepartment['NEEDS ATTENTION'] %>
-    <% const orderPrepSendToCustomerTickets = orderPrepTicketsGroupedBySubDepartment['SEND TO CUSTOMER'] %>
-    <% const orderPrepWaitingOnApprovalTickets = orderPrepTicketsGroupedBySubDepartment['WAITING ON APPROVAL'] %>
-    <% const orderPrepWaitingOnCustomerTickets = orderPrepTicketsGroupedBySubDepartment['WAITING ON CUSTOMER'] %>
-    <% const orderPrepReadyToOrderTickets = orderPrepTicketsGroupedBySubDepartment['READY TO ORDER PLATE OR DIE'] %>
-    <% const orderPrepInProgressTickets = orderPrepTicketsGroupedBySubDepartment['IN PROGRESS'] %> <!-- TODO: This table is missing and therefore this variable is unused right now, ask storm about it -->
+    <% const orderPrepNeedsAttentionTickets = orderPrepTicketsGroupedByDepartmentStatus['NEEDS ATTENTION'] %>
+    <% const orderPrepSendToCustomerTickets = orderPrepTicketsGroupedByDepartmentStatus['SEND TO CUSTOMER'] %>
+    <% const orderPrepWaitingOnApprovalTickets = orderPrepTicketsGroupedByDepartmentStatus['WAITING ON APPROVAL'] %>
+    <% const orderPrepWaitingOnCustomerTickets = orderPrepTicketsGroupedByDepartmentStatus['WAITING ON CUSTOMER'] %>
+    <% const orderPrepReadyToOrderTickets = orderPrepTicketsGroupedByDepartmentStatus['READY TO ORDER PLATE OR DIE'] %>
+    <% const orderPrepInProgressTickets = orderPrepTicketsGroupedByDepartmentStatus['IN PROGRESS'] %> <!-- TODO: This table is missing and therefore this variable is unused right now, ask storm about it -->
 
-    <% const artPrepNeedsAttentionTickets = artPrepTicketsGroupedBySubDepartment['NEEDS ATTENTION'] %>
-    <% const artPrepInProgressTickets = artPrepTicketsGroupedBySubDepartment['IN PROGRESS'] %>
-    <% const artPrepNeedsProofTickets = artPrepTicketsGroupedBySubDepartment['NEEDS PROOF'] %>
-    <% const artPrepNeedsDieLineTickets = artPrepTicketsGroupedBySubDepartment['NEEDS DIE LINE'] %>
-    <% const artPrepNeedsPlateTickets = artPrepTicketsGroupedBySubDepartment['NEEDS PLATE'] %>
+    <% const artPrepNeedsAttentionTickets = artPrepTicketsGroupedByDepartmentStatus['NEEDS ATTENTION'] %>
+    <% const artPrepInProgressTickets = artPrepTicketsGroupedByDepartmentStatus['IN PROGRESS'] %>
+    <% const artPrepNeedsProofTickets = artPrepTicketsGroupedByDepartmentStatus['NEEDS PROOF'] %>
+    <% const artPrepNeedsDieLineTickets = artPrepTicketsGroupedByDepartmentStatus['NEEDS DIE LINE'] %>
+    <% const artPrepNeedsPlateTickets = artPrepTicketsGroupedByDepartmentStatus['NEEDS PLATE'] %>
 
-    <% const prePressNeedsAttentionTickets = prePressTicketsGroupedBySubDepartment['NEEDS ATTENTION'] %>
-    <% const prePressInProgressTickets = prePressTicketsGroupedBySubDepartment['IN PROGRESS'] %>
-    <% const prePressSendToPressTickets = prePressTicketsGroupedBySubDepartment['SEND TO PRESS'] %>
+    <% const prePressNeedsAttentionTickets = prePressTicketsGroupedByDepartmentStatus['NEEDS ATTENTION'] %>
+    <% const prePressInProgressTickets = prePressTicketsGroupedByDepartmentStatus['IN PROGRESS'] %>
+    <% const prePressSendToPressTickets = prePressTicketsGroupedByDepartmentStatus['SEND TO PRESS'] %>
 
-    <% const printingInProgressTickets = printingTicketsGroupedBySubDepartment['IN PROGRESS'] %>
-    <% const printingReadyForSchedulingTickets = printingTicketsGroupedBySubDepartment['READY FOR SCHEDULING'] %>
-    <% const printingSchedulePressOneTickets = printingTicketsGroupedBySubDepartment['SCHEDULE PRESS ONE'] %>
-    <% const printingSchedulePressTwoTickets = printingTicketsGroupedBySubDepartment['SCHEDULE PRESS TWO'] %>
-    <% const printingSchedulePressThreeTickets = printingTicketsGroupedBySubDepartment['SCHEDULE PRESS THREE'] %> <!-- TODO: This table is missing and therefore this variable is unused right now, ask storm about it -->
-    <% const printingOnHoldTickets = printingTicketsGroupedBySubDepartment['ON HOLD'] %>
+    <% const printingInProgressTickets = printingTicketsGroupedByDepartmentStatus['IN PROGRESS'] %>
+    <% const printingReadyForSchedulingTickets = printingTicketsGroupedByDepartmentStatus['READY FOR SCHEDULING'] %>
+    <% const printingSchedulePressOneTickets = printingTicketsGroupedByDepartmentStatus['SCHEDULE PRESS ONE'] %>
+    <% const printingSchedulePressTwoTickets = printingTicketsGroupedByDepartmentStatus['SCHEDULE PRESS TWO'] %>
+    <% const printingSchedulePressThreeTickets = printingTicketsGroupedByDepartmentStatus['SCHEDULE PRESS THREE'] %> <!-- TODO: This table is missing and therefore this variable is unused right now, ask storm about it -->
+    <% const printingOnHoldTickets = printingTicketsGroupedByDepartmentStatus['ON HOLD'] %>
 
-    <% const cuttingInProgressTickets = cuttingTicketsGroupedBySubDepartment['IN PROGRESS'] %>
-    <% const cuttingReadyForSchedulingTickets = cuttingTicketsGroupedBySubDepartment['READY FOR SCHEDULING'] %>
-    <% const cuttingScheduleDeltaOneTickets = cuttingTicketsGroupedBySubDepartment['SCHEDULE DELTA ONE'] %>
-    <% const cuttingScheduleDeltaTwoTickets = cuttingTicketsGroupedBySubDepartment['SCHEDULE DELTA TWO'] %>
-    <% const cuttingScheduleRotoflexTickets = cuttingTicketsGroupedBySubDepartment['SCHEDULE ROTOFLEX'] %>
-    <% const cuttingOnHoldTickets = cuttingTicketsGroupedBySubDepartment['ON HOLD'] %>
+    <% const cuttingInProgressTickets = cuttingTicketsGroupedByDepartmentStatus['IN PROGRESS'] %>
+    <% const cuttingReadyForSchedulingTickets = cuttingTicketsGroupedByDepartmentStatus['READY FOR SCHEDULING'] %>
+    <% const cuttingScheduleDeltaOneTickets = cuttingTicketsGroupedByDepartmentStatus['SCHEDULE DELTA ONE'] %>
+    <% const cuttingScheduleDeltaTwoTickets = cuttingTicketsGroupedByDepartmentStatus['SCHEDULE DELTA TWO'] %>
+    <% const cuttingScheduleRotoflexTickets = cuttingTicketsGroupedByDepartmentStatus['SCHEDULE ROTOFLEX'] %>
+    <% const cuttingOnHoldTickets = cuttingTicketsGroupedByDepartmentStatus['ON HOLD'] %>
 
-    <% const windingInProgressTickets = windingTicketsGroupedBySubDepartment['IN PROGRESS'] %>
-    <% const windingReadyForSchedulingTickets = windingTicketsGroupedBySubDepartment['READY FOR SCHEDULING'] %>
-    <% const windingOnHoldTickets = windingTicketsGroupedBySubDepartment['ON HOLD'] %>
+    <% const windingInProgressTickets = windingTicketsGroupedByDepartmentStatus['IN PROGRESS'] %>
+    <% const windingReadyForSchedulingTickets = windingTicketsGroupedByDepartmentStatus['READY FOR SCHEDULING'] %>
+    <% const windingOnHoldTickets = windingTicketsGroupedByDepartmentStatus['ON HOLD'] %>
 
-    <% const shippingInProgressTickets = shippingTicketsGroupedBySubDepartment['IN PROGRESS'] %>
-    <% const shippingReadyForShippingTickets = shippingTicketsGroupedBySubDepartment['READY FOR SHIPPING'] %>
-    <% const shippingOnHoldTickets = shippingTicketsGroupedBySubDepartment['ON HOLD'] %>
-    <% const shippingToolArrivalTickets = shippingTicketsGroupedBySubDepartment['TOOL ARRIVALS'] %>
+    <% const shippingInProgressTickets = shippingTicketsGroupedByDepartmentStatus['IN PROGRESS'] %>
+    <% const shippingReadyForShippingTickets = shippingTicketsGroupedByDepartmentStatus['READY FOR SHIPPING'] %>
+    <% const shippingOnHoldTickets = shippingTicketsGroupedByDepartmentStatus['ON HOLD'] %>
+    <% const shippingToolArrivalTickets = shippingTicketsGroupedByDepartmentStatus['TOOL ARRIVALS'] %>
 
-    <% const billingInProgressTickets = billingTicketsGroupedBySubDepartment['IN PROGRESS'] %> <!-- TODO: This table is missing and therefore this variable is unused right now, ask storm about it -->
-    <% const billingReadyForBillingTickets = billingTicketsGroupedBySubDepartment['READY FOR BILLING'] %> <!-- TODO: This table is missing and therefore this variable is unused right now, ask storm about it -->
+    <% const billingInProgressTickets = billingTicketsGroupedByDepartmentStatus['IN PROGRESS'] %> <!-- TODO: This table is missing and therefore this variable is unused right now, ask storm about it -->
+    <% const billingReadyForBillingTickets = billingTicketsGroupedByDepartmentStatus['READY FOR BILLING'] %> <!-- TODO: This table is missing and therefore this variable is unused right now, ask storm about it -->
     
-    <% if (orderPrepTicketsGroupedBySubDepartment && Object.keys(orderPrepTicketsGroupedBySubDepartment).length > 0) { %>
-      <% const numberOfOrderPrepTickets = Object.values(orderPrepTicketsGroupedBySubDepartment).flat().length %>
+    <% if (orderPrepTicketsGroupedByDepartmentStatus && Object.keys(orderPrepTicketsGroupedByDepartmentStatus).length > 0) { %>
+      <% const numberOfOrderPrepTickets = Object.values(orderPrepTicketsGroupedByDepartmentStatus).flat().length %>
       <!-- Order Prep Department -->
       <div class='department-wrapper' data-department="ORDER-PREP">
         <h2>Order Prep Department - <span class='text-blue' id='departmentTotalTickets'><%= numberOfOrderPrepTickets %></span></h2>
@@ -948,8 +948,8 @@
       </div>
       
       <!--- Art Prep Department Start-->
-      <% if (artPrepTicketsGroupedBySubDepartment && Object.keys(artPrepTicketsGroupedBySubDepartment).length > 0) { %>
-        <% const numberOfArtPrepTickets = Object.values(artPrepTicketsGroupedBySubDepartment).flat().length %>
+      <% if (artPrepTicketsGroupedByDepartmentStatus && Object.keys(artPrepTicketsGroupedByDepartmentStatus).length > 0) { %>
+        <% const numberOfArtPrepTickets = Object.values(artPrepTicketsGroupedByDepartmentStatus).flat().length %>
       <!-- Art Department -->
       <div class='department-wrapper' data-department="ART-PREP">
         <h2>Art Department - <span class='text-blue' id='departmentTotalTickets'><%= numberOfArtPrepTickets %></span></h2>
@@ -1722,8 +1722,8 @@
         <div class="department-divide-line"></div><h4>End Art Prep</h4><div class="department-divide-line"></div>
       </div>
   
-      <% if (prePressTicketsGroupedBySubDepartment && Object.keys(prePressTicketsGroupedBySubDepartment).length > 0) { %>
-        <% const numberOfPrePressTickets = Object.values(prePressTicketsGroupedBySubDepartment).flat().length %>
+      <% if (prePressTicketsGroupedByDepartmentStatus && Object.keys(prePressTicketsGroupedByDepartmentStatus).length > 0) { %>
+        <% const numberOfPrePressTickets = Object.values(prePressTicketsGroupedByDepartmentStatus).flat().length %>
       <!-- Pre Press Department-->
       <div class='department-wrapper' data-department="PRE-PRESS">
         <h2>Pre-Printing - <span class='text-blue' id='departmentTotalTickets'><%= numberOfPrePressTickets %></span></h2>
@@ -2186,8 +2186,8 @@
         <div class="department-divide-line"></div><h4>End Pre Printing</h4><div class="department-divide-line"></div>
       </div>
 
-      <% if (printingTicketsGroupedBySubDepartment && Object.keys(printingTicketsGroupedBySubDepartment).length > 0) { %>
-        <% const numberOfPrintingTickets = Object.values(printingTicketsGroupedBySubDepartment).flat().length %>
+      <% if (printingTicketsGroupedByDepartmentStatus && Object.keys(printingTicketsGroupedByDepartmentStatus).length > 0) { %>
+        <% const numberOfPrintingTickets = Object.values(printingTicketsGroupedByDepartmentStatus).flat().length %>
       <!-- Printing Department-->
       <div class='department-wrapper' data-department="PRINTING">
         <h2>Printing Department - <span class='text-blue' id='departmentTotalTickets'><%= numberOfPrintingTickets %></span></h2>
@@ -2954,8 +2954,8 @@
         <div class="department-divide-line"></div><h4>End Printing</h4><div class="department-divide-line"></div>
       </div>
     
-      <% if (cuttingTicketsGroupedBySubDepartment && Object.keys(cuttingTicketsGroupedBySubDepartment).length > 0) { %>
-        <% const numberOfCuttingTickets = Object.values(cuttingTicketsGroupedBySubDepartment).flat().length %>
+      <% if (cuttingTicketsGroupedByDepartmentStatus && Object.keys(cuttingTicketsGroupedByDepartmentStatus).length > 0) { %>
+        <% const numberOfCuttingTickets = Object.values(cuttingTicketsGroupedByDepartmentStatus).flat().length %>
       <!-- Cutting Department -->
       <div class='department-wrapper' data-department="CUTTING">
         <h2>Cutting Department - <span class='text-blue' id='departmentTotalTickets'><%= numberOfCuttingTickets %></span></h2>
@@ -3872,8 +3872,8 @@
         <div class="department-divide-line"></div><h4>End Cutting</h4><div class="department-divide-line"></div>
       </div>
 
-      <% if (windingTicketsGroupedBySubDepartment && Object.keys(windingTicketsGroupedBySubDepartment).length > 0) { %>
-        <% const numberOfWindingTickets = Object.values(windingTicketsGroupedBySubDepartment).flat().length %>
+      <% if (windingTicketsGroupedByDepartmentStatus && Object.keys(windingTicketsGroupedByDepartmentStatus).length > 0) { %>
+        <% const numberOfWindingTickets = Object.values(windingTicketsGroupedByDepartmentStatus).flat().length %>
       <!-- Winding Department -->
       <div class='department-wrapper' data-department="WINDING">
         <h2>Winding Department - <span class='text-blue' id='departmentTotalTickets'><%= numberOfWindingTickets %></span></h2>
@@ -4341,8 +4341,8 @@
         <div class="department-divide-line"></div><h4>End of Winding</h4><div class="department-divide-line"></div>
       </div>
 
-      <% if (shippingTicketsGroupedBySubDepartment && Object.keys(shippingTicketsGroupedBySubDepartment).length > 0) { %>
-        <% const numberOfShippingTickets = Object.values(shippingTicketsGroupedBySubDepartment).flat().length %>
+      <% if (shippingTicketsGroupedByDepartmentStatus && Object.keys(shippingTicketsGroupedByDepartmentStatus).length > 0) { %>
+        <% const numberOfShippingTickets = Object.values(shippingTicketsGroupedByDepartmentStatus).flat().length %>
       <!-- Shipping Department -->
       <div class='department-wrapper' data-department="SHIPPING">
         <h2>Shipping Department - <span class='text-blue' id='departmentTotalTickets'><%= numberOfShippingTickets %></span></h2>
@@ -4955,8 +4955,8 @@
         <div class="department-divide-line"></div><h4>End Shipping</h4><div class="department-divide-line"></div>
       </div>
 
-      <% if (billingTicketsGroupedBySubDepartment && Object.keys(billingTicketsGroupedBySubDepartment).length > 0) { %>
-        <% const numberOfBillingTickets = Object.values(billingTicketsGroupedBySubDepartment).flat().length %>
+      <% if (billingTicketsGroupedByDepartmentStatus && Object.keys(billingTicketsGroupedByDepartmentStatus).length > 0) { %>
+        <% const numberOfBillingTickets = Object.values(billingTicketsGroupedByDepartmentStatus).flat().length %>
       <!-- Billing Department -->
       <div class='department-wrapper' data-department="BILLING">
         <h2>Billing Department (TODO Storm: this second's subdepartments appear incorrect) - <span class='text-blue' id='departmentTotalTickets'><%= numberOfBillingTickets %></span></h2>

--- a/test/enums/departmentsEnum.spec.js
+++ b/test/enums/departmentsEnum.spec.js
@@ -1,17 +1,17 @@
-const {getAllSubDepartments, getAllDepartments} = require('../../application/enums/departmentsEnum');
+const {getAllDepartmentStatuses, getAllDepartments} = require('../../application/enums/departmentsEnum');
 
 describe('departmentsEnum', () => {
-    it('should return the list of subdepartments', () => {
-        const expectedNumberOfSubDepartments = 39;
-        const expectedNumberOfUniqueSubDepartments = 24;
+    it('should return the list of departmentStatus', () => {
+        const expectedNumberOfDepartmentStatuses = 39;
+        const expectedNumberOfUniqueDepartmentStatuses = 24;
 
-        const subDepartments = getAllSubDepartments();
-        const uniqueSubDepartments = new Set(subDepartments);
+        const departmentStatuses = getAllDepartmentStatuses();
+        const uniqueDepartmentStatuses = new Set(departmentStatuses);
 
-        console.log(uniqueSubDepartments.size);
+        console.log(uniqueDepartmentStatuses.size);
 
-        expect(subDepartments.length).toBe(expectedNumberOfSubDepartments);
-        expect(uniqueSubDepartments.size).toBe(expectedNumberOfUniqueSubDepartments);
+        expect(departmentStatuses.length).toBe(expectedNumberOfDepartmentStatuses);
+        expect(uniqueDepartmentStatuses.size).toBe(expectedNumberOfUniqueDepartmentStatuses);
     });
 
     it('should return the list of departments', () => {

--- a/test/models/ticket.spec.js
+++ b/test/models/ticket.spec.js
@@ -1,6 +1,6 @@
 const chance = require('chance').Chance();
 const TicketModel = require('../../application/models/ticket');
-const {subDepartmentsGroupedByDepartment} = require('../../application/enums/departmentsEnum');
+const {departmentStatusesGroupedByDepartment} = require('../../application/enums/departmentsEnum');
 const databaseService = require('../../application/services/databaseService');
 const {standardPriority, getAllPriorities} = require('../../application/enums/priorityEnum');
 
@@ -592,7 +592,7 @@ describe('validation', () => {
         it('should fail validation if department attribute IS NOT an accepted value', () => {
             const validDepartment = 'ART-PREP';
             const invalidDepartment = chance.string();
-            const validSubDepartment = chance.pickone(subDepartmentsGroupedByDepartment[validDepartment]);
+            const validSubDepartment = chance.pickone(departmentStatusesGroupedByDepartment[validDepartment]);
 
             ticketAttributes.destination = {
                 department: invalidDepartment,

--- a/test/models/ticket.spec.js
+++ b/test/models/ticket.spec.js
@@ -565,7 +565,7 @@ describe('validation', () => {
             expect(error).toBe(undefined);
         });
 
-        it('should pass validation if attribute exists but department/subdepartment are both not defined', () => {
+        it('should pass validation if attribute exists but department/departmentStatus are both not defined', () => {
             ticketAttributes.destination = {};
             const ticket = new TicketModel(ticketAttributes);
 
@@ -574,13 +574,13 @@ describe('validation', () => {
             expect(error).toBe(undefined);
         });
 
-        it('should fail validation if subDepartment attribute IS NOT an accepted value', () => {
+        it('should fail validation if departmentStatus attribute IS NOT an accepted value', () => {
             const validDepartment = 'PRE-PRESS';
-            const invalidSubDepartment = chance.string();
+            const invalidDepartmentStatus = chance.string();
 
             ticketAttributes.destination = {
                 department: validDepartment,
-                subDepartment: invalidSubDepartment
+                departmentStatus: invalidDepartmentStatus
             };
             const ticket = new TicketModel(ticketAttributes);
 
@@ -592,11 +592,11 @@ describe('validation', () => {
         it('should fail validation if department attribute IS NOT an accepted value', () => {
             const validDepartment = 'ART-PREP';
             const invalidDepartment = chance.string();
-            const validSubDepartment = chance.pickone(departmentStatusesGroupedByDepartment[validDepartment]);
+            const validDepartmentStatus = chance.pickone(departmentStatusesGroupedByDepartment[validDepartment]);
 
             ticketAttributes.destination = {
                 department: invalidDepartment,
-                subDepartment: validSubDepartment
+                departmentStatus: validDepartmentStatus
             };
             const ticket = new TicketModel(ticketAttributes);
 
@@ -605,13 +605,13 @@ describe('validation', () => {
             expect(error).not.toBe(undefined);
         });
 
-        it('should fail validation if exactly one of either department or subdepartment is left blank', () => {
+        it('should fail validation if exactly one of either department or departmentStatus is left blank', () => {
             const validDepartment = 'ORDER PREP';
-            const invalidSubDepartment = undefined;
+            const invalidDepartmentStatus = undefined;
 
             ticketAttributes.destination = {
                 department: validDepartment,
-                subDepartment: invalidSubDepartment
+                departmentStatus: invalidDepartmentStatus
             };
 
             const ticket = new TicketModel(ticketAttributes);
@@ -621,13 +621,13 @@ describe('validation', () => {
             expect(error).not.toBe(undefined);
         });
 
-        it('should fail validation if department is COMPLETED and subDepartment is defined', () => {
+        it('should fail validation if department is COMPLETED and departmentStatus is defined', () => {
             const validDepartment = 'COMPLETED';
-            const invalidSubDepartment = chance.word();
+            const invalidDepartmentStatus = chance.word();
     
             ticketAttributes.destination = {
                 department: validDepartment,
-                subDepartment: invalidSubDepartment
+                departmentStatus: invalidDepartmentStatus
             };
     
             const ticket = new TicketModel(ticketAttributes);
@@ -637,7 +637,7 @@ describe('validation', () => {
             expect(error).not.toBe(undefined);
         });
 
-        it('should pass validation if department is COMPLETED and subDepartment not defined', () => {
+        it('should pass validation if department is COMPLETED and departmentStatus not defined', () => {
             const validDepartment = 'COMPLETED';
 
             ticketAttributes.destination = {
@@ -651,13 +651,13 @@ describe('validation', () => {
             expect(error).toBe(undefined);
         });
 
-        it('should fail validation if subDepartment is not a valid subdepartment for the provided department', () => {
+        it('should fail validation if departmentStatus is not a valid departmentStatus for the provided department', () => {
             const orderPrepDepartment = 'ORDER-PREP';
-            const billingSubDepartment = 'READY FOR BILLING';
+            const billingDepartmentStatus = 'READY FOR BILLING';
     
             ticketAttributes.destination = {
                 department: orderPrepDepartment,
-                subDepartment: billingSubDepartment
+                departmentStatus: billingDepartmentStatus
             };
     
             const ticket = new TicketModel(ticketAttributes);

--- a/test/models/workflowStep.spec.js
+++ b/test/models/workflowStep.spec.js
@@ -1,6 +1,6 @@
 const chance = require('chance').Chance();
 const WorkflowStep = require('../../application/models/WorkflowStep');
-const {getAllSubDepartments, departmentStatusesGroupedByDepartment} = require('../../application/enums/departmentsEnum');
+const {getAllDepartmentStatuses, departmentStatusesGroupedByDepartment} = require('../../application/enums/departmentsEnum');
 const mongoose = require('mongoose');
 
 const DEPARTMENT_WITH_STATUSES = 'PRINTING';
@@ -102,7 +102,7 @@ describe('validation', () => {
         });
 
         it('should pass if attribute IS an accepted value', () => {
-            const validDepartmentStatus = chance.pickone(getAllSubDepartments());
+            const validDepartmentStatus = chance.pickone(getAllDepartmentStatuses());
             workFlowStepAttributes.status = validDepartmentStatus;
             const workflowStep = new WorkflowStep(workFlowStepAttributes);
 

--- a/test/models/workflowStep.spec.js
+++ b/test/models/workflowStep.spec.js
@@ -1,6 +1,6 @@
 const chance = require('chance').Chance();
 const WorkflowStep = require('../../application/models/WorkflowStep');
-const {getAllSubDepartments, subDepartmentsGroupedByDepartment} = require('../../application/enums/departmentsEnum');
+const {getAllSubDepartments, departmentStatusesGroupedByDepartment} = require('../../application/enums/departmentsEnum');
 const mongoose = require('mongoose');
 
 const DEPARTMENT_WITH_STATUSES = 'PRINTING';
@@ -11,7 +11,7 @@ describe('validation', () => {
 
     beforeEach(() => {
         let department = DEPARTMENT_WITH_STATUSES;
-        let departmentStatus = chance.pickone(subDepartmentsGroupedByDepartment[department]);
+        let departmentStatus = chance.pickone(departmentStatusesGroupedByDepartment[department]);
 
         workFlowStepAttributes = {
             ticketId: new mongoose.Types.ObjectId(),
@@ -74,7 +74,7 @@ describe('validation', () => {
 
         it('should pass if attribute IS an accepted value', () => {
             const validDepartment = DEPARTMENT_WITH_STATUSES;
-            const validStatus = chance.pickone(subDepartmentsGroupedByDepartment[validDepartment]);
+            const validStatus = chance.pickone(departmentStatusesGroupedByDepartment[validDepartment]);
             workFlowStepAttributes.department = validDepartment;
             workFlowStepAttributes.departmentStatus = validStatus;
             const workflowStep = new WorkflowStep(workFlowStepAttributes);

--- a/test/services/ticketService.spec.js
+++ b/test/services/ticketService.spec.js
@@ -1,5 +1,6 @@
 const chance = require('chance').Chance();
 const ticketService = require('../../application/services/ticketService');
+const {getAllDepartmentsWithDepartmentStatuses, departmentStatusesGroupedByDepartment, getAllDepartmentStatuses} = require('../../application/enums/departmentsEnum');
 
 const TICKET_ITEM_KEY = 'TicketItem';
 
@@ -111,89 +112,90 @@ describe('ticketService test suite', () => {
     });
 
     describe('groupTicketsByDepartment', () => {
-        let ticketsWithDepartments;
-        let ticketsWithoutDepartments;
-        let allTickets;
-        let departmentNames;
-        let departmentStatusNames;
-        let ticketsWithoutADepartmentOrDepartmentStatus;
+        const allDepartmentsWithAtLeastOneDepartmentStatus = getAllDepartmentsWithDepartmentStatuses();
 
-        beforeEach(() => {
-            departmentNames = [chance.word(), chance.word(), chance.word()];
-            departmentStatusNames = [chance.word(), chance.word(), chance.word()];
-            ticketsWithDepartments = [
-                {
-                    destination: {
-                        department: departmentNames[0],
-                        departmentStatus: departmentStatusNames[0],
-                    }
-                },
-                {
-                    destination: {
-                        department: departmentNames[1],
-                        departmentStatus: departmentStatusNames[1],
-                    }
-                },
-                {
-                    destination: {
-                        department: departmentNames[2],
-                        departmentStatus: departmentStatusNames[2],
-                    }
-                }
-            ];
-            ticketsWithoutDepartments = [{}, {}, {}, {}, {}];
+        it('should generate correct number of departments in the datastructure even if no tickets were passed in', () => {
+            const emptyTicketsArray = [];
+            const groupedTicketsByDepartment = ticketService.groupTicketsByDestination(emptyTicketsArray);
 
-            allTickets = [...ticketsWithDepartments, ...ticketsWithoutDepartments];
+            expect(Object.keys(groupedTicketsByDepartment).length).toEqual(allDepartmentsWithAtLeastOneDepartmentStatus.length);
         });
 
-        it('should generate correct department names', () => {
-            console.log(`allTickets => ${JSON.stringify(allTickets)}`);
-            const groupedTicketsByDepartment = ticketService.groupTicketsByDestination(allTickets);
+        it('should generate correct number of departmentsStatuses in the datastructure even if no tickets were passed in', () => {
+            const emptyTicketsArray = [];
+            const groupedTicketsByDepartment = ticketService.groupTicketsByDestination(emptyTicketsArray);
 
-            console.log(groupedTicketsByDepartment);
-
-            expect(Object.keys(groupedTicketsByDepartment).length).toEqual(departmentNames.length);
-            expect(Object.keys(groupedTicketsByDepartment)).toEqual(expect.arrayContaining([departmentNames[0], departmentNames[1], departmentNames[2]]));
+            expect(Object.keys(groupedTicketsByDepartment).length).toEqual(allDepartmentsWithAtLeastOneDepartmentStatus.length);
+            expect(Object.keys(groupedTicketsByDepartment).sort()).toEqual(allDepartmentsWithAtLeastOneDepartmentStatus.sort());
         });
 
         it('should map list of tickets according to department', () => {
-            const groupedTicketsByDepartment = ticketService.groupTicketsByDestination(allTickets);
+            const emptyTicketsArray = [];
+            const groupedTicketsByDepartment = ticketService.groupTicketsByDestination(emptyTicketsArray);
+            let departmentStatusesInDataStructure = [];
 
-            expect(Object.keys(groupedTicketsByDepartment).length).toBe(departmentNames.length);
+            Object.keys(groupedTicketsByDepartment).forEach((departmentName) => {
+                const group = groupedTicketsByDepartment[departmentName];
+
+                departmentStatusesInDataStructure = [
+                    ...departmentStatusesInDataStructure,
+                    ...Object.keys(group)
+                ]; 
+            });
+
+            console.log(departmentStatusesInDataStructure);
+
+            expect(departmentStatusesInDataStructure.length).toBe(getAllDepartmentStatuses().length);
         });
 
         it('should ignore tickets whose department and/or departmentStatus is unknown', () => {
-            const numberOfTicketsWithAValidDepartmentAndDepartmentStatus = allTickets.length;
+            const validTickets = chance.n(buildATicketWithAValidDesintation, chance.integer({min: 0, max: 100}));
+            const invalidTickets = chance.n(buildTicketWithoutAValidDestination, chance.integer({min: 0, max: 100}));
+            
+            const tickets = [...validTickets, ...invalidTickets];
 
-            ticketsWithoutADepartmentOrDepartmentStatus = [
-                {
-                    destination: {
-                        department: chance.word(),
-                        departmentStatus: undefined,
-                    }
-                },
-                {
-                    destination: {
-                        department: undefined,
-                        departmentStatus: chance.word(),
-                    }
-                },
-                {
-                    destination: {
-                        department: undefined,
-                        departmentStatus: undefined,
-                    }
-                }
-            ];
+            const groupedTicketsByDepartment = ticketService.groupTicketsByDestination(tickets);
 
-            allTickets = [
-                ...allTickets,
-                ...ticketsWithoutADepartmentOrDepartmentStatus
-            ];
-            const groupedTicketsByDepartment = ticketService.groupTicketsByDestination(allTickets);
-
-            expect(groupedTicketsByDepartment.length).toBe(numberOfTicketsWithAValidDepartmentAndDepartmentStatus.length);
+            expect(countNumberOfTicketsGroupedByDestination(groupedTicketsByDepartment)).toBe(validTickets.length);
         });
     });
 });
+
+function countNumberOfTicketsGroupedByDestination(ticketsGroupedByDestination) {
+    let numberOfTickets = 0;
+
+    Object.keys(ticketsGroupedByDestination).forEach((department) => {
+        const departmentStatuses = Object.keys(ticketsGroupedByDestination[department]);
+        
+        departmentStatuses.forEach((departmentStatus) => {
+            numberOfTickets = numberOfTickets + ticketsGroupedByDestination[department][departmentStatus].length;
+        });
+    });
+
+    return numberOfTickets;
+}
+
+function buildATicketWithAValidDesintation() {
+    const departmentWithAtLeastOneDepartmentStatus = chance.pickone(getAllDepartmentsWithDepartmentStatuses());
+    const departmentStatus = chance.pickone(departmentStatusesGroupedByDepartment[departmentWithAtLeastOneDepartmentStatus]);
+
+    return {
+        destination: {
+            department: departmentWithAtLeastOneDepartmentStatus,
+            departmentStatus
+        }
+    };
+}
+
+function buildTicketWithoutAValidDestination() {
+    const invalidDepartment = chance.string();
+    const invalidDepartmentStatus = chance.string();
+
+    return {
+        destination: {
+            department: invalidDepartment,
+            departmentStatus: invalidDepartmentStatus
+        }
+    };
+}
 

--- a/test/services/ticketService.spec.js
+++ b/test/services/ticketService.spec.js
@@ -115,27 +115,29 @@ describe('ticketService test suite', () => {
         let ticketsWithoutDepartments;
         let allTickets;
         let departmentNames;
+        let departmentStatusNames;
+        let ticketsWithoutADepartmentOrDepartmentStatus;
 
         beforeEach(() => {
             departmentNames = [chance.word(), chance.word(), chance.word()];
-            subDepartmentNames = [chance.word(), chance.word(), chance.word()];
+            departmentStatusNames = [chance.word(), chance.word(), chance.word()];
             ticketsWithDepartments = [
                 {
                     destination: {
                         department: departmentNames[0],
-                        subDepartment: subDepartmentNames[0],
+                        departmentStatus: departmentStatusNames[0],
                     }
                 },
                 {
                     destination: {
                         department: departmentNames[1],
-                        subDepartment: subDepartmentNames[1],
+                        departmentStatus: departmentStatusNames[1],
                     }
                 },
                 {
                     destination: {
                         department: departmentNames[2],
-                        subDepartment: subDepartmentNames[2],
+                        departmentStatus: departmentStatusNames[2],
                     }
                 }
             ];
@@ -160,37 +162,37 @@ describe('ticketService test suite', () => {
             expect(Object.keys(groupedTicketsByDepartment).length).toBe(departmentNames.length);
         });
 
-        it('should ignore tickets whose department and/or subDepartment is unknown', () => {
-            const numberOfTicketsWithAValidDepartmentAndSubDepartment = allTickets.length;
+        it('should ignore tickets whose department and/or departmentStatus is unknown', () => {
+            const numberOfTicketsWithAValidDepartmentAndDepartmentStatus = allTickets.length;
 
-            ticketsWithoutADepartmentOrSubDepartment = [
+            ticketsWithoutADepartmentOrDepartmentStatus = [
                 {
                     destination: {
                         department: chance.word(),
-                        subDepartment: undefined,
+                        departmentStatus: undefined,
                     }
                 },
                 {
                     destination: {
                         department: undefined,
-                        subDepartment: chance.word(),
+                        departmentStatus: chance.word(),
                     }
                 },
                 {
                     destination: {
                         department: undefined,
-                        subDepartment: undefined,
+                        departmentStatus: undefined,
                     }
                 }
             ];
 
             allTickets = [
                 ...allTickets,
-                ...ticketsWithoutADepartmentOrSubDepartment
+                ...ticketsWithoutADepartmentOrDepartmentStatus
             ];
             const groupedTicketsByDepartment = ticketService.groupTicketsByDestination(allTickets);
 
-            expect(groupedTicketsByDepartment.length).toBe(numberOfTicketsWithAValidDepartmentAndSubDepartment.length);
+            expect(groupedTicketsByDepartment.length).toBe(numberOfTicketsWithAValidDepartmentAndDepartmentStatus.length);
         });
     });
 });


### PR DESCRIPTION
# Description

It was determined that the naming `subDepartment` throughout the code was not technically valid and was misleading.

Instead, it was determined that a better name was `DepartmentStatus`.


## Verification
![image](https://user-images.githubusercontent.com/42784674/199609181-051848fa-3703-48e7-8d30-1972ad6d1124.png)

> After changing the column name on the database table, all the old data essentially become outdated and no tickets which existed before appear on this page. This is because the old tickets have  a `subDepartment` attribute instead of the new `departmentStatus` attribute. This old data is not important so no migration will occur.

![image](https://user-images.githubusercontent.com/42784674/199609311-6aed73c4-6811-4cee-a151-f07b4e5ab750.png)
> After uploading a new ticket and setting its the `department` and new `departmentStatus` attribute, it is displayed correctly in the table