### PR TITLE
Add/Update `PRODUCT` Attributes and Validation Rules

### DIFF
--- a/application/models/product.js
+++ b/application/models/product.js
@@ -15,6 +15,25 @@ const NUMBER_OF_DECIMAL_PLACES_IN_CURRENCY = 2;
 const FRAME_REPEAT_SCALAR = 25.4;
 const FEET_PER_ROLL = 5000;
 
+function roundToNearestQuarterInch(valueInInches) {
+    const numberOfQuarterInchesPerInch = 4;
+
+    if (!valueInInches || numberOfQuarterInchesPerInch < 0) { // eslint-disable-line no-magic-numbers
+        return;
+    }
+
+    const numberOfQuarterInches = valueInInches * numberOfQuarterInchesPerInch;
+
+    const totalNumberOfQuarterInchesRoundedToNearestQuarterInch = roundValueToNearestDecimalPlace(numberOfQuarterInches, 0); // eslint-disable-line no-magic-numbers
+    const totalNumberOfInches = totalNumberOfQuarterInchesRoundedToNearestQuarterInch / numberOfQuarterInchesPerInch;
+
+    return totalNumberOfInches;
+}
+
+function isRollsFinishType(finishType) {
+    return finishType && finishType.toUpperCase() === 'ROLLS';
+}
+
 function cannotBeFalsy(value) {
     if (!value) {
         return false;
@@ -300,8 +319,15 @@ const schema = new Schema({
     },
     coreHeight: {
         type: Number,
+        default: function() {
+            if (!isRollsFinishType(this.finishType)) {
+                return;
+            }
+
+            return roundToNearestQuarterInch(this.labelsAcross);
+        },
         required: function() {
-            return this.finishType && this.finishType.toUpperCase() === 'ROLL';
+            return isRollsFinishType(this.finishType);
         }
     },
     labelRepeat: {

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -524,6 +524,12 @@ const schema = new Schema({
         default: function(){
             return this.labelRepeat;
         }
+    },
+    numberOfCores: {
+        type: Number,
+        default: function() {
+            return Math.ceil(this.labelQty / this.labelsPerRoll);
+        }
     }
 }, { timestamps: true });
 

--- a/application/views/viewOneProduct.ejs
+++ b/application/views/viewOneProduct.ejs
@@ -376,7 +376,7 @@
                     <label># of Cores: </label>
                 </div>
                 <div class="flex-center-center-row full-width">
-                    <span><%= product.numberOfRolls || 'N/A' %> (AS)</span>
+                    <span><%= product.numberOfCores || 'N/A' %> (AS)</span>
                 </div>
             </div>
             <div class="card quarter-width">

--- a/application/views/viewOneProduct.ejs
+++ b/application/views/viewOneProduct.ejs
@@ -384,7 +384,7 @@
                     <label>Overrun: </label>
                 </div>
                 <div class="flex-center-center-row full-width">
-                    <span>  <%= product.overRun || 'N/A' %> (AT)</span>
+                    <span>  <%= product.overRun * 100 %>% (AT)</span>
                 </div>
             </div>
             <div class="card quarter-width">

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -938,26 +938,64 @@ describe('validation', () => {
     });
 
     describe('attribute: coreHeight', () => {
-        it('should be required if FinishType attribute equals "Roll"', () => {
-            productAttributes.FinishType = 'Roll';
-            delete productAttributes.coreHeight;
+        const ROLLS_FINISH_TYPE = 'RoLLs';
+
+        it('should be defined if FinishType attribute equals "Rolls"', () => {
+            productAttributes.FinishType = ROLLS_FINISH_TYPE;
 
             const product = new ProductModel(productAttributes);
 
-            const error = product.validateSync();
-
-            expect(error).not.toBe(undefined);
+            expect(product.coreHeight).not.toBe(undefined);
         });
 
-        it('should NOT BE required if FinishType DOES NOT equal "Roll"', () => {
-            productAttributes.FinishType = chance.string();
-            delete productAttributes.coreHeight;
+        it('should NOT be defined if "FinishType" DOES NOT equals "Rolls"', () => {
+            productAttributes.FinishType = chance.string;
 
+            const product = new ProductModel(productAttributes);
+
+            expect(product.coreHeight).toBe(undefined);
+        });
+
+        it('should validate correct when FinishType is "Rolls" and coreHeight was calculated', () => {
+            productAttributes.FinishType = ROLLS_FINISH_TYPE;
             const product = new ProductModel(productAttributes);
 
             const error = product.validateSync();
 
             expect(error).toBe(undefined);
+        });
+
+        it('should be equal to the attribute labelAcross but rounded to the nearest quarter inch (test 1)', () => {
+            const labelAcross = 6.69;
+            const expectedCoreHeight = 6.75;
+            productAttributes.FinishType = ROLLS_FINISH_TYPE;
+            productAttributes.NoAcross = labelAcross;
+
+            const product = new ProductModel(productAttributes);
+
+            expect(product.coreHeight).toBe(expectedCoreHeight);
+        });
+
+        it('should be equal to the attribute labelAcross but rounded to the nearest quarter inch (test 2)', () => {
+            const labelAcross = 0.05;
+            const expectedCoreHeight = 0;
+            productAttributes.FinishType = ROLLS_FINISH_TYPE;
+            productAttributes.NoAcross = labelAcross;
+
+            const product = new ProductModel(productAttributes);
+
+            expect(product.coreHeight).toBe(expectedCoreHeight);
+        });
+
+        it('should be equal to the attribute labelAcross but rounded to the nearest quarter inch (test 3)', () => {
+            const labelAcross = 11.251;
+            const expectedCoreHeight = 11.25;
+            productAttributes.FinishType = ROLLS_FINISH_TYPE;
+            productAttributes.NoAcross = labelAcross;
+
+            const product = new ProductModel(productAttributes);
+
+            expect(product.coreHeight).toBe(expectedCoreHeight);
         });
     });
 

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -1971,4 +1971,54 @@ describe('validation', () => {
             expect(product.deltaRepeat).toEqual(expectedValue);
         });
     });
+
+    describe('attribute: numberOfCores', () => {
+        it('should contain attribute', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.numberOfCores).toBeDefined();
+        });
+
+        it('should be of type Number', () => {
+            const product = new ProductModel(productAttributes);
+
+            expect(product.numberOfCores).toEqual(expect.any(Number));
+        });
+
+        it('should be calculated correctly according to formula: ceil(labelQuantity / labelsPerRoll) [test 1]', () => {
+            const labelQuantity = 100;
+            const labelsPerRoll = 9;
+            productAttributes.OrderQuantity = labelQuantity;
+            productAttributes.LabelsPer_ = labelsPerRoll;
+            const expectedNumberOfCores = 12;
+
+            const product = new ProductModel(productAttributes);
+
+            expect(product.numberOfCores).toEqual(expectedNumberOfCores);
+        });
+
+        it('should be calculated correctly according to formula: ceil(labelQuantity / labelsPerRoll) [test 2]', () => {
+            const labelQuantity = 5;
+            const labelsPerRoll = 5;
+            productAttributes.OrderQuantity = labelQuantity;
+            productAttributes.LabelsPer_ = labelsPerRoll;
+            const expectedNumberOfCores = 1;
+
+            const product = new ProductModel(productAttributes);
+
+            expect(product.numberOfCores).toEqual(expectedNumberOfCores);
+        });
+
+        it('should be calculated correctly according to formula: ceil(labelQuantity / labelsPerRoll) [test 3]', () => {
+            const labelQuantity = 1;
+            const labelsPerRoll = 5;
+            productAttributes.OrderQuantity = labelQuantity;
+            productAttributes.LabelsPer_ = labelsPerRoll;
+            const expectedNumberOfCores = 1;
+
+            const product = new ProductModel(productAttributes);
+
+            expect(product.numberOfCores).toEqual(expectedNumberOfCores);
+        });
+    });
 });


### PR DESCRIPTION
# Description

This updates 2 product level attributes and updates those attribute's validation rules. The attributes are:
  1. product.coreHeight
  2. product.numberOfCores

This PR also updates how the attribute product.coreHeight is displayed on the UI. Previously it was displayed as a decimal between 0 and 1. Instead, we wish to display it as a percentage, so this PR makes that change.

## Verification

![image](https://user-images.githubusercontent.com/42784674/200205576-cc817cb0-ac39-4330-973e-19cb9cdddee7.png)
> This screenshot shows the 3 attributes after my changes