### PR TITLE
Feature: Update Ticket Row Numbers After a Ticket is Moved

### DIFF
--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -888,6 +888,16 @@ $( document ).ready(function() {
 
         return ticketRow;
     }
+    
+    function updateTicketRowNumbers() {
+        const departmentTables = $('.table-body');
+        departmentTables.each(function() {
+            const ticketRows = $(this).find('[id^=ticket-row]'); // https://stackoverflow.com/a/5376445/9273261
+            ticketRows.each(function(index) {
+                $(this).find('.row-number').text(index + 1);
+            });
+        });
+    }
 
     function moveTicket(ticket) {
         const ticketId = ticket._id;
@@ -905,6 +915,7 @@ $( document ).ready(function() {
         updateDepartmentTicketCounts();
         updateDepartmentSectionTicketCounts();
         showOrHideDepartmentSections();
+        updateTicketRowNumbers();
     }
 
     function findTableWithinSection(departmentStatusSection) {

--- a/application/views/viewTickets.ejs
+++ b/application/views/viewTickets.ejs
@@ -125,7 +125,7 @@
                         }
                     ) %>
                     </div>
-                    <div class='column-td column-td-b bg-white'><%= index + 1 %></div>
+                    <div class='column-td column-td-b bg-white row-number'><%= index + 1 %></div>
                     <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                     <div class='column-td column-td-d bg-white status-column'></div>
                     <div class='column-td column-td-e bg-white'></div>
@@ -182,7 +182,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %> </div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-purple text-white status-column'>Rush</div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -234,7 +234,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %></div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %></div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-white status-column'></div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -286,7 +286,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %></div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %></div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-white status-column'></div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -338,7 +338,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %> </div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>Plate (TODO)</div>
                   <div class='column-td column-td-d bg-white'></div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -390,7 +390,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %> </div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>Plate (TODO)</div>
                   <div class='column-td column-td-d bg-white'></div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -448,7 +448,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %></div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %></div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-white status-column'></div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -504,7 +504,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %></div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %></div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-purple text-white status-column'>Rush (TODO)</div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -556,7 +556,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %> </div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-white status-column'></div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -608,7 +608,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %> </div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber %></div>
                   <div class='column-td column-td-d bg-white status-column'></div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -660,7 +660,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %> </div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>Plate (TODO)</div>
                   <div class='column-td column-td-d bg-white'></div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -717,7 +717,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %> </div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %> </div>
                   <div class='column-td column-td-d bg-white status-column'></div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -769,7 +769,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %></div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %></div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-purple text-white status-column'>Rush</div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -821,7 +821,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %> </div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %> </div>
                   <div class='column-td column-td-d bg-white status-column'></div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -878,7 +878,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %></div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %></div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber %> </div>
                   <div class='column-td column-td-d bg-purple text-white status-column'>Rush</div>
                   <div class='column-td column-td-e bg-white'>
@@ -934,7 +934,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %> </div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber %></div>
                   <div class='column-td column-td-d bg-red text-white status-column'>Hot (TODO)</div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -986,7 +986,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %></div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %></div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-red text-white status-column'>Hot (TODO)</div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -1038,7 +1038,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %> </div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %> </div>
                   <div class='column-td column-td-d bg-white status-column'></div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -1090,7 +1090,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %> </div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %> </div>
                   <div class='column-td column-td-d bg-white status-column'></div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -1142,7 +1142,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %></div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %></div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %> </div>
                   <div class='column-td column-td-d bg-white status-column'></div>
                   <div class='column-td column-td-e bg-white hold-status-column'></div>
@@ -1200,7 +1200,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %> </div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-purple text-white'>Rush (TODO)</div>
                   <div class='column-td column-td-e bg-white'>
@@ -1256,7 +1256,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %></div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %></div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber %></div>
                   <div class='column-td column-td-d bg-white'></div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -1308,7 +1308,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %></div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %></div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber %></div>
                   <div class='column-td column-td-d bg-white'></div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -1360,7 +1360,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %></div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %></div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber %> </div>
                   <div class='column-td column-td-d bg-white'></div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -1412,7 +1412,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %> </div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber %></div>
                   <div class='column-td column-td-d bg-white'></div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -1464,7 +1464,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %> </div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %> </div>
                   <div class='column-td column-td-d bg-white'></div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -1521,7 +1521,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %> </div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-purple text-white'>Rush (TODO)</div>
                   <div class='column-td column-td-e bg-white'>
@@ -1577,7 +1577,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %></div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %></div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-white'></div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -1629,7 +1629,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %> </div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-white'></div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -1686,7 +1686,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %> </div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-purple text-white'>Rush (TODO)</div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -1738,7 +1738,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %> </div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-white'></div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -1790,7 +1790,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %> </div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-white'></div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -1842,7 +1842,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %></div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %></div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>Plate (TODO)</div>
                   <div class='column-td column-td-d bg-white'></div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -1899,7 +1899,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %> </div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-purple text-white'>Rush (TODO)</div>
                   <div class='column-td column-td-e bg-white'></div>
@@ -1951,7 +1951,7 @@
                       }
                   ) %>
                   </div>
-                  <div class='column-td column-td-b bg-white'><%= index + 1 %> </div>
+                  <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-white'></div>
                   <div class='column-td column-td-e bg-white'></div>


### PR DESCRIPTION
# Description

Currently, one page `viewTickets.ejs` contains many various HTML tables, each table has many rows.

A user is able to move a row from one table to another via UI interactions, however, prior to this PR, the row numbers shown would not be updated during the move.

This PR now refreshes all row numbers in ALL tables after any move occurs.

## Verification

![image](https://user-images.githubusercontent.com/42784674/204034906-0d2d4eb3-3bf2-43d1-845c-c3de13dcde57.png)
> Before

![image](https://user-images.githubusercontent.com/42784674/204034786-0e1b8b85-be8e-46f1-a936-995ad4e01773.png)
> After