### PR TITLE
Feature: Make `Move` Tickets Work

### DIFF
--- a/application/controllers/ticketController.js
+++ b/application/controllers/ticketController.js
@@ -95,15 +95,12 @@ router.post('/update/:id', async (request, response) => {
     const ticketId = request.params.id;
 
     try {
-        await TicketModel.findOneAndUpdate({_id: ticketId}, {$set: request.body}, {runValidators: true}).exec();
-
-        return response.json({});
+        const updatedTicket = await TicketModel.findOneAndUpdate({_id: ticketId}, {$set: request.body}, {runValidators: true, new: true}).exec();
+        response.send(updatedTicket);
     } catch (error) {
-        console.log(`Failed to update ticket with id ${ticketId}: ${error.message}`);
+        console.log(`Failed to update ticket with id ${ticketId}. Error message: ${error.message}`);
         request.flash('errors', [error.message]);
-        return response.json({
-            error: error.message
-        });
+        return response.status(500).send(error.message);
     }
 });
 

--- a/application/controllers/ticketController.js
+++ b/application/controllers/ticketController.js
@@ -13,6 +13,8 @@ const workflowStepService = require('../services/workflowStepService');
 
 router.use(verifyJwtToken);
 
+const SERVER_ERROR_CODE = 500;
+
 function deleteFileFromFileSystem(path) {
     fs.unlinkSync(path);
 }
@@ -100,7 +102,7 @@ router.post('/update/:id', async (request, response) => {
     } catch (error) {
         console.log(`Failed to update ticket with id ${ticketId}. Error message: ${error.message}`);
         request.flash('errors', [error.message]);
-        return response.status(500).send(error.message);
+        return response.status(SERVER_ERROR_CODE).send(error.message);
     }
 });
 

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -691,16 +691,74 @@ $( document ).ready(function() {
     });
     
     function getIdentifierUsingTicketDepartmentAndDepartmentStatus(department, departmentStatus) {
-        const destinationToIdentifierMapping = {
-            'ORDER-PREP': {
-                'NEEDS ATTENTION': 'order-prep-needs-attention',
-                'SEND TO CUSTOMER': 'order-prep-send-to-customer',
-                'WAITING ON APPROVAL': 'order-prep-waiting-on-approval',
-                'WAITING ON CUSTOMER': 'order-prep-waiting-on-customer',
-                'READY TO ORDER PLATE OR DIE': 'order-prep-ready-to-order',
-                'IN PROGRESS': 'order-prep-in-progress',
-            }
+        const ORDER_PREP_DEPARTMENT = 'ORDER-PREP';
+        const ART_PREP_DEPARTMENT = 'ART-PREP';
+        const PRE_PRESS_DEPARTMENT = 'PRE-PRESS';
+        const PRINTING_DEPARTMENT = 'PRINTING';
+        const CUTTING_DEPARTMENT = 'CUTTING';
+        const WINDING_DEPARTMENT = 'WINDING';
+        const SHIPPING_DEPARTMENT = 'SHIPPING';
+        const BILLING_DEPARTMENT = 'BILLING';
+        
+        const destinationToIdentifierMapping = 
+        {
+            [ORDER_PREP_DEPARTMENT]: {
+                NEEDS_ATTENTION: 'order-prep-needs-attention',
+                SEND_TO_CUSTOMER: 'order-prep-send-to-customer',
+                WAITING_ON_APPROVAL: 'order-prep-waiting-on-approval',
+                WAITING_ON_CUSTOMER: 'order-prep-waiting-on-customer',
+                READY_TO_ORDER_PLATE_OR_DIE: 'order-prep-ready-to-order',
+                IN_PROGRESS: 'order-prep-in-progress'
+            },
+            [ART_PREP_DEPARTMENT]: {
+                NEEDS_ATTENTION: 'art-prep-needs-attention',
+                IN_PROGRESS: 'art-prep-in-progress',
+                NEEDS_PROOF: 'art-prep-needs-proof',
+                NEEDS_DIE_LINE: 'art-prep-needs-die',
+                NEEDS_PLATE: 'art-prep-needs-plate'
+            },
+            [PRE_PRESS_DEPARTMENT]: {
+                NEEDS_ATTENTION: 'pre-press-needs-attention',
+                IN_PROGRESS: 'pre-press-in-progress',
+                SEND_TO_PRESS: 'pre-press-send-to-press'
+            },
+            [PRINTING_DEPARTMENT]: {
+                SETUP: 'printing-setup',
+                RUNTIME: 'printing-runtime',
+                TEAR_DOWN: 'printing-teardown',
+                READY_FOR_SCHEDULING: 'printing-ready-for-scheduling',
+                SCHEDULE_PRESS_ONE: 'printing-schedule-press-one',
+                SCHEDULE_PRESS_TWO: 'printing-schedule-press-two',
+                SCHEDULE_PRESS_THREE: 'printing-schedule-press-three',
+                ON_HOLD: 'printing-on-hold'
+            },
+            [CUTTING_DEPARTMENT]: {
+                SETUP: 'cutting-setup',
+                RUNTIME: 'cutting-runtime',
+                TEAR_DOWN: 'cutting-teardown',
+                READY_FOR_SCHEDULING: 'cutting-ready-for-scheduling',
+                SCHEDULE_DELTA_ONE: 'cutting-delta-one',
+                SCHEDULE_DELTA_TWO: 'cutting-delta-two',
+                SCHEDULE_ROTOFLEX: 'cutting-rotoflex',
+                ON_HOLD: 'cutting-on-hold'
+            },
+            [WINDING_DEPARTMENT]: {
+                IN_PROGRESS: 'winding-in-progress',
+                READY_FOR_SCHEDULING: 'winding-ready-for-scheduling',
+                ON_HOLD: 'winding-on-hold'
+            },
+            [SHIPPING_DEPARTMENT]: {
+                IN_PROGRESS: 'winding-in-progress',
+                READY_FOR_SHIPPING: 'winding-ready-for-shipping',
+                ON_HOLD: 'winding-on-hold',
+                TOOL_ARRIVALS: 'winding-tool-arrivals'
+            },
+            [BILLING_DEPARTMENT]: {
+                READY_FOR_BILLING: 'billing-ready-for-billing',
+                IN_PROGRESS: 'billing-in-progress'
+            },
         };
+
         const identifier = destinationToIdentifierMapping[department][departmentStatus];
 
         if (!identifier) {

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -827,7 +827,7 @@ $( document ).ready(function() {
         console.log(`ticket => ${JSON.stringify(ticket)}`);
         alert('TODO: Finish building populateTicketRowAttributes()');
         const ticketRow = ticketRowTemplate.clone();
-        ticketRow.attr('id', getIdForTicketRow(ticket._id))
+        ticketRow.attr('id', getIdForTicketRow(ticket._id));
 
         return ticketRow;
     }

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -11,19 +11,19 @@ $( document ).ready(function() {
         $(`.department-wrapper*[data-department="${selectedDepartment}"]`).show(cssTransitionDelayInMs);
     });
 
-    function updateTicket(ticketAttributes, ticketId) {
+    function updateTicket(ticketAttributes, ticketId, callback) {
         $.ajax({
             url: `/tickets/update/${ticketId}`,
             type: 'POST',
             data: ticketAttributes,
-            success: function(response) {
-                if (response.error) {
-                    alert(`An error occurred: ${response.error}`);
+            success: function(updatedTicket) {
+                if (callback) {
+                    callback(updatedTicket);
                 }
             },
             error: function(error) {
-                console.log(error);
-                alert('An error occurred while attempting to update the ticket');
+                const errorMessage = error.responseText ? error.responseText : 'N/A';
+                alert(`An error occurred while attempting to update the ticket: "${errorMessage}"`);
             }
         });
     }
@@ -690,6 +690,11 @@ $( document ).ready(function() {
         populateDepartmentStatusList(departmentSelection, departmentStatusHtmlList, clone);
     });
 
+    function moveTicket(response) {
+        alert('alert from the callback!')
+        console.log(JSON.stringify(response));
+    }
+
     $('.status-dropdown-list').on('click', '.status-option', function() {
         let departmentSelection = $(this).parent('.status-dropdown-list').parent('.department-status-dropdown').siblings('.departments-dropdown').find('.department-option.active').data('department-name');
         let statusSelection = $(this).data('status-name');
@@ -702,7 +707,7 @@ $( document ).ready(function() {
             }
         };
 
-        updateTicket(ticketAttributes, ticketId);
+        updateTicket(ticketAttributes, ticketId, moveTicket);
     });
 
     const ticketCounts = $('.category-ticket-count');
@@ -716,9 +721,3 @@ $( document ).ready(function() {
         });
     }
 });
-
-
-
-
-
-

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -681,7 +681,6 @@ $( document ).ready(function() {
         });
     }
 
-    /* Gavin code for console.logs department seleciton */
     $('.departments-dropdown li').click(function() {
         let departmentSelection = $(this).data('department-name');
         const departmentStatusHtmlList = $(this).parent('.department-dropdown-list').parent('.departments-dropdown').siblings('.department-status-dropdown').find('.status-dropdown-list');
@@ -691,6 +690,33 @@ $( document ).ready(function() {
     });
     
     function getIdentifierUsingTicketDepartmentAndDepartmentStatus(department, departmentStatus) {
+        const NEEDS_ATTENTION = 'NEEDS ATTENTION';
+        const SEND_TO_CUSTOMER = 'SEND TO CUSTOMER';
+        const WAITING_ON_APPROVAL = 'WAITING ON APPROVAL';
+        const WAITING_ON_CUSTOMER = 'WAITING ON CUSTOMER';
+        const READY_TO_ORDER_PLATE_OR_DIE = 'READY TO ORDER PLATE OR DIE';
+        const IN_PROGRESS = 'IN PROGRESS';
+
+        const SETUP = 'SET-UP';
+        const RUNTIME = 'RUNTIME';
+        const TEAR_DOWN = 'TEAR-DOWN';
+
+        const NEEDS_DIE_LINE = 'NEEDS DIE LINE';
+        const NEEDS_PLATE = 'NEEDS PLATE';
+        const SEND_TO_PRESS = 'SEND TO PRESS';
+        const READY_FOR_SCHEDULING = 'READY FOR SCHEDULING';
+        const SCHEDULE_PRESS_ONE = 'SCHEDULE PRESS ONE';
+        const SCHEDULE_PRESS_TWO = 'SCHEDULE PRESS TWO';
+        const SCHEDULE_PRESS_THREE = 'SCHEDULE PRESS THREE';
+        const NEEDS_PROOF = 'NEEDS PROOF';
+        const ON_HOLD = 'ON HOLD';
+        const SCHEDULE_DELTA_ONE = 'SCHEDULE DELTA ONE';
+        const SCHEDULE_DELTA_TWO = 'SCHEDULE DELTA TWO';
+        const SCHEDULE_ROTOFLEX = 'SCHEDULE ROTOFLEX';
+        const READY_FOR_SHIPPING = 'READY FOR SHIPPING';
+        const TOOL_ARRIVALS = 'TOOL ARRIVALS';
+        const READY_FOR_BILLING = 'READY FOR BILLING';
+
         const ORDER_PREP_DEPARTMENT = 'ORDER-PREP';
         const ART_PREP_DEPARTMENT = 'ART-PREP';
         const PRE_PRESS_DEPARTMENT = 'PRE-PRESS';
@@ -703,59 +729,59 @@ $( document ).ready(function() {
         const destinationToIdentifierMapping = 
         {
             [ORDER_PREP_DEPARTMENT]: {
-                NEEDS_ATTENTION: 'order-prep-needs-attention',
-                SEND_TO_CUSTOMER: 'order-prep-send-to-customer',
-                WAITING_ON_APPROVAL: 'order-prep-waiting-on-approval',
-                WAITING_ON_CUSTOMER: 'order-prep-waiting-on-customer',
-                READY_TO_ORDER_PLATE_OR_DIE: 'order-prep-ready-to-order',
-                IN_PROGRESS: 'order-prep-in-progress'
+                [NEEDS_ATTENTION]: 'order-prep-needs-attention',
+                [SEND_TO_CUSTOMER]: 'order-prep-send-to-customer',
+                [WAITING_ON_APPROVAL]: 'order-prep-waiting-on-approval',
+                [WAITING_ON_CUSTOMER]: 'order-prep-waiting-on-customer',
+                [READY_TO_ORDER_PLATE_OR_DIE]: 'order-prep-ready-to-order',
+                [IN_PROGRESS]: 'order-prep-in-progress'
             },
             [ART_PREP_DEPARTMENT]: {
-                NEEDS_ATTENTION: 'art-prep-needs-attention',
-                IN_PROGRESS: 'art-prep-in-progress',
-                NEEDS_PROOF: 'art-prep-needs-proof',
-                NEEDS_DIE_LINE: 'art-prep-needs-die',
-                NEEDS_PLATE: 'art-prep-needs-plate'
+                [NEEDS_ATTENTION]: 'art-prep-needs-attention',
+                [IN_PROGRESS]: 'art-prep-in-progress',
+                [NEEDS_PROOF]: 'art-prep-needs-proof',
+                [NEEDS_DIE_LINE]: 'art-prep-needs-die',
+                [NEEDS_PLATE]: 'art-prep-needs-plate'
             },
             [PRE_PRESS_DEPARTMENT]: {
-                NEEDS_ATTENTION: 'pre-press-needs-attention',
-                IN_PROGRESS: 'pre-press-in-progress',
-                SEND_TO_PRESS: 'pre-press-send-to-press'
+                [NEEDS_ATTENTION]: 'pre-press-needs-attention',
+                [IN_PROGRESS]: 'pre-press-in-progress',
+                [SEND_TO_PRESS]: 'pre-press-send-to-press'
             },
             [PRINTING_DEPARTMENT]: {
-                SETUP: 'printing-setup',
-                RUNTIME: 'printing-runtime',
-                TEAR_DOWN: 'printing-teardown',
-                READY_FOR_SCHEDULING: 'printing-ready-for-scheduling',
-                SCHEDULE_PRESS_ONE: 'printing-schedule-press-one',
-                SCHEDULE_PRESS_TWO: 'printing-schedule-press-two',
-                SCHEDULE_PRESS_THREE: 'printing-schedule-press-three',
-                ON_HOLD: 'printing-on-hold'
+                [SETUP]: 'printing-setup',
+                [RUNTIME]: 'printing-runtime',
+                [TEAR_DOWN]: 'printing-teardown',
+                [READY_FOR_SCHEDULING]: 'printing-ready-for-scheduling',
+                [SCHEDULE_PRESS_ONE]: 'printing-schedule-press-one',
+                [SCHEDULE_PRESS_TWO]: 'printing-schedule-press-two',
+                [SCHEDULE_PRESS_THREE]: 'printing-schedule-press-three',
+                [ON_HOLD]: 'printing-on-hold'
             },
             [CUTTING_DEPARTMENT]: {
-                SETUP: 'cutting-setup',
-                RUNTIME: 'cutting-runtime',
-                TEAR_DOWN: 'cutting-teardown',
-                READY_FOR_SCHEDULING: 'cutting-ready-for-scheduling',
-                SCHEDULE_DELTA_ONE: 'cutting-delta-one',
-                SCHEDULE_DELTA_TWO: 'cutting-delta-two',
-                SCHEDULE_ROTOFLEX: 'cutting-rotoflex',
-                ON_HOLD: 'cutting-on-hold'
+                [SETUP]: 'cutting-setup',
+                [RUNTIME]: 'cutting-runtime',
+                [TEAR_DOWN]: 'cutting-teardown',
+                [READY_FOR_SCHEDULING]: 'cutting-ready-for-scheduling',
+                [SCHEDULE_DELTA_ONE]: 'cutting-delta-one',
+                [SCHEDULE_DELTA_TWO]: 'cutting-delta-two',
+                [SCHEDULE_ROTOFLEX]: 'cutting-rotoflex',
+                [ON_HOLD]: 'cutting-on-hold'
             },
             [WINDING_DEPARTMENT]: {
-                IN_PROGRESS: 'winding-in-progress',
-                READY_FOR_SCHEDULING: 'winding-ready-for-scheduling',
-                ON_HOLD: 'winding-on-hold'
+                [IN_PROGRESS]: 'winding-in-progress',
+                [READY_FOR_SCHEDULING]: 'winding-ready-for-scheduling',
+                [ON_HOLD]: 'winding-on-hold'
             },
             [SHIPPING_DEPARTMENT]: {
-                IN_PROGRESS: 'winding-in-progress',
-                READY_FOR_SHIPPING: 'winding-ready-for-shipping',
-                ON_HOLD: 'winding-on-hold',
-                TOOL_ARRIVALS: 'winding-tool-arrivals'
+                [IN_PROGRESS]: 'winding-in-progress',
+                [READY_FOR_SHIPPING]: 'winding-ready-for-shipping',
+                [ON_HOLD]: 'winding-on-hold',
+                [TOOL_ARRIVALS]: 'winding-tool-arrivals'
             },
             [BILLING_DEPARTMENT]: {
-                READY_FOR_BILLING: 'billing-ready-for-billing',
-                IN_PROGRESS: 'billing-in-progress'
+                [READY_FOR_BILLING]: 'billing-ready-for-billing',
+                [IN_PROGRESS]: 'billing-in-progress'
             },
         };
 
@@ -793,10 +819,15 @@ $( document ).ready(function() {
         return rows.length;
     }
 
+    function getIdForTicketRow(ticketId) {
+        return `ticket-row-${ticketId}`;
+    }
+
     function populateTicketRowAttributes(ticketRowTemplate, ticket) {
         console.log(`ticket => ${JSON.stringify(ticket)}`);
         alert('TODO: Finish building populateTicketRowAttributes()');
         const ticketRow = ticketRowTemplate.clone();
+        ticketRow.attr('id', getIdForTicketRow(ticket._id))
 
         return ticketRow;
     }

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -700,7 +700,7 @@ $( document ).ready(function() {
                 'READY TO ORDER PLATE OR DIE': 'order-prep-ready-to-order',
                 'IN PROGRESS': 'order-prep-in-progress',
             }
-        }
+        };
         const identifier = destinationToIdentifierMapping[department][departmentStatus];
 
         if (!identifier) {
@@ -716,7 +716,7 @@ $( document ).ready(function() {
 
     function findDepartmentStatusTableTicketBelongsIn(ticket) {
         const {department, departmentStatus} = ticket.destination;
-        const identifier = getIdentifierUsingTicketDepartmentAndDepartmentStatus(department, departmentStatus)
+        const identifier = getIdentifierUsingTicketDepartmentAndDepartmentStatus(department, departmentStatus);
         const tableId = `#${identifier}-table`;
         
         return $(tableId);
@@ -724,18 +724,19 @@ $( document ).ready(function() {
 
     function findATicketRowToClone(ticket) {
         const {department, departmentStatus} = ticket.destination;
-        const identifier = getIdentifierUsingTicketDepartmentAndDepartmentStatus(department, departmentStatus)
+        const identifier = getIdentifierUsingTicketDepartmentAndDepartmentStatus(department, departmentStatus);
         const tableRowCloneSelector = `.${identifier}-row`;
 
         return $(tableRowCloneSelector).clone();
     }
 
     function countHowManyRowsExistInTable(ticketTable) {
-        const rows = ticketTable.children('.table-row-wrapper')
+        const rows = ticketTable.children('.table-row-wrapper');
         return rows.length;
     }
 
     function populateTicketRowAttributes(ticketRowTemplate, ticket) {
+        console.log(`ticket => ${JSON.stringify(ticket)}`);
         alert('TODO: Finish building populateTicketRowAttributes()');
         const ticketRow = ticketRowTemplate.clone();
 
@@ -744,7 +745,7 @@ $( document ).ready(function() {
 
     function moveTicket(ticket) {
         const ticketId = ticket._id;
-        const ticketRowToRemove = findTicketRow(ticketId)
+        const ticketRowToRemove = findTicketRow(ticketId);
         
         ticketRowToRemove.remove();
 
@@ -753,7 +754,7 @@ $( document ).ready(function() {
 
         const ticketRow = populateTicketRowAttributes(ticketRowTemplate, ticket);
 
-        departmentStatusTable.append(ticketRow)
+        departmentStatusTable.append(ticketRow);
 
         updateDepartmentTicketCounts();
         updateDepartmentSectionTicketCounts();
@@ -765,27 +766,28 @@ $( document ).ready(function() {
     }
 
     function showOrHideDepartmentSections() {
+        const emptyLength = 0;
         $('.department-section').each(function() {
             const departmentStatusSection = $(this);
-            const departmentStatusTable = findTableWithinSection(departmentStatusSection)
-            const tableIsNotEmpty = countHowManyRowsExistInTable(departmentStatusTable) > 0;
+            const departmentStatusTable = findTableWithinSection(departmentStatusSection);
+            const tableIsNotEmpty = countHowManyRowsExistInTable(departmentStatusTable) > emptyLength;
 
             if (tableIsNotEmpty) {
                 departmentStatusSection.show();
             } else {
                 departmentStatusSection.hide();
             }
-        })
+        });
     }
 
     function updateDepartmentSectionTicketCounts() {
         $('.department-section').each(function() {
             const departmentStatusSection = $(this);
-            const departmentStatusTable = findTableWithinSection(departmentStatusSection)
+            const departmentStatusTable = findTableWithinSection(departmentStatusSection);
             const numberOfRowsInSection = countHowManyRowsExistInTable(departmentStatusTable);
 
-            departmentStatusSection.find('.category-ticket-count').text(numberOfRowsInSection)
-        })
+            departmentStatusSection.find('.category-ticket-count').text(numberOfRowsInSection);
+        });
     }
 
     function updateDepartmentTicketCounts() {
@@ -797,9 +799,9 @@ $( document ).ready(function() {
             const departmentStatusTables = department.find('.table-body');
             departmentStatusTables.each(function() {
                 const table = $(this);
-                const numberOfRowsInTable = countHowManyRowsExistInTable(table)
+                const numberOfRowsInTable = countHowManyRowsExistInTable(table);
                 numberOfTicketsInDepartment += numberOfRowsInTable;
-            })
+            });
 
             department.find('#departmentTotalTickets').text(numberOfTicketsInDepartment);
         });

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -811,7 +811,7 @@ $( document ).ready(function() {
         const identifier = getIdentifierUsingTicketDepartmentAndDepartmentStatus(department, departmentStatus);
         const tableRowCloneSelector = `.${identifier}-row`;
 
-        return $(tableRowCloneSelector).clone();
+        return $(tableRowCloneSelector).first().clone();
     }
 
     function countHowManyRowsExistInTable(ticketTable) {

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -749,9 +749,9 @@ $( document ).ready(function() {
                 [SEND_TO_PRESS]: 'pre-press-send-to-press'
             },
             [PRINTING_DEPARTMENT]: {
-                [SETUP]: 'printing-setup',
-                [RUNTIME]: 'printing-runtime',
-                [TEAR_DOWN]: 'printing-teardown',
+                [SETUP]: 'printing-in-progress',
+                [RUNTIME]: 'printing-in-progress',
+                [TEAR_DOWN]: 'printing-in-progress',
                 [READY_FOR_SCHEDULING]: 'printing-ready-for-scheduling',
                 [SCHEDULE_PRESS_ONE]: 'printing-schedule-press-one',
                 [SCHEDULE_PRESS_TWO]: 'printing-schedule-press-two',
@@ -759,13 +759,13 @@ $( document ).ready(function() {
                 [ON_HOLD]: 'printing-on-hold'
             },
             [CUTTING_DEPARTMENT]: {
-                [SETUP]: 'cutting-setup',
-                [RUNTIME]: 'cutting-runtime',
-                [TEAR_DOWN]: 'cutting-teardown',
+                [SETUP]: 'cutting-in-progress',
+                [RUNTIME]: 'cutting-in-progress',
+                [TEAR_DOWN]: 'cutting-in-progress',
                 [READY_FOR_SCHEDULING]: 'cutting-ready-for-scheduling',
-                [SCHEDULE_DELTA_ONE]: 'cutting-delta-one',
-                [SCHEDULE_DELTA_TWO]: 'cutting-delta-two',
-                [SCHEDULE_ROTOFLEX]: 'cutting-rotoflex',
+                [SCHEDULE_DELTA_ONE]: 'cutting-schedule-delta-one',
+                [SCHEDULE_DELTA_TWO]: 'cutting-schedule-delta-two',
+                [SCHEDULE_ROTOFLEX]: 'cutting-schedule-rotoflex',
                 [ON_HOLD]: 'cutting-on-hold'
             },
             [WINDING_DEPARTMENT]: {
@@ -774,10 +774,10 @@ $( document ).ready(function() {
                 [ON_HOLD]: 'winding-on-hold'
             },
             [SHIPPING_DEPARTMENT]: {
-                [IN_PROGRESS]: 'winding-in-progress',
-                [READY_FOR_SHIPPING]: 'winding-ready-for-shipping',
-                [ON_HOLD]: 'winding-on-hold',
-                [TOOL_ARRIVALS]: 'winding-tool-arrivals'
+                [IN_PROGRESS]: 'shipping-in-progress',
+                [READY_FOR_SHIPPING]: 'shipping-ready-for-shipping',
+                [ON_HOLD]: 'shipping-on-hold',
+                [TOOL_ARRIVALS]: 'shipping-tool-arrivals'
             },
             [BILLING_DEPARTMENT]: {
                 [READY_FOR_BILLING]: 'billing-ready-for-billing',

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -690,9 +690,31 @@ $( document ).ready(function() {
         populateDepartmentStatusList(departmentSelection, departmentStatusHtmlList, clone);
     });
 
-    function moveTicket(response) {
-        alert('alert from the callback!')
-        console.log(JSON.stringify(response));
+    function determineWhichTableToPutThisTicket(ticket) {
+        const {department, departmentStatus} = ticket.destination;
+
+        const destinationToTableSelector = {
+            'ORDER-PREP': {
+                'NEEDS ATTENTION': '#order-prep-needs-attention-table',
+                'SEND TO CUSTOMER': '#order-prep-send-to-customer-table',
+                'WAITING ON APPROVAL': '#order-prep-waiting-on-approval-table',
+                'WAITING ON CUSTOMER': '#order-prep-waiting-on-customer-table',
+                'READY TO ORDER PLATE OR DIE': '#order-prep-ready-to-order-table',
+                'IN PROGRESS': '#order-prep-in-progress-table',
+            }
+        }
+        const tableSelector = destinationToTableSelector[department][departmentStatus];
+
+        if (!tableSelector) {
+            alert('Error: Failed to find a table to put the moved ticket into, contact a developer');
+        }
+
+        alert(`found the table selector: ${tableSelector}`)
+        return tableSelector;
+    }
+
+    function updateDepartmentSectionTicketCounts(departmentSectionToDecriment, departmentSectionToIncriment) {
+        alert('TODO: finish updateDepartmentSectionTicketCounts(...)')
     }
 
     $('.status-dropdown-list').on('click', '.status-option', function() {
@@ -707,7 +729,30 @@ $( document ).ready(function() {
             }
         };
 
-        updateTicket(ticketAttributes, ticketId, moveTicket);
+        updateTicket(ticketAttributes, ticketId, (updatedTicket) => {
+            alert('alert from the callback! -> ' + String(updatedTicket._id));
+
+            // Step 0a: Hide the moved ticket
+            $(`#ticket-row-${updatedTicket._id}`).hide()
+
+            // Step 0b: Select required attributes
+                // "Ticket Row": The row in the table that is going to be injected
+                // "Department Status Table": "The table whose rows represent a ticket with the associated department/department status"
+                // "Department Status Section": "The Section which contains the Department Status Table" and additional Meta Data / CSS Formatting
+            const ticketRow = $('.order-prep-needs-attention-row').first().clone();
+            const tableSelector = determineWhichTableToPutThisTicket(updatedTicket);
+            const departmentStatusTable = $(tableSelector);
+            const departmentStatusSection = departmentStatusTable.parent('.ticket-container').parent('.department-section').show();
+            const oldDepartmentStatusSection = 'TODO: Get this using jquery';
+
+            // Step 1: Update dynamic counts displayed in the new/old department sections AND department status sections
+            updateDepartmentSectionTicketCounts(departmentStatusSection, oldDepartmentStatusSection);
+            // Step 2a: Hide old "Department Status Section" (ONLY IF it is now empty)
+            // Step 2b: Show "Department Status Section" (just in case it was previously empty and hidden)
+            departmentStatusSection.show();
+            // Step 3: Add Row to the the "department Status Table"
+            departmentStatusTable.append(ticketRow)
+        });
     });
 
     const ticketCounts = $('.category-ticket-count');

--- a/application/views/partials/department-status-clones.ejs
+++ b/application/views/partials/department-status-clones.ejs
@@ -189,7 +189,7 @@
 
 
 <!-- Order Prep - Send To Customer -->
-<div class='table-row-wrapper full-width'>
+<div class='table-row-wrapper full-width order-prep-send-to-customer-row'>
   <div class='table-row flex-center-center-row'>
     <div class='column-td column-td-a bg-green'>
       <i class='fa-light fa-ellipsis-vertical text-white'></i>

--- a/application/views/partials/department-status-clones.ejs
+++ b/application/views/partials/department-status-clones.ejs
@@ -1,5 +1,5 @@
 <!-- Order Prep - Needs Attention -->
-<div class='table-row-wrapper full-width'>
+<div class='table-row-wrapper full-width order-prep-needs-attention-row'>
   <div class='start-job-bg-overlay flex-center-center-row'>
     <i class="fa-regular fa-xmark-large"></i>
     <div class='card modal-window start-job-modal'>

--- a/application/views/partials/department-status-clones.ejs
+++ b/application/views/partials/department-status-clones.ejs
@@ -351,7 +351,7 @@
 </div>
 
 <!-- Art Prep - Needs Attention -->
-<div class='table-row-wrapper full-width'>
+<div class='table-row-wrapper full-width art-prep-needs-attention-row'>
   <div class='table-row flex-center-center-row'>
     <div class='column-td column-td-a bg-green'>
       <i class='fa-light fa-ellipsis-vertical text-white'></i>

--- a/application/views/viewTickets.ejs
+++ b/application/views/viewTickets.ejs
@@ -187,7 +187,7 @@
             </div>
             <div id='order-prep-needs-attention-table' class='table-body flex-center-center-column'>
               <% orderPrepNeedsAttentionTickets.forEach((ticket, index) => { %>
-              <div id="ticket-row-<%= ticket._id %>" class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width order-prep-needs-attention-row'>
                 <div class='start-job-bg-overlay flex-center-center-row'>
                   <i class="fa-regular fa-xmark-large"></i>
                   <div class='card modal-window start-job-modal'>
@@ -410,7 +410,7 @@
             </div>
             <div id='order-prep-send-to-customer-table' class='table-body flex-center-center-column'>
               <% orderPrepSendToCustomerTickets.forEach((ticket, index) => { %>
-              <div id="ticket-row-<%= ticket._id %>" class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width order-prep-send-to-customer-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -604,9 +604,9 @@
               <div class='column-header column-header-h'>Sent Date</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='order-prep-waiting-on-approval-table' class='table-body flex-center-center-column'>
               <% orderPrepWaitingOnApprovalTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width order-prep-waiting-on-approval-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -800,9 +800,9 @@
               <div class='column-header column-header-h'>Sent Date</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='order-prep-waiting-on-customer-table' class='table-body flex-center-center-column'>
               <% orderPrepWaitingOnCustomerTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width order-prep-waiting-on-customer-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -996,9 +996,9 @@
               <div class='column-header column-header-h'></div>
               <div class='column-header column-header-i'></div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='order-prep-ready-to-order-table' class='table-body flex-center-center-column'>
               <% orderPrepReadyToOrderTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width order-prep-ready-to-order-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -1192,9 +1192,9 @@
               <div class='column-header column-header-h'></div>
               <div class='column-header column-header-i'></div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='order-prep-in-progress-table' class='table-body flex-center-center-column'>
               <% orderPrepInProgressTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width order-prep-in-progress-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -1399,9 +1399,9 @@
               <div class='column-header column-header-h'>From</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='art-prep-needs-attention-table' class='table-body flex-center-center-column'>
               <% artPrepNeedsAttentionTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width art-prep-needs-attention-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -1599,9 +1599,9 @@
               <div class='column-header column-header-h'></div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='art-prep-in-progress-table' class='table-body flex-center-center-column'>
               <% artPrepInProgressTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width art-prep-in-progress-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -1795,9 +1795,9 @@
               <div class='column-header column-header-h'>Sent Date</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='art-prep-needs-proof-table' class='table-body flex-center-center-column'>
               <% artPrepNeedsProofTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width art-prep-needs-proof-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -1991,9 +1991,9 @@
               <div class='column-header column-header-h'>Sent Date</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='art-prep-needs-die-table' class='table-body flex-center-center-column'>
               <% artPrepNeedsDieLineTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width art-prep-needs-die-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -2187,9 +2187,9 @@
               <div class='column-header column-header-h'></div>
               <div class='column-header column-header-i'></div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='art-prep-needs-plate-table' class='table-body flex-center-center-column'>
               <% artPrepNeedsPlateTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width art-prep-needs-plate-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -2393,9 +2393,9 @@
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='pre-press-needs-attention-table' class='table-body flex-center-center-column'>
               <% prePressNeedsAttentionTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width pre-press-needs-attention-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -2589,9 +2589,9 @@
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='pre-press-in-progress-table' class='table-body flex-center-center-column'>
               <% prePressInProgressTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width pre-press-in-progress-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -2785,9 +2785,9 @@
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='pre-press-send-to-press-table' class='table-body flex-center-center-column'>
               <% prePressSendToPressTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width pre-press-send-to-press-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -2991,9 +2991,9 @@
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='printing-in-progress-table' class='table-body flex-center-center-column'>
               <% printingInProgressTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width printing-in-progress-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -3191,9 +3191,9 @@
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='printing-ready-for-scheduling-table' class='table-body flex-center-center-column'>
               <% printingReadyForSchedulingTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width printing-ready-for-scheduling-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -3387,9 +3387,9 @@
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='printing-schedule-press-one-table' class='table-body flex-center-center-column'>
               <% printingSchedulePressOneTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width printing-schedule-press-one-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -3583,9 +3583,9 @@
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='printing-schedule-press-two-table' class='table-body flex-center-center-column'>
               <% printingSchedulePressTwoTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width printing-schedule-press-two-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -3779,9 +3779,9 @@
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='printing-schedule-press-three-table' class='table-body flex-center-center-column'>
               <% printingSchedulePressThreeTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width printing-schedule-press-three-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -3975,9 +3975,9 @@
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='printing-on-hold-table' class='table-body flex-center-center-column'>
               <% printingOnHoldTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width printing-on-hold-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -4181,9 +4181,9 @@
               <div class='column-header column-header-h'>Finish</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='cutting-in-progress-table' class='table-body flex-center-center-column'>
               <% cuttingInProgressTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width cutting-in-progress-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -4381,9 +4381,9 @@
               <div class='column-header column-header-h'>Finish</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='cutting-ready-for-scheduling-table' class='table-body flex-center-center-column'>
               <% cuttingReadyForSchedulingTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width cutting-ready-for-scheduling-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -4576,9 +4576,9 @@
               <div class='column-header column-header-h'>Finish</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='cutting-schedule-delta-one-table' class='table-body flex-center-center-column'>
               <% cuttingScheduleDeltaOneTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width cutting-schedule-delta-one-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -4772,9 +4772,9 @@
               <div class='column-header column-header-h'>Finish</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='cutting-schedule-delta-two-table' class='table-body flex-center-center-column'>
               <% cuttingScheduleDeltaTwoTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width cutting-schedule-delta-two-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -4968,9 +4968,9 @@
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='cutting-schedule-rotoflex-table' class='table-body flex-center-center-column'>
               <% cuttingScheduleRotoflexTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width cutting-schedule-rotoflex-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -5164,9 +5164,9 @@
               <div class='column-header column-header-h'>Finish</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='cutting-on-hold-table' class='table-body flex-center-center-column'>
               <% cuttingOnHoldTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width cutting-on-hold-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -5370,9 +5370,9 @@
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='winding-in-progress-table' class='table-body flex-center-center-column'>
               <% windingInProgressTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width winding-in-progress-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -5570,9 +5570,9 @@
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='winding-ready-for-scheduling-table' class='table-body flex-center-center-column'>
               <% windingReadyForSchedulingTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width winding-ready-for-scheduling-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -5765,9 +5765,9 @@
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='winding-on-hold-table' class='table-body flex-center-center-column'>
               <% windingOnHoldTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width winding-on-hold-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -5971,9 +5971,9 @@
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='shipping-in-progress-table' class='table-body flex-center-center-column'>
               <% shippingInProgressTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width shipping-in-progress-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -6167,9 +6167,9 @@
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='shipping-ready-for-shipping-table' class='table-body flex-center-center-column'>
               <% shippingReadyForShippingTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width shipping-ready-for-shipping-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -6363,9 +6363,9 @@
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='shipping-on-hold-table' class='table-body flex-center-center-column'>
               <% shippingOnHoldTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width shipping-on-hold-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>
@@ -6559,9 +6559,9 @@
               <div class='column-header column-header-h'></div>
               <div class='column-header column-header-i'>Arrival Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='shipping-tool-arrivals-table' class='table-body flex-center-center-column'>
               <% shippingToolArrivalTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id='ticket-row-<%= ticket._id %>' class='table-row-wrapper full-width shipping-tool-arrivals-row'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>

--- a/application/views/viewTickets.ejs
+++ b/application/views/viewTickets.ejs
@@ -185,9 +185,9 @@
               <div class='column-header column-header-h'>From</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='order-prep-needs-attention-table' class='table-body flex-center-center-column'>
               <% orderPrepNeedsAttentionTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id="ticket-row-<%= ticket._id %>" class='table-row-wrapper full-width'>
                 <div class='start-job-bg-overlay flex-center-center-row'>
                   <i class="fa-regular fa-xmark-large"></i>
                   <div class='card modal-window start-job-modal'>
@@ -408,9 +408,9 @@
               <div class='column-header column-header-h'></div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
-            <div class='table-body flex-center-center-column'>
+            <div id='order-prep-send-to-customer-table' class='table-body flex-center-center-column'>
               <% orderPrepSendToCustomerTickets.forEach((ticket, index) => { %>
-              <div class='table-row-wrapper full-width'>
+              <div id="ticket-row-<%= ticket._id %>" class='table-row-wrapper full-width'>
                 <div class='table-row flex-center-center-row'>
                   <div class='column-td column-td-a bg-green'>
                     <i class='fa-light fa-ellipsis-vertical text-white'></i>


### PR DESCRIPTION
# Description

This PR is a wip and my plan is to move it partially completed for reasons.

This PR allows a user to move a ticket from one departmentStatus to another departmentStatus.

Previously this could be done on the UI, however the user needed to refresh to see the ticket move on the UI to its new departmentStatus.

This PR does a ton with html/css/js in order to make the ticket move on the UI to the new departmentStatus without the user needing to refresh the page.

### The Parts that are done in this PR
A user can now select a ticket with `departmentStatus A` and choose to move that ticket to `departmentStatus B` and the ticket will be removed from `Table A` and appear on `Table B`.

The areas on the UI that display how many tickets are in each table is updated dynamically, and in the event that the moved ticket now makes `Table A` empty, that table is automatically hidden.

### What this PR does not do
This PR does not dynamically populate the row that is injected into `Table B` in the example above. The ticket that gets added to Table B simply has hardcoded data.

I will create a future PR to dynamically populate this row.