### PR TITLE
Feature: Make Tickets Movable

### DIFF
--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -652,17 +652,49 @@ $( document ).ready(function() {
         }
     });
 
+    function populateDepartmentStatusList(departmentName, departmentStatusList, listItemTemplate) {
+        $.ajax({
+            url: '/tickets/find-department-statuses',
+            type: 'POST',
+            data: {
+                departmentName: departmentName
+            },
+            success: function(response) {
+                if (response.error) {
+                    alert(`An error occurred: ${response.error}`);
+                } else {
+                    departmentStatusList.empty();
+                    const departmentStatuses = response.departmentStatuses;
+
+                    departmentStatuses.forEach((departmentStatus) => {
+                        const clone = listItemTemplate.clone();
+                        clone.data('status-name', departmentStatus);
+                        clone.text(departmentStatus);
+                        departmentStatusList.append(clone)
+                    });
+                }
+            },
+            error: function(error) {
+                alert('Uh oh, an unknown error occurred, see the console for more details');
+                console.log(JSON.stringify(error));
+            }
+        });
+    }
+
     /* Gavin code for console.logs department seleciton */
     $('.departments-dropdown li').click(function() {
         let departmentSelection = $(this).data('department-name');
-        console.log(departmentSelection);
+        const departmentStatusHtmlList = $(this).parent('.department-dropdown-list').parent('.departments-dropdown').siblings('.department-status-dropdown').find('.status-dropdown-list');
+        const clone = departmentStatusHtmlList.find('.status-option').first().clone();
+
+        populateDepartmentStatusList(departmentSelection, departmentStatusHtmlList, clone);
     });
 
-    $('.status-option').click(function() {
+    $('.status-dropdown-list').on('click', '.status-option', function() {
         let departmentSelection = $(this).parent('.status-dropdown-list').parent('.department-status-dropdown').siblings('.departments-dropdown').find('.department-option.active').data('department-name');
         let statusSelection = $(this).data('status-name');
         let ticketId = $(this).data('ticket-id');
-        // $(departmentSelection).addClass('storm');  
+        // $(departmentSelection).addClass('storm');
         console.log('Ticket ID:' + ticketId + ' ' + 'Department Selection:' + departmentSelection + ' ' + 'Status:' + statusSelection );
     });
 

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -694,8 +694,15 @@ $( document ).ready(function() {
         let departmentSelection = $(this).parent('.status-dropdown-list').parent('.department-status-dropdown').siblings('.departments-dropdown').find('.department-option.active').data('department-name');
         let statusSelection = $(this).data('status-name');
         let ticketId = $(this).data('ticket-id');
-        // $(departmentSelection).addClass('storm');
-        console.log('Ticket ID:' + ticketId + ' ' + 'Department Selection:' + departmentSelection + ' ' + 'Status:' + statusSelection );
+        
+        const ticketAttributes = {
+            destination: {
+                department: departmentSelection,
+                departmentStatus: statusSelection
+            }
+        }
+
+        updateTicket(ticketAttributes, ticketId);
     });
 
     const ticketCounts = $('.category-ticket-count');

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -670,7 +670,7 @@ $( document ).ready(function() {
                         const clone = listItemTemplate.clone();
                         clone.data('status-name', departmentStatus);
                         clone.text(departmentStatus);
-                        departmentStatusList.append(clone)
+                        departmentStatusList.append(clone);
                     });
                 }
             },
@@ -700,7 +700,7 @@ $( document ).ready(function() {
                 department: departmentSelection,
                 departmentStatus: statusSelection
             }
-        }
+        };
 
         updateTicket(ticketAttributes, ticketId);
     });

--- a/application/services/ejsService.js
+++ b/application/services/ejsService.js
@@ -1,7 +1,9 @@
 const workflowStepService = require('./workflowStepService');
 const dateTimeService = require('./dateTimeService');
+const {getAllDepartmentsWithDepartmentStatuses} = require('../enums/departmentsEnum');
 
 const helperMethods = {
+    getDepartmentsWithAtLeastOneStatus: getAllDepartmentsWithDepartmentStatuses,
     prettifyDuration: dateTimeService.prettifyDuration,
     getSimpleDate: dateTimeService.getSimpleDate,
     getOverallTicketDuration: workflowStepService.getOverallTicketDuration,

--- a/application/services/ejsService.js
+++ b/application/services/ejsService.js
@@ -1,9 +1,7 @@
 const workflowStepService = require('./workflowStepService');
 const dateTimeService = require('./dateTimeService');
-const {getAllDepartmentsWithDepartmentStatuses} = require('../enums/departmentsEnum');
 
 const helperMethods = {
-    getDepartmentsWithAtLeastOneStatus: getAllDepartmentsWithDepartmentStatuses,
     prettifyDuration: dateTimeService.prettifyDuration,
     getSimpleDate: dateTimeService.getSimpleDate,
     getOverallTicketDuration: workflowStepService.getOverallTicketDuration,

--- a/application/views/viewTickets.ejs
+++ b/application/views/viewTickets.ejs
@@ -228,15 +228,15 @@
                                     <div class='department-dropdown-header flex-bottom-space-between-row'>
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
-                                    <ul>
-                                      <li class='click-me' data-department-name='order-prep'>Order Prep</li>
-                                      <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                      <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                      <li class='department-option' data-department-name='printing'>Printing</li>
-                                      <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                      <li class='department-option' data-department-name='winding'>Winding</li>
-                                      <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                      <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <ul class='department-dropdown-list'>
+                                      <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                      <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                      <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                      <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                      <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                      <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                      <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                      <li class='department-option' data-department-name='BILLING'>Billing</li>
                                     </ul>
                                   </div>
                                   <div class='department-status-dropdown back-out-hover'>
@@ -244,10 +244,10 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                    <ul class='status-dropdown-list'>
-                                      <li class='status-option'>Department Status A</li>
-                                      <li class='status-option'>Department Status B</li>
-                                      <li class='status-option'>Department Status C</li>
+                                   <ul class='status-dropdown-list'>
+                                      <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
+                                      <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
+                                      <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
                                     </ul>
                                     <!-- End Gavin Target -->
                                   </div>
@@ -431,14 +431,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -629,14 +629,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='click-me department-option' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option active' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -827,14 +827,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -1025,14 +1025,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -1040,7 +1040,7 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                  <ul class='status-dropdown-list'>
+                                 <ul class='status-dropdown-list'>
                                     <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
                                     <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
                                     <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
@@ -1223,25 +1223,27 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
                                   <div class='department-dropdown-header flex-bottom-space-between-row'>
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
-                                  <ul class='status-dropdown-list'>
+                                  <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
+                                 <ul class='status-dropdown-list'>
                                     <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
                                     <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
                                     <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
                                   </ul>
+                                  <!-- End Gavin Target -->
                                 </div>
                               </li>
                               <li class='move-to-list-trigger'>Move To List
@@ -1430,14 +1432,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -1632,14 +1634,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -1830,14 +1832,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -2028,14 +2030,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -2226,14 +2228,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -2434,14 +2436,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -2632,14 +2634,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -2830,14 +2832,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -3038,14 +3040,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -3240,14 +3242,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -3438,14 +3440,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -3636,14 +3638,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -3833,26 +3835,28 @@
                                   <div class='department-dropdown-header flex-bottom-space-between-row'>
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
-                                  <ul>
-                                      <li class='click-me' data-department-name='order-prep'>Order Prep</li>
-                                      <li data-department-name='art-prep'>Art Prep</li>
-                                      <li data-department-name='pre-printing'>Pre-Printing</li>
-                                      <li data-department-name='printing'>Printing</li>
-                                      <li data-department-name='cutting'>Cutting</li>
-                                      <li data-department-name='winding'>Winding</li>
-                                      <li data-department-name='shipping'>Shipping</li>
-                                      <li data-department-name='billing'>Billing</li>
-                                    </ul>
+                                  <ul class='department-dropdown-list'>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
+                                  </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
                                   <div class='department-dropdown-header flex-bottom-space-between-row'>
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
-                                  <ul class='status-dropdown-list'>
-                                  <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                  <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                  <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
-                                </ul>
+                                  <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
+                                 <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  </ul>
+                                  <!-- End Gavin Target -->
                                 </div>
                               </li>
                               <li class='move-to-list-trigger'>Move To List
@@ -4030,14 +4034,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -4238,14 +4242,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -4440,14 +4444,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -4637,14 +4641,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -4835,14 +4839,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -5033,14 +5037,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -5231,14 +5235,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -5439,14 +5443,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -5641,14 +5645,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -5838,14 +5842,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -6046,14 +6050,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -6244,14 +6248,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -6442,14 +6446,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -6640,14 +6644,14 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
                                 <div class='department-status-dropdown back-out-hover'>
@@ -6850,25 +6854,25 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
-                                <div class='department-status-dropdown'>
+                                <div class='department-status-dropdown back-out-hover'>
                                   <div class='department-dropdown-header flex-bottom-space-between-row'>
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                  <ul>
-                                    <li>Department Status A</li>
-                                    <li>Department Status B</li>
-                                    <li>Department Status C</li>
+                                 <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -6998,25 +7002,25 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <ul class='department-dropdown-list'>
-                                    <li class='department-option click-me' data-department-name='order-prep'>Order Prep</li>
-                                    <li class='department-option' data-department-name='art-prep'>Art Prep</li>
-                                    <li class='department-option' data-department-name='pre-printing'>Pre-Printing</li>
-                                    <li class='department-option' data-department-name='printing'>Printing</li>
-                                    <li class='department-option' data-department-name='cutting'>Cutting</li>
-                                    <li class='department-option' data-department-name='winding'>Winding</li>
-                                    <li class='department-option' data-department-name='shipping'>Shipping</li>
-                                    <li class='department-option' data-department-name='billing'>Billing</li>
+                                    <li class='department-option' data-department-name='ORDER-PREP'>Order Prep</li>
+                                    <li class='department-option' data-department-name='ART-PREP'>Art Prep</li>
+                                    <li class='department-option' data-department-name='PRE-PRESS'>Pre-Printing</li>
+                                    <li class='department-option' data-department-name='PRINTING'>Printing</li>
+                                    <li class='department-option' data-department-name='CUTTING'>Cutting</li>
+                                    <li class='department-option' data-department-name='WINDING'>Winding</li>
+                                    <li class='department-option' data-department-name='SHIPPING'>Shipping</li>
+                                    <li class='department-option' data-department-name='BILLING'>Billing</li>
                                   </ul>
                                 </div>
-                                <div class='department-status-dropdown'>
+                                <div class='department-status-dropdown back-out-hover'>
                                   <div class='department-dropdown-header flex-bottom-space-between-row'>
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                  <ul>
-                                    <li>Department Status A</li>
-                                    <li>Department Status B</li>
-                                    <li>Department Status C</li>
+                                 <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>

--- a/application/views/viewTickets.ejs
+++ b/application/views/viewTickets.ejs
@@ -244,10 +244,8 @@
                                       <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                     </div>
                                     <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                   <ul class='status-dropdown-list'>
-                                      <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                      <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                      <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                    <ul class='status-dropdown-list'>
+                                      <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                     </ul>
                                     <!-- End Gavin Target -->
                                   </div>
@@ -446,10 +444,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -644,10 +640,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -842,10 +836,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -1040,10 +1032,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -1238,10 +1228,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -1447,10 +1435,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -1649,10 +1635,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -1847,10 +1831,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -2045,10 +2027,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -2243,10 +2223,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -2451,10 +2429,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -2649,10 +2625,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -2847,10 +2821,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -3055,10 +3027,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -3257,10 +3227,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -3455,10 +3423,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -3653,10 +3619,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -3851,10 +3815,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -4049,10 +4011,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -4257,10 +4217,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -4459,10 +4417,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -4656,10 +4612,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -4854,10 +4808,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -5052,10 +5004,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -5250,10 +5200,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -5458,10 +5406,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -5660,10 +5606,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -5857,10 +5801,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -6065,10 +6007,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -6263,10 +6203,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -6461,10 +6399,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -6659,10 +6595,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -6869,10 +6803,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>
@@ -7017,10 +6949,8 @@
                                     <span class='drpdwn-title'>Choose Dept.</span><span class="sub-drpdwn-back-btn"><div class='background-hover'></div>Back</span>
                                   </div>
                                   <!-- #409 Gavin This the list of department statuss. We would want to populate this with list of department-statuss that correspond with the main department-->
-                                 <ul class='status-dropdown-list'>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-a'>Department Status A</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-b'>Department Status B</li>
-                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='department-status-c'>Department Status C</li>
+                                  <ul class='status-dropdown-list'>
+                                    <li class='status-option' data-ticket-id='<%= ticket.id %>' data-status-name='N/A'>N/A</li> <!-- This row is used as a clone -->
                                   </ul>
                                   <!-- End Gavin Target -->
                                 </div>


### PR DESCRIPTION
# Description

On the frontend, a list of tickets are displayed in various tables.

Each ticket has an option to `move` a ticket to a different table on the same page.

This PR makes that `move` functionality work and utilizes ajax to persist that moved state.

The functionality for making the ticket disapear from the table it's currently in and reappear in the table it is being moved to is coming in a future PR.

## Verification

![image](https://user-images.githubusercontent.com/42784674/201803189-baf755b5-2e6e-46c9-8e9f-a2a696cbe7c6.png)

![image](https://user-images.githubusercontent.com/42784674/201803259-8ed4eae3-c34a-409d-a524-248df5a5b8eb.png)

![image](https://user-images.githubusercontent.com/42784674/201803313-2927113d-8d14-4687-96af-c9a5b40b9c25.png)
> The correct `departmentStatuses` are displayed when the `order-prep` department is selected