### PR TITLE
Wip: Dynamically Populate HTML Attributes on Moved Ticket

### DIFF
--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -952,6 +952,20 @@ $( document ).ready(function() {
         });
     }
 
+    function populateTicketRowDropdownOptions(ticketRow) {
+        ticketRow.find('.date-created-target').text('TODO 1');
+        ticketRow.find('.overall-duration-target').text('TODO 2');
+        ticketRow.find('.production-duration-target').text('TODO 3');
+        ticketRow.find('.department-duration-target').text('TODO 4');
+        ticketRow.find('.list-duration-target').text('TODO 5');
+
+        ticketRow.find('.view-ticket-link').attr('href','TODO 6');
+        ticketRow.find('.edit-ticket-link').attr('href','TODO 7');
+        ticketRow.find('.archive-ticket-link').attr('href','TODO 8');
+
+        ticketRow.find('.start-modal-ticket-number').attr('href','TODO 9');
+    }
+
     function moveTicket(ticket) {
         const ticketId = ticket._id;
         const ticketRowToRemove = findTicketRow(ticketId);
@@ -965,6 +979,7 @@ $( document ).ready(function() {
         const productRows = buildProductRows(ticket.products);
 
         addProductRowsToTicketRow(ticketRow, productRows);
+        populateTicketRowDropdownOptions(ticketRow)
 
         departmentStatusTable.append(ticketRow);
 

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -979,7 +979,7 @@ $( document ).ready(function() {
         const productRows = buildProductRows(ticket.products);
 
         addProductRowsToTicketRow(ticketRow, productRows);
-        populateTicketRowDropdownOptions(ticketRow)
+        populateTicketRowDropdownOptions(ticketRow);
 
         departmentStatusTable.append(ticketRow);
 

--- a/application/views/partials/products-wrapper.ejs
+++ b/application/views/partials/products-wrapper.ejs
@@ -1,6 +1,7 @@
 <div class='ticket-products-wrapper flex-center-right-column full-width'>
+    <% const numberOfProducts = ticket.products ? ticket.products.length : 0 %> 
     <div class='product-wrapper-header flex-center-left-row'>
-        <h4>Products - <span>3</span></h4>
+        <h4>Products - <span><%= numberOfProducts %></span></h4>
     </div>
     <div class='table-header secondary-table-header flex-center-center-row'>
         <div class='column-header column-header-a'></div>
@@ -14,7 +15,7 @@
         <div class='column-header column-header-i'>Artwork</div>
     </div>
     <div class='full-width flex-center-right-column products-table'>
-        <% ticket.products.forEach((product, index) => { %>
+        <% ticket.products && ticket.products.forEach((product, index) => { %>
         <div class='product-wrapper flex-top-center-column'>
             <div class='table-row flex-center-center-row'>
             <div class='group-lines'></div>

--- a/application/views/partials/start-job-modal.ejs
+++ b/application/views/partials/start-job-modal.ejs
@@ -6,7 +6,7 @@
             <h2>Start This Job</h2>
             </div>
             <div class='modal-body flex-center-center-column'>
-                <h1><%= ticket.ticketNumber || 'N/A' %></h1>
+                <h1 class='start-modal-ticket-number'><%= ticket.ticketNumber || 'N/A' %></h1>
                 <select name="machine-list" id="machine">
                     <option>Press 1</option>
                     <option>Press 2</option>

--- a/application/views/partials/ticket-dropdown-options.ejs
+++ b/application/views/partials/ticket-dropdown-options.ejs
@@ -53,7 +53,7 @@
             </div>
             <i class="fa-regular fa-chevron-right"></i>
         </li>
-        <a href="/tickets/<%= ticket.id %>"><li class='view-ticket back-out-hover'><i class="fa-regular fa-eye"></i>View Ticket</li></a>
+        <a href="/tickets/<%= ticket.id %>" class="view-ticket-link"><li class='view-ticket back-out-hover'><i class="fa-regular fa-eye"></i>View Ticket</li></a>
         <div class='line'></div>
         <li class="show-products back-out-hover"><i class="fa-regular fa-list-tree"></i>Show Products</li>
         <li class="hide-products back-out-hover"><i class="fa-regular fa-arrows-to-line"></i>Hide Products</li>
@@ -97,7 +97,7 @@
             <i class="fa-regular fa-chevron-right"></i>
         </li>
         <div class='line'></div>
-        <a href="/tickets/update/<%= ticket.id %>"><li class='edit-ticket back-out-hover'><i class="fa-regular fa-pen-to-square"></i>Edit Ticket</li></a>
-        <li class='archive-ticket back-out-hover'><i class="fa-regular fa-box-archive"></i>Archive Ticket</li>
+        <a href="/tickets/update/<%= ticket.id %>" class='edit-ticket-link'><li class='edit-ticket back-out-hover'><i class="fa-regular fa-pen-to-square"></i>Edit Ticket</li></a>
+        <a href='' class='archive-ticket-link'><li class='archive-ticket back-out-hover'><i class="fa-regular fa-box-archive"></i>Archive Ticket</li></a>
     </ul>
   </div>

--- a/application/views/partials/ticket-dropdown-options.ejs
+++ b/application/views/partials/ticket-dropdown-options.ejs
@@ -60,12 +60,15 @@
         <li class="duration-dropdown-trigger back-out-hover">
             <i class="fa-regular fa-clock-two"></i>Duration
             <div class='duration-dropdown-options'>
+                <% const department = ticket.destination ? ticket.destination.department : undefined %>
+                <% const departmentStatus = ticket.destination ? ticket.destination.departmentStatus : undefined %>
+                <% const workflowTimeLedgerForTicket = (workflowStepTimeLedger && Object.keys(workflowStepTimeLedger).length > 0) ? workflowStepTimeLedger[ticket.id] : undefined %>
                 <ul>
-                    <li class='date-creation'>Date Created - <span class='text-blue date-created-target'><%= helperMethods.getSimpleDate(ticket.createdAt) %></span></li>
-                    <li class='overall-duration'>Overall - <span class='text-blue overall-duration-target'><%= helperMethods.prettifyDuration(helperMethods.getOverallTicketDuration(workflowStepTimeLedger[ticket.id])) %></span></li>
-                    <li class='production-duration'>Production - <span class='text-blue production-duration-target'><%= helperMethods.prettifyDuration(helperMethods.getHowLongTicketHasBeenInProduction(workflowStepTimeLedger[ticket.id])) %></span></li>
-                    <li class='department-duration'>Department - <span class='text-blue department-duration-target'><%= helperMethods.prettifyDuration(helperMethods.getHowLongTicketHasBeenInDepartment(workflowStepTimeLedger[ticket.id], ticket.destination.department)) %></span></li>
-                    <li class='list-duration'>Current List - <span class='text-blue list-duration-target'><%= helperMethods.prettifyDuration(helperMethods.getHowLongTicketHasHadADepartmentStatus(workflowStepTimeLedger[ticket.id], ticket.destination.department, ticket.destination.departmentStatus)) %></span></li>
+                    <li class='date-creation'>Date Created - <span class='text-blue date-created-target'><%= ticket.createdAt ? helperMethods.getSimpleDate(ticket.createdAt) : 'N/A' %></span></li>
+                    <li class='overall-duration'>Overall - <span class='text-blue overall-duration-target'><%= helperMethods.prettifyDuration(helperMethods.getOverallTicketDuration(workflowTimeLedgerForTicket)) %></span></li>
+                    <li class='production-duration'>Production - <span class='text-blue production-duration-target'><%= helperMethods.prettifyDuration(helperMethods.getHowLongTicketHasBeenInProduction(workflowTimeLedgerForTicket)) %></span></li>
+                    <li class='department-duration'>Department - <span class='text-blue department-duration-target'><%= helperMethods.prettifyDuration(helperMethods.getHowLongTicketHasBeenInDepartment(workflowTimeLedgerForTicket, department)) %></span></li>
+                    <li class='list-duration'>Current List - <span class='text-blue list-duration-target'><%= helperMethods.prettifyDuration(helperMethods.getHowLongTicketHasHadADepartmentStatus(workflowTimeLedgerForTicket, department, departmentStatus)) %></span></li>
                 </ul>
             </div>
             <i class="fa-regular fa-chevron-right"></i>

--- a/application/views/viewTickets.ejs
+++ b/application/views/viewTickets.ejs
@@ -121,8 +121,7 @@
                     <div class='column-td column-td-a'>
                       <i class='fa-light fa-ellipsis-vertical text-white'></i>
                       <%- include('partials/ticket-dropdown-options.ejs', {
-                        ticket: {},
-                        workflowStepTimeLedger: {}
+                        ticket: ticket
                         }
                     ) %>
                     </div>

--- a/application/views/viewTickets.ejs
+++ b/application/views/viewTickets.ejs
@@ -121,7 +121,8 @@
                     <div class='column-td column-td-a'>
                       <i class='fa-light fa-ellipsis-vertical text-white'></i>
                       <%- include('partials/ticket-dropdown-options.ejs', {
-                        ticket: ticket
+                        ticket: {},
+                        workflowStepTimeLedger: {}
                         }
                     ) %>
                     </div>


### PR DESCRIPTION
# Description

Prior to this PR, when a ticket is moved from one departmentStatus table to another departmentStatus table, that "move" was done via jquery.

However, after injecting the element with jquery, many attributes on that injected row are not dynamically set and need to be.

This PR takes a step in the direction of populating the many attributes that need to be set dynamically, more PRs need to be done to fully finish this feature.