### PR TITLE
Track Changes to a Ticket Object's `department`/`DepartmentStatus` Attributes

### DIFF
--- a/application/models/WorkflowStep.js
+++ b/application/models/WorkflowStep.js
@@ -1,26 +1,6 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
-const {departmentStatusesGroupedByDepartment, getAllDepartments} = require('../enums/departmentsEnum');
-
-function isDepartmentAndDepartmentStatusCombinationValid() {
-    const lengthOfEmptyArray = 0;
-    const allowedStatuses = departmentStatusesGroupedByDepartment[this.department];
-    const noDepartmentStatusesExistForThisDepartment = allowedStatuses.length === lengthOfEmptyArray;
-
-    if (noDepartmentStatusesExistForThisDepartment) {
-        return true;
-    }
-
-    return allowedStatuses.includes(this.departmentStatus);
-}
-
-function isDepartmentValid(department) {
-    if (!getAllDepartments().includes(department)) {
-        return false;
-    }
-
-    return true;
-}
+const destinationSchema = require('../models/destination').schema;
 
 const workflowStepSchema = new Schema({
     ticketId: {
@@ -28,33 +8,10 @@ const workflowStepSchema = new Schema({
         ref: 'Ticket',
         required: true
     },
-    department: {
-        type: String,
-        required: true,
-        validate: [
-            {
-                validator: isDepartmentValid,
-                message: 'The department "{VALUE}" is not a valid department'
-            },
-            {
-                validator: isDepartmentAndDepartmentStatusCombinationValid,
-                message: 'The department "{VALUE}" is not allowed to be paired with the provided departmentStatus'
-            }
-        ]
-    },
-    departmentStatus: {
-        type: String,
-        required: false,
-        validate: [isDepartmentAndDepartmentStatusCombinationValid, 'The departmentStatus "{VALUE}" is not allowed to be paired with the provided department']
-    },
-    assignees: {
-        type: [Schema.Types.ObjectId],
-        ref: 'User'
-    },
-    machines: {
-        type: [Schema.Types.ObjectId],
-        ref: 'Machine',
-    },
+    destination: {
+        type: destinationSchema,
+        required: true
+    }
 }, { timestamps: true });
 
 const WorkflowStep = mongoose.model('WorkflowStep', workflowStepSchema);

--- a/application/models/destination.js
+++ b/application/models/destination.js
@@ -1,0 +1,56 @@
+const mongoose = require('mongoose');
+mongoose.Schema.Types.String.set('trim', true);
+const Schema = mongoose.Schema;
+const {getAllDepartments, departmentStatusesGroupedByDepartment} = require('../enums/departmentsEnum');
+
+function isDepartmentAndDepartmentStatusCombinationValid() {
+    const lengthOfEmptyArray = 0;
+    const allowedStatuses = departmentStatusesGroupedByDepartment[this.department];
+    const noDepartmentStatusesExistForThisDepartment = allowedStatuses.length === lengthOfEmptyArray;
+
+    if (noDepartmentStatusesExistForThisDepartment && !this.departmentStatus) {
+        return true;
+    }
+
+    return allowedStatuses.includes(this.departmentStatus);
+}
+
+function isDepartmentValid(department) {
+    if (!getAllDepartments().includes(department)) {
+        return false;
+    }
+
+    return true;
+}
+
+const destinationSchema = new Schema({
+    department: {
+        type: String,
+        validate: [
+            {
+                validator: isDepartmentValid,
+                message: 'The department "{VALUE}" is not a valid department'
+            },
+            {
+                validator: isDepartmentAndDepartmentStatusCombinationValid,
+                message: 'The department "{VALUE}" is not allowed to be paired with the provided departmentStatus'
+            }
+        ]
+    },
+    departmentStatus: {
+        type: String,
+        validate: [isDepartmentAndDepartmentStatusCombinationValid, 'The departmentStatus "{VALUE}" is not allowed to be paired with the provided department']
+    },
+    assignees: {
+        type: [Schema.Types.ObjectId],
+        ref: 'User'
+    },
+    machines: {
+        type: [Schema.Types.ObjectId],
+        ref: 'Machine'
+    }
+}, { timestamps: true });
+
+const Destination = mongoose.model('Destination', destinationSchema);
+
+module.exports = Destination;

--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -301,7 +301,7 @@ ticketSchema.pre('updateOne', async function(next) {
         ticketId,
         department,
         departmentStatus
-    }
+    };
 
     if (!destination) {
         return next();
@@ -309,11 +309,11 @@ ticketSchema.pre('updateOne', async function(next) {
 
     try {
         await addRowToWorkflowStepDbTable(workflowStepAttributes);
-    } catch(error) {
+    } catch (error) {
         console.log(`Error during mongoose ticketSchema.pre('updateOne') hook: ${error}; attributes used: ${JSON.stringify(workflowStepAttributes)}`);
         return next(error);
     }
-})
+});
 
 ticketSchema.pre('findOneAndUpdate', async function(next) {
     const destination = this.getUpdate().$set.destination;
@@ -324,7 +324,7 @@ ticketSchema.pre('findOneAndUpdate', async function(next) {
         ticketId,
         department,
         departmentStatus
-    }
+    };
 
     if (!destination) {
         return next();
@@ -332,7 +332,7 @@ ticketSchema.pre('findOneAndUpdate', async function(next) {
 
     try {
         await addRowToWorkflowStepDbTable(workflowStepAttributes);
-    } catch(error) {
+    } catch (error) {
         console.log(`Error during mongoose ticketSchema.pre('findOneAndUpdate') hook: ${error}; attributes used: ${JSON.stringify(workflowStepAttributes)}`);
         return next(error);
     }

--- a/test/models/destination.spec.js
+++ b/test/models/destination.spec.js
@@ -9,7 +9,7 @@ const DEPARTMENT_WITHOUT_STATUSES = 'COMPLETED';
 describe('validation', () => {
     let destinationAttributes;
 
-    beforeEach(() => {
+    beforeEach(async () => {
         let department = DEPARTMENT_WITH_STATUSES;
         let departmentStatus = chance.pickone(departmentStatusesGroupedByDepartment[department]);
 
@@ -21,12 +21,17 @@ describe('validation', () => {
         };
     });
 
-    it('should validate if all attributes are defined successfully', () => {
+    it('should validate if all attributes are defined successfully', async () => {
+        let validationError;
         const destination = new Destination(destinationAttributes);
-    
-        const error = destination.validateSync();
 
-        expect(error).toBe(undefined);
+        try {
+            await destination.validate();
+        } catch (error) {
+            validationError = error;
+        }
+
+        expect(validationError).toBe(undefined);
     });
 
     describe('attribute: department', () => {
@@ -36,48 +41,68 @@ describe('validation', () => {
             expect(destination.department).toEqual(expect.any(String));
         });
 
-        it('should fail if attribute is not defined', () => {
+        it('should fail if attribute is not defined', async () => {
             delete destinationAttributes.department;
             const destination = new Destination(destinationAttributes);
+            let validationError;
 
-            const error = destination.validateSync();
+            try {
+                await destination.validate();
+            } catch (error) {
+                validationError = error;
+            }
 
-            expect(error).not.toBe(undefined);
+            expect(validationError).not.toBe(undefined);
         });
 
-        it('should fail if attribute is NOT an accepted value', () => {
+        it('should fail if attribute is NOT an accepted value', async () => {
             const invalidDepartment = chance.string();
             destinationAttributes.department = invalidDepartment;
             const destination = new Destination(destinationAttributes);
+            let validationError;
 
-            const error = destination.validateSync();
+            try {
+                await destination.validate();
+            } catch (error) {
+                validationError = error;
+            }
 
-            expect(error).not.toBe(undefined);
+            expect(validationError).not.toBe(undefined);
         });
 
-        it('should pass if attribute IS an accepted value', () => {
+        it('should pass if attribute IS an accepted value', async () => {
             const validDepartment = DEPARTMENT_WITH_STATUSES;
             const validStatus = chance.pickone(departmentStatusesGroupedByDepartment[validDepartment]);
             destinationAttributes.department = validDepartment;
             destinationAttributes.departmentStatus = validStatus;
             const destination = new Destination(destinationAttributes);
+            let validationError;
 
-            const error = destination.validateSync();
+            try {
+                await destination.validate();
+            } catch (error) {
+                validationError = error;
+            }
 
-            expect(error).toBe(undefined);
+            expect(validationError).toBe(undefined);
         });
 
-        it('should pass if attribute IS an accepted value surrounded by whitespace', () => {
+        it('should pass if attribute IS an accepted value surrounded by whitespace', async () => {
             const whitespaceToTrim = '  ';
             const validDepartment = DEPARTMENT_WITH_STATUSES;
             const validStatus = chance.pickone(departmentStatusesGroupedByDepartment[validDepartment]);
             destinationAttributes.department = whitespaceToTrim + validDepartment + whitespaceToTrim;
             destinationAttributes.departmentStatus = whitespaceToTrim + validStatus + whitespaceToTrim;
             const destination = new Destination(destinationAttributes);
+            let validationError;
 
-            const error = destination.validateSync();
+            try {
+                await destination.validate();
+            } catch (error) {
+                validationError = error;
+            }
 
-            expect(error).toBe(undefined);
+            expect(validationError).toBe(undefined);
         });
     });
 
@@ -88,34 +113,49 @@ describe('validation', () => {
             expect(destination.departmentStatus).toEqual(expect.any(String));
         });
 
-        it('should fail if departmentStatus is not a valid departmentStatus a given department', () => {
+        it('should fail if departmentStatus is not a valid departmentStatus a given department', async () => {
             const invalidDepartmentStatus = chance.string();
             destinationAttributes.departmentStatus = invalidDepartmentStatus;
             const destination = new Destination(destinationAttributes);
+            let validationError;
 
-            const error = destination.validateSync();
+            try {
+                await destination.validate();
+            } catch (error) {
+                validationError = error;
+            }
 
-            expect(error).not.toBe(undefined);
+            expect(validationError).not.toBe(undefined);
         });
 
-        it('should pass if departmentStatus is left blank because the department has no statuses', () => {
+        it('should pass if departmentStatus is left blank because the department has no statuses', async () => {
             destinationAttributes.department = DEPARTMENT_WITHOUT_STATUSES;
             delete destinationAttributes.departmentStatus;
             const destination = new Destination(destinationAttributes);
+            let validationError;
 
-            const error = destination.validateSync();
+            try {
+                await destination.validate();
+            } catch (error) {
+                validationError = error;
+            }
 
-            expect(error).toBe(undefined);
+            expect(validationError).toBe(undefined);
         });
 
-        it('should fail if departmentStatus is not an allowed status for the given department', () => {
+        it('should fail if departmentStatus is not an allowed status for the given department', async () => {
             destinationAttributes.department = DEPARTMENT_WITH_STATUSES;
             delete destinationAttributes.departmentStatus;
             const destination = new Destination(destinationAttributes);
+            let validationError;
 
-            const error = destination.validateSync();
+            try {
+                await destination.validate();
+            } catch (error) {
+                validationError = error;
+            }
 
-            expect(error).not.toBe(undefined);
+            expect(validationError).not.toBe(undefined);
         });
     });
 

--- a/test/models/destination.spec.js
+++ b/test/models/destination.spec.js
@@ -1,0 +1,159 @@
+const chance = require('chance').Chance();
+const Destination = require('../../application/models/destination');
+const {departmentStatusesGroupedByDepartment} = require('../../application/enums/departmentsEnum');
+const mongoose = require('mongoose');
+
+const DEPARTMENT_WITH_STATUSES = 'PRINTING';
+const DEPARTMENT_WITHOUT_STATUSES = 'COMPLETED';
+
+describe('validation', () => {
+    let destinationAttributes;
+
+    beforeEach(() => {
+        let department = DEPARTMENT_WITH_STATUSES;
+        let departmentStatus = chance.pickone(departmentStatusesGroupedByDepartment[department]);
+
+        destinationAttributes = {
+            department: department,
+            departmentStatus: departmentStatus,
+            assignees: [],
+            machines: []
+        };
+    });
+
+    it('should validate if all attributes are defined successfully', () => {
+        const destination = new Destination(destinationAttributes);
+    
+        const error = destination.validateSync();
+
+        expect(error).toBe(undefined);
+    });
+
+    describe('attribute: department', () => {
+        it('should be of type String', () => {
+            const destination = new Destination(destinationAttributes);
+
+            expect(destination.department).toEqual(expect.any(String));
+        });
+
+        it('should fail if attribute is not defined', () => {
+            delete destinationAttributes.department;
+            const destination = new Destination(destinationAttributes);
+
+            const error = destination.validateSync();
+
+            expect(error).not.toBe(undefined);
+        });
+
+        it('should fail if attribute is NOT an accepted value', () => {
+            const invalidDepartment = chance.string();
+            destinationAttributes.department = invalidDepartment;
+            const destination = new Destination(destinationAttributes);
+
+            const error = destination.validateSync();
+
+            expect(error).not.toBe(undefined);
+        });
+
+        it('should pass if attribute IS an accepted value', () => {
+            const validDepartment = DEPARTMENT_WITH_STATUSES;
+            const validStatus = chance.pickone(departmentStatusesGroupedByDepartment[validDepartment]);
+            destinationAttributes.department = validDepartment;
+            destinationAttributes.departmentStatus = validStatus;
+            const destination = new Destination(destinationAttributes);
+
+            const error = destination.validateSync();
+
+            expect(error).toBe(undefined);
+        });
+
+        it('should pass if attribute IS an accepted value surrounded by whitespace', () => {
+            const whitespaceToTrim = '  ';
+            const validDepartment = DEPARTMENT_WITH_STATUSES;
+            const validStatus = chance.pickone(departmentStatusesGroupedByDepartment[validDepartment]);
+            destinationAttributes.department = whitespaceToTrim + validDepartment + whitespaceToTrim;
+            destinationAttributes.departmentStatus = whitespaceToTrim + validStatus + whitespaceToTrim;
+            const destination = new Destination(destinationAttributes);
+
+            const error = destination.validateSync();
+
+            expect(error).toBe(undefined);
+        });
+    });
+
+    describe('attribute: departmentStatus', () => {
+        it('should be of type String', () => {
+            const destination = new Destination(destinationAttributes);
+
+            expect(destination.departmentStatus).toEqual(expect.any(String));
+        });
+
+        it('should fail if departmentStatus is not a valid departmentStatus a given department', () => {
+            const invalidDepartmentStatus = chance.string();
+            destinationAttributes.departmentStatus = invalidDepartmentStatus;
+            const destination = new Destination(destinationAttributes);
+
+            const error = destination.validateSync();
+
+            expect(error).not.toBe(undefined);
+        });
+
+        it('should pass if departmentStatus is left blank because the department has no statuses', () => {
+            destinationAttributes.department = DEPARTMENT_WITHOUT_STATUSES;
+            delete destinationAttributes.departmentStatus;
+            const destination = new Destination(destinationAttributes);
+
+            const error = destination.validateSync();
+
+            expect(error).toBe(undefined);
+        });
+
+        it('should fail if departmentStatus is not an allowed status for the given department', () => {
+            destinationAttributes.department = DEPARTMENT_WITH_STATUSES;
+            delete destinationAttributes.departmentStatus;
+            const destination = new Destination(destinationAttributes);
+
+            const error = destination.validateSync();
+
+            expect(error).not.toBe(undefined);
+        });
+    });
+
+    describe('attribute: assignees', () => {
+        it('should have one element which is a valid mongoose objectId', () => {
+            destinationAttributes.assignees = [
+                new mongoose.Types.ObjectId()
+            ];
+            const destination = new Destination(destinationAttributes);
+
+            expect(mongoose.Types.ObjectId.isValid(destination.assignees[0])).toBe(true);
+        });
+
+        it('should default to an empty array if attribute is not defined', () => {
+            delete destinationAttributes.assignees;
+            const emptyArray = [];
+            const destination = new Destination(destinationAttributes);
+
+            expect(destination.assignees).toEqual(emptyArray);
+        });
+    });
+
+    describe('attribute: machines', () => {
+        it('should have one element which is a valid mongoose objectId', () => {
+            destinationAttributes.machines = [
+                new mongoose.Types.ObjectId()
+            ];
+            const destination = new Destination(destinationAttributes);
+
+            expect(mongoose.Types.ObjectId.isValid(destination.machines[0])).toBe(true);
+        });
+
+        it('should default to an empty array if attribute is not defined', () => {
+            delete destinationAttributes.machines;
+            const emptyArray = [];
+            const destination = new Destination(destinationAttributes);
+
+            expect(destination.machines).toEqual(emptyArray);
+        });
+    });
+});

--- a/test/models/ticket.spec.js
+++ b/test/models/ticket.spec.js
@@ -1,6 +1,5 @@
 const chance = require('chance').Chance();
 const TicketModel = require('../../application/models/ticket');
-const {departmentStatusesGroupedByDepartment} = require('../../application/enums/departmentsEnum');
 const databaseService = require('../../application/services/databaseService');
 const {standardPriority, getAllPriorities} = require('../../application/enums/priorityEnum');
 
@@ -550,13 +549,7 @@ describe('validation', () => {
     });
 
     describe('attribute: destination', () => {
-        it('should contain attribute', () => {
-            const ticket = new TicketModel(ticketAttributes);
-
-            expect(ticket.destination).toBeDefined();
-        });
-
-        it('should pass validation if attribute is missing', () => {
+        it('should pass validation if attribute is not defined', () => {
             delete ticketAttributes.destination;
             const ticket = new TicketModel(ticketAttributes);
 
@@ -565,23 +558,8 @@ describe('validation', () => {
             expect(error).toBe(undefined);
         });
 
-        it('should pass validation if attribute exists but department/departmentStatus are both not defined', () => {
-            ticketAttributes.destination = {};
-            const ticket = new TicketModel(ticketAttributes);
-
-            const error = ticket.validateSync();
-
-            expect(error).toBe(undefined);
-        });
-
-        it('should fail validation if departmentStatus attribute IS NOT an accepted value', () => {
-            const validDepartment = 'PRE-PRESS';
-            const invalidDepartmentStatus = chance.string();
-
-            ticketAttributes.destination = {
-                department: validDepartment,
-                departmentStatus: invalidDepartmentStatus
-            };
+        it('should fail validation if attribute is not the correct type', () => {
+            ticketAttributes.destination = chance.word();
             const ticket = new TicketModel(ticketAttributes);
 
             const error = ticket.validateSync();
@@ -589,82 +567,10 @@ describe('validation', () => {
             expect(error).not.toBe(undefined);
         });
 
-        it('should fail validation if department attribute IS NOT an accepted value', () => {
-            const validDepartment = 'ART-PREP';
-            const invalidDepartment = chance.string();
-            const validDepartmentStatus = chance.pickone(departmentStatusesGroupedByDepartment[validDepartment]);
-
-            ticketAttributes.destination = {
-                department: invalidDepartment,
-                departmentStatus: validDepartmentStatus
-            };
+        it('should be a mongoose object with an _id attribute', () => {
             const ticket = new TicketModel(ticketAttributes);
 
-            const error = ticket.validateSync();
-
-            expect(error).not.toBe(undefined);
-        });
-
-        it('should fail validation if exactly one of either department or departmentStatus is left blank', () => {
-            const validDepartment = 'ORDER PREP';
-            const invalidDepartmentStatus = undefined;
-
-            ticketAttributes.destination = {
-                department: validDepartment,
-                departmentStatus: invalidDepartmentStatus
-            };
-
-            const ticket = new TicketModel(ticketAttributes);
-
-            const error = ticket.validateSync();
-
-            expect(error).not.toBe(undefined);
-        });
-
-        it('should fail validation if department is COMPLETED and departmentStatus is defined', () => {
-            const validDepartment = 'COMPLETED';
-            const invalidDepartmentStatus = chance.word();
-    
-            ticketAttributes.destination = {
-                department: validDepartment,
-                departmentStatus: invalidDepartmentStatus
-            };
-    
-            const ticket = new TicketModel(ticketAttributes);
-    
-            const error = ticket.validateSync();
-    
-            expect(error).not.toBe(undefined);
-        });
-
-        it('should pass validation if department is COMPLETED and departmentStatus not defined', () => {
-            const validDepartment = 'COMPLETED';
-
-            ticketAttributes.destination = {
-                department: validDepartment
-            };
-
-            const ticket = new TicketModel(ticketAttributes);
-
-            const error = ticket.validateSync();
-
-            expect(error).toBe(undefined);
-        });
-
-        it('should fail validation if departmentStatus is not a valid departmentStatus for the provided department', () => {
-            const orderPrepDepartment = 'ORDER-PREP';
-            const billingDepartmentStatus = 'READY FOR BILLING';
-    
-            ticketAttributes.destination = {
-                department: orderPrepDepartment,
-                departmentStatus: billingDepartmentStatus
-            };
-    
-            const ticket = new TicketModel(ticketAttributes);
-    
-            const error = ticket.validateSync();
-    
-            expect(error).not.toBe(undefined);
+            expect(ticket.destination._id).not.toBe(undefined);
         });
     });
 

--- a/test/models/workflowStep.spec.js
+++ b/test/models/workflowStep.spec.js
@@ -1,10 +1,9 @@
 const chance = require('chance').Chance();
 const WorkflowStep = require('../../application/models/WorkflowStep');
-const {getAllDepartmentStatuses, departmentStatusesGroupedByDepartment} = require('../../application/enums/departmentsEnum');
+const {departmentStatusesGroupedByDepartment} = require('../../application/enums/departmentsEnum');
 const mongoose = require('mongoose');
 
 const DEPARTMENT_WITH_STATUSES = 'PRINTING';
-const DEPARTMENT_WITHOUT_STATUSES = 'COMPLETED';
 
 describe('validation', () => {
     let workFlowStepAttributes;
@@ -15,10 +14,12 @@ describe('validation', () => {
 
         workFlowStepAttributes = {
             ticketId: new mongoose.Types.ObjectId(),
-            department: department,
-            departmentStatus: departmentStatus,
-            assignees: [],
-            machines: []
+            destination: {
+                department: department,
+                departmentStatus: departmentStatus,
+                assignees: [],
+                machines: []
+            }
         };
     });
 
@@ -46,15 +47,10 @@ describe('validation', () => {
             expect(mongoose.Types.ObjectId.isValid(workflowStep.ticketId)).toBe(true);
         });
     });
-    describe('attribute: department', () => {
-        it('should be of type String', () => {
-            const workflowStep = new WorkflowStep(workFlowStepAttributes);
 
-            expect(workflowStep.department).toEqual(expect.any(String));
-        });
-
-        it('should fail if attribute is not defined', () => {
-            delete workFlowStepAttributes.department;
+    describe('attribute: destination', () => {
+        it('should fail validation if attribute is not defined', () => {
+            delete workFlowStepAttributes.destination;
             const workflowStep = new WorkflowStep(workFlowStepAttributes);
 
             const error = workflowStep.validateSync();
@@ -62,9 +58,8 @@ describe('validation', () => {
             expect(error).not.toBe(undefined);
         });
 
-        it('should fail if attribute is NOT an accepted value', () => {
-            const invalidDepartment = chance.string();
-            workFlowStepAttributes.department = invalidDepartment;
+        it('should fail validation if attribute is not the correct type', () => {
+            workFlowStepAttributes.destination = chance.word();
             const workflowStep = new WorkflowStep(workFlowStepAttributes);
 
             const error = workflowStep.validateSync();
@@ -72,101 +67,10 @@ describe('validation', () => {
             expect(error).not.toBe(undefined);
         });
 
-        it('should pass if attribute IS an accepted value', () => {
-            const validDepartment = DEPARTMENT_WITH_STATUSES;
-            const validStatus = chance.pickone(departmentStatusesGroupedByDepartment[validDepartment]);
-            workFlowStepAttributes.department = validDepartment;
-            workFlowStepAttributes.departmentStatus = validStatus;
+        it('should be a mongoose object with an _id attribute', () => {
             const workflowStep = new WorkflowStep(workFlowStepAttributes);
 
-            const error = workflowStep.validateSync();
-
-            expect(error).toBe(undefined);
-        });
-    });
-    describe('attribute: departmentStatus', () => {
-        it('should be of type String', () => {
-            const workflowStep = new WorkflowStep(workFlowStepAttributes);
-
-            expect(workflowStep.departmentStatus).toEqual(expect.any(String));
-        });
-
-        it('should fail if departmentStatus is not a valid departmentStatus a given department', () => {
-            const invalidDepartmentStatus = chance.string();
-            workFlowStepAttributes.departmentStatus = invalidDepartmentStatus;
-            const workflowStep = new WorkflowStep(workFlowStepAttributes);
-
-            const error = workflowStep.validateSync();
-
-            expect(error).not.toBe(undefined);
-        });
-
-        it('should pass if attribute IS an accepted value', () => {
-            const validDepartmentStatus = chance.pickone(getAllDepartmentStatuses());
-            workFlowStepAttributes.status = validDepartmentStatus;
-            const workflowStep = new WorkflowStep(workFlowStepAttributes);
-
-            const error = workflowStep.validateSync();
-
-            expect(error).toBe(undefined);
-        });
-
-        it('should pass if departmentStatus is left blank because the department has no statuses', () => {
-            workFlowStepAttributes.department = DEPARTMENT_WITHOUT_STATUSES;
-            delete workFlowStepAttributes.departmentStatus;
-            const workflowStep = new WorkflowStep(workFlowStepAttributes);
-
-            const error = workflowStep.validateSync();
-
-            expect(error).toBe(undefined);
-        });
-
-        it('should fail if departmentStatus is not an allowed status for the given department', () => {
-            workFlowStepAttributes.department = DEPARTMENT_WITH_STATUSES;
-            delete workFlowStepAttributes.departmentStatus;
-            const workflowStep = new WorkflowStep(workFlowStepAttributes);
-
-            const error = workflowStep.validateSync();
-
-            expect(error).not.toBe(undefined);
-        });
-    });
-
-    describe('attribute: assignees', () => {
-        it('should have one element which is a valid mongoose objectId', () => {
-            workFlowStepAttributes.assignees = [
-                new mongoose.Types.ObjectId()
-            ];
-            const workflowStep = new WorkflowStep(workFlowStepAttributes);
-
-            expect(mongoose.Types.ObjectId.isValid(workflowStep.assignees[0])).toBe(true);
-        });
-
-        it('should default to an empty array if attribute is not defined', () => {
-            delete workFlowStepAttributes.assignees;
-            const emptyArray = [];
-            const workflowStep = new WorkflowStep(workFlowStepAttributes);
-
-            expect(workflowStep.assignees).toEqual(emptyArray);
-        });
-    });
-
-    describe('attribute: machines', () => {
-        it('should have one element which is a valid mongoose objectId', () => {
-            workFlowStepAttributes.machines = [
-                new mongoose.Types.ObjectId()
-            ];
-            const workflowStep = new WorkflowStep(workFlowStepAttributes);
-
-            expect(mongoose.Types.ObjectId.isValid(workflowStep.machines[0])).toBe(true);
-        });
-
-        it('should default to an empty array if attribute is not defined', () => {
-            delete workFlowStepAttributes.machines;
-            const emptyArray = [];
-            const workflowStep = new WorkflowStep(workFlowStepAttributes);
-
-            expect(workflowStep.machines).toEqual(emptyArray);
+            expect(workflowStep.destination._id).not.toBe(undefined);
         });
     });
 });


### PR DESCRIPTION
# Description

Previously there were 2 NO-SQL database tables named `Ticket` and `WorkflowStep`.

On these two tables, there were shared attributes, namely `department`, `departmentStatus`, `assignees`, `machines`.

Instead of duplicating these attributes and their validations across these two tables, instead I decided to extract that duplicate logic into a new mongoose schema called `destination` and then reference that schema on both database tables.

The second thing this PR does is creates a new item in the `WorkflowStep` table IF a `Ticket` object has either of the `department` or `departmentStatus` attributes updated.

## Verification

After performing an update to a `Ticket`'s department/departmentStatus attribute, a new item is injected into the database table `workflowStep`

![image](https://user-images.githubusercontent.com/42784674/200195964-2dec3c45-b3c3-451c-b7bf-c817316eeff4.png)
> Update to `Ticket`'s department/departmentStatus attribute

![image](https://user-images.githubusercontent.com/42784674/200196018-11d75f5c-1c38-4a51-babe-889eecc6a4aa.png)
> New record is added to `WorkflowStep` database table

