### PR TITLE
Feature: Make 'view product' Button Work

### DIFF
--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -919,7 +919,7 @@ $( document ).ready(function() {
         
         products && products.forEach((product) => {
             const productRow = getAProductRowClone();
-            productRow.find('.view-product-link').attr('href', `/products/${product._id}`)
+            productRow.find('.view-product-link').attr('href', `/products/${product._id}`);
 
             // TODO: Populate the template with dynamic data
 

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -918,8 +918,8 @@ $( document ).ready(function() {
         let productRows = [];
         
         products && products.forEach((product) => {
-            console.log(`product => ${JSON.stringify(product)}`);
             const productRow = getAProductRowClone();
+            productRow.find('.view-product-link').attr('href', `/products/${product._id}`)
 
             // TODO: Populate the template with dynamic data
 

--- a/application/views/partials/product-clone.ejs
+++ b/application/views/partials/product-clone.ejs
@@ -5,7 +5,7 @@
         <i class='fa-light fa-ellipsis-vertical text-white'></i>
         <div class='ticket-dropdown-options dropdown'>
         <ul> 
-            <a href=""><li><i class="fa-regular fa-eye"></i>View Product</li></a>
+            <a href='' class='view-product-link'><li><i class="fa-regular fa-eye"></i>View Product</li></a>
             <li class='collapse-ticket'><i class="fa-regular fa-arrows-to-line"></i>Hide Products</li>
         </ul>
         </div>


### PR DESCRIPTION
# Description

Previously when a ticket was moved from one department to another, a bunch of jQuery made that move happen without the need of a refresh.

However, some links on the moved ticket were not updated to work, which includes a "view product" button.

This PR fixes the href on that button to make it link correctly utilizing jQuery.

## Verification
<img width="1423" alt="Screenshot 2022-11-26 at 1 06 53 PM" src="https://user-images.githubusercontent.com/42784674/204105193-9d16c87d-d203-4342-ae2f-b2bd501a1d83.png">
> Clicking this button now calls the `GET /products/:id` endpoint
