### PR TITLE
perform batch db query to improve performance

### DIFF
--- a/application/services/workflowStepService.js
+++ b/application/services/workflowStepService.js
@@ -82,10 +82,10 @@ function updateWorkflowStepTimeLedger(workflowStepTimeLedger, workflowStep, time
 }
 
 module.exports.computeTimeTicketsHaveSpentInEachWorkflowStep = async () => {
-    const searchQueryThatExcludesTicketsWithoutADestinationOrCompletedTickets = { $or:[ {'destination': null}, {'destination.department': { $ne: COMPLETE_DEPARTMENT } } ] };
+    const searchQueryThatExcludesTicketsWithoutADestinationAndCompletedTickets = { $or:[ {'destination': null}, {'destination.department': { $ne: COMPLETE_DEPARTMENT } } ] };
 
     const ticketIds = await TicketModel
-        .find(searchQueryThatExcludesTicketsWithoutADestinationOrCompletedTickets)
+        .find(searchQueryThatExcludesTicketsWithoutADestinationAndCompletedTickets)
         .distinct('_id')
         .exec();
 

--- a/test/services/workflowStepService.spec.js
+++ b/test/services/workflowStepService.spec.js
@@ -7,6 +7,14 @@ const TIME_PER_DEPARTMENT_STATUS = 'timePerDepartmentStatus';
 
 describe('workflowStepService test suite', () => {
     describe('getOverallTicketDuration()', () => {
+        it('should return undefined if the workflowStepLedger is undefined', () => {
+            let workflowStepLedger;
+
+            const actualDuration = workflowStepService.getOverallTicketDuration(workflowStepLedger);
+
+            expect(actualDuration).toBe(undefined);
+        });
+
         it('should return 0 if the workflowStepLedger is empty', () => {
             const workflowStepLedger = {};
             const expectedDuration = 0;
@@ -38,6 +46,13 @@ describe('workflowStepService test suite', () => {
     });
 
     describe('getHowLongTicketHasBeenInProduction()', () => {
+        it('should return undefined if workflowStepLedger is undefined', () => {
+            let workflowStepLedger;
+
+            const actualDuration = workflowStepService.getHowLongTicketHasBeenInProduction(workflowStepLedger);
+
+            expect(actualDuration).toBe(undefined);
+        });
 
         it('should return 0 if ticket has not been in a production department', () => {
             const nonProductionDepartments = getNonProductionDepartments();
@@ -80,6 +95,14 @@ describe('workflowStepService test suite', () => {
     });
 
     describe('getHowLongTicketHasBeenInDepartment()', () => {
+        it('should return undefined if workflowStepLedger is undefined', () => {
+            let workflowStepLedger;
+
+            const actualDuration = workflowStepService.getHowLongTicketHasBeenInDepartment(workflowStepLedger);
+
+            expect(actualDuration).toBe(undefined);
+        });
+
         it ('should determine how long a ticket has been in the department correctly', () => {
             const department = chance.word();
             const timeSpentInDepartment = chance.floating({min: 0});
@@ -97,6 +120,14 @@ describe('workflowStepService test suite', () => {
     });
 
     describe('getHowLongTicketHasHadADepartmentStatus()', () => {
+        it('should return undefined if workflowStepLedger is undefined', () => {
+            let workflowStepLedger;
+
+            const actualDuration = workflowStepService.getHowLongTicketHasHadADepartmentStatus(workflowStepLedger);
+
+            expect(actualDuration).toBe(undefined);
+        });
+
         it ('should determine how long a ticket has been in the departmentStatus correctly', () => {
             const department = chance.word();
             const departmentStatus = chance.word();


### PR DESCRIPTION
# Description

Previously I had written code that looped over values in an array, and for each value, a unique HTTP request was sent to the cloud database to query for data.

Each of these HTTP requests has a small amount of latency to send the request and receive the response.

This was dumb, and scales horribly, especially when the front-end page is stuck loading until all the requests have been sent and received.

The fix for this was to perform one HTTP request, which contained the array of attributes I wished to query, and then perform logic on the server to parse and format the results in the way I needed.

## Verification
Before making these changes, I timed how long the N number of HTTP requests took to complete. I timed this 10 times and the average result was `494.994 ms`.

After making these changes, I timed the same method a total of 10 different times and the average result was `141.897 ms`

This function now performs the same action but does so `71.33%` faster 🎊 

Also, I only specified certain attributes (aka columns) for the data that is selected, cutting down the data returned for each record from `~64kb` to `~32kb` 🎊 

Moral of the story: Don't execute N http requests unless absolutely neccessary.