### PR TITLE
Populate product rows on moved ticket

### DIFF
--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -504,7 +504,7 @@ $( document ).ready(function() {
         }
     });
 
-    $('.column-td-a').click(function(){
+    $('.table-body').on('click', '.table-row-wrapper .table-row .column-td-a', function() {
         if ($(this).hasClass('active')){
             $(this).removeClass('active');
         } else {

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -942,6 +942,16 @@ $( document ).ready(function() {
         productsTable.append(...productRows);
     }
 
+    function updateTicketRowNumbers() {
+        const departmentTables = $('.table-body');
+        departmentTables.each(function() {
+            const ticketRows = $(this).find('[id^=ticket-row]'); // https://stackoverflow.com/a/5376445/9273261
+            ticketRows.each(function(index) {
+                $(this).find('.row-number').text(index + 1);
+            });
+        });
+    }
+
     function moveTicket(ticket) {
         const ticketId = ticket._id;
         const ticketRowToRemove = findTicketRow(ticketId);

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -1,5 +1,7 @@
 $( document ).ready(function() {
     const emptyLength = 0;
+    const ZERO = 0;
+
     $('.workflow-navigation ul li').on('click', function() {
         $('.department-end-frame').remove();
         let currentDepartmentName = $(this).text();
@@ -511,7 +513,7 @@ $( document ).ready(function() {
         }
     });
 
-    $('.ticket-number-column').click(function(){
+    $('.table-body').on('click', '.table-row .ticket-number-column', function(){
         let currentActive = $(this).closest('.table-row-wrapper');
         if ($(currentActive).hasClass('active')) {
             $('.table-row-wrapper').removeClass('active');
@@ -827,6 +829,13 @@ $( document ).ready(function() {
         return `ticket-row-${ticketId}`;
     }
 
+    function formatDate(dateAsString, formatConfig) {
+        if (!dateAsString) {
+            return;
+        }
+        return new Date(dateAsString).toLocaleDateString('en-us', formatConfig);
+    }
+
     const ticketNumberColumn = '.ticket-number-column';
     const statusColumn = '.status-column';
     const fromColumn = '.from-column';
@@ -845,19 +854,21 @@ $( document ).ready(function() {
 
     function mapTicketRowColumnSelectorToValues(ticket) {
         console.log(ticket);
+        const machineName = (ticket.destination.machines && ticket.destination.machines.length > emptyLength) ? ticket.destination.machines[0].name : '';
+        const numberOfProducts = ticket.products ? ticket.products.length : ZERO;
         return {
-            [ticketNumberColumn]: '!TODO!',
-            [statusColumn]: '!TODO!',
+            [ticketNumberColumn]: ticket.shippingAttention,
+            [statusColumn]: ticket.shippingAttention,
             [fromColumn]: '!TODO!',
-            [dueDateColumn]: '!TODO!',
+            [dueDateColumn]: formatDate(ticket.shipDate, {month:'short', day:'numeric'}),
             [followUpDateColumn]: '!TODO!',
             [sentDateColumn]: '!TODO!',
             [typeColumn]: '!TODO!',
-            [productCountColumn]: '!TODO!',
-            [locationColumn]: '!TODO!',
-            [materialColumn]: '!TODO!',
+            [productCountColumn]: numberOfProducts,
+            [locationColumn]: machineName,
+            [materialColumn]: ticket.primaryMaterial, // TODO: I think Storm marked this wrong on the mockup, check with him
             [dieColumn]: '!TODO!',
-            [lengthColumn]: '!TODO!',
+            [lengthColumn]: ticket.totalFeet,
             [holdStatusColumn]: '!TODO!',
             [rolls]: '!TODO!',
             [groupedColumn]: '!TODO!',
@@ -899,6 +910,38 @@ $( document ).ready(function() {
         });
     }
 
+    function getAProductRowClone() {
+        return $('#product-row-template').first().clone();
+    }
+
+    function buildProductRows(products) {
+        let productRows = [];
+        
+        products && products.forEach((product) => {
+            console.log(`product => ${JSON.stringify(product)}`);
+            const productRow = getAProductRowClone();
+
+            // TODO: Populate the template with dynamic data
+
+            productRows.push(productRow);
+
+        });
+
+        return productRows;
+    }
+
+    function addProductRowsToTicketRow(ticketRow, productRows) {
+        if (!productRows || productRows.length === emptyLength) {
+            return;
+        }
+
+        const productsTable = ticketRow.find('.products-table');
+        
+        productsTable.empty();
+
+        productsTable.append(...productRows);
+    }
+
     function moveTicket(ticket) {
         const ticketId = ticket._id;
         const ticketRowToRemove = findTicketRow(ticketId);
@@ -909,6 +952,9 @@ $( document ).ready(function() {
         const ticketRowTemplate = findATicketRowToClone(ticket);
 
         const ticketRow = populateTicketRowAttributes(ticketRowTemplate, ticket);
+        const productRows = buildProductRows(ticket.products);
+
+        addProductRowsToTicketRow(ticketRow, productRows);
 
         departmentStatusTable.append(ticketRow);
 

--- a/application/views/partials/department-status-clones.ejs
+++ b/application/views/partials/department-status-clones.ejs
@@ -160,7 +160,7 @@
       <div class='column-header column-header-h'>Quantity</div>
       <div class='column-header column-header-i'>Artwork</div>
     </div>
-    <div class='full-width flex-center-right-column'>
+    <div class='full-width flex-center-right-column products-table'>
       <div class='product-wrapper flex-top-center-column'>
         <div class='table-row flex-center-center-row'>
           <div class='group-lines'></div>
@@ -323,7 +323,7 @@
       <div class='column-header column-header-h'>Quantity</div>
       <div class='column-header column-header-i'>Artwork</div>
     </div>
-    <div class='full-width flex-center-right-column'>
+    <div class='full-width flex-center-right-column products-table'>
       <div class='product-wrapper flex-top-center-column'>
         <div class='table-row flex-center-center-row'>
           <div class='group-lines'></div>
@@ -489,7 +489,7 @@
       <div class='column-header column-header-h'>Quantity</div>
       <div class='column-header column-header-i'>Artwork</div>
     </div>
-    <div class='full-width flex-center-right-column'>
+    <div class='full-width flex-center-right-column products-table'>
       <div class='product-wrapper flex-top-center-column'>
         <div class='table-row flex-center-center-row'>
           <div class='group-lines'></div>

--- a/application/views/partials/product-clone.ejs
+++ b/application/views/partials/product-clone.ejs
@@ -1,0 +1,22 @@
+<div id='product-row-template' class='product-wrapper flex-top-center-column'>
+    <div class='table-row flex-center-center-row'>
+    <div class='group-lines'></div>
+    <div class='column-td column-td-a bg-green'>
+        <i class='fa-light fa-ellipsis-vertical text-white'></i>
+        <div class='ticket-dropdown-options dropdown'>
+        <ul> 
+            <a href=""><li><i class="fa-regular fa-eye"></i>View Product</li></a>
+            <li class='collapse-ticket'><i class="fa-regular fa-arrows-to-line"></i>Hide Products</li>
+        </ul>
+        </div>
+    </div>
+    <div class='column-td column-td-b bg-white'></div>
+    <div class='column-td column-td-c product-number-column bg-white'>Product Number (TODO)</div>
+    <div class='column-td column-td-d bg-white'></div>
+    <div class='column-td column-td-e bg-white'></div>
+    <div class='column-td column-td-f bg-white'></div>
+    <div class='column-td column-td-g bg-white'>Frames (TODO)</div>
+    <div class='column-td column-td-h bg-white'>Label QTY (TODO)</div>
+    <div class='column-td column-td-i bg-white'><i class="fa-regular fa-image-polaroid"></i></div>
+    </div>
+</div>

--- a/application/views/partials/products-wrapper.ejs
+++ b/application/views/partials/products-wrapper.ejs
@@ -13,7 +13,7 @@
         <div class='column-header column-header-h'>Quantity</div>
         <div class='column-header column-header-i'>Artwork</div>
     </div>
-    <div class='full-width flex-center-right-column'>
+    <div class='full-width flex-center-right-column products-table'>
         <% ticket.products.forEach((product, index) => { %>
         <div class='product-wrapper flex-top-center-column'>
             <div class='table-row flex-center-center-row'>

--- a/application/views/viewTickets.ejs
+++ b/application/views/viewTickets.ejs
@@ -1994,7 +1994,9 @@
       <div class="department-end-frame flex-center-center-row full-width">
         <div class="department-divide-line"></div><h4>End Billing</h4><div class="department-divide-line"></div>
       </div>
-      <%- include('partials/department-status-clones.ejs') %>
+
+       <%- include('partials/department-status-clones.ejs') %>
+       <%- include('partials/product-clone.ejs') %>
   </div>
 </div>
 


### PR DESCRIPTION
# Description

Currently the view `viewTickets.ejs` has many tables, each table has many rows. Each row represents a ticket. Each row is clickable, and on click, the products associated with that Ticket are displayed as rows below it.

This functionality was working great, but when tickets were moved from table to table on this view, the injected ticket row was not clickable due to jquery reasons.

This PR makes jquery updates such that the moved ticket rows are still clickable and on-click, the products associated to that ticket are dispalyed as rows below it.

## Verification
![image](https://user-images.githubusercontent.com/42784674/204037796-45422193-c233-4ca2-badc-fa1e51e3d27f.png)
> Tickets are still clickable after being moved ✔️ 