### PR TITLE
Feature: Dynamically Populate Product Rows after Ticket is Moved

### DIFF
--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -920,14 +920,23 @@ $( document ).ready(function() {
     function buildProductRows(products) {
         let productRows = [];
         
-        products && products.forEach((product) => {
+        products && products.forEach((product, index) => {
             const productRow = getAProductRowClone();
             productRow.find('.view-product-link').attr('href', `/products/${product._id}`);
+            productRow.find('.product-row-number-column').text(index + 1);
+            productRow.find('.product-number-column').text(product.productNumber);
+            productRow.find('.frames-column').text(product.frameCount);
+            productRow.find('.label-quanity-column').text(product.labelQty);
 
-            // TODO: Populate the template with dynamic data
+            const proofUrl = product.proof ? product.proof.url : undefined;
+
+            if (proofUrl) {
+                productRow.find('.product-proof-column a').attr('href', proofUrl);
+            } else {
+                productRow.find('.product-proof-column').text('N/A');
+            }
 
             productRows.push(productRow);
-
         });
 
         return productRows;

--- a/application/views/partials/product-clone.ejs
+++ b/application/views/partials/product-clone.ejs
@@ -10,13 +10,13 @@
         </ul>
         </div>
     </div>
-    <div class='column-td column-td-b bg-white'></div>
+    <div class='column-td column-td-b bg-white product-row-number-column'>TODO</div>
     <div class='column-td column-td-c product-number-column bg-white'>Product Number (TODO)</div>
     <div class='column-td column-td-d bg-white'></div>
     <div class='column-td column-td-e bg-white'></div>
     <div class='column-td column-td-f bg-white'></div>
-    <div class='column-td column-td-g bg-white'>Frames (TODO)</div>
-    <div class='column-td column-td-h bg-white'>Label QTY (TODO)</div>
-    <div class='column-td column-td-i bg-white'><i class="fa-regular fa-image-polaroid"></i></div>
+    <div class='column-td column-td-g bg-white frames-column'>Frames (TODO)</div>
+    <div class='column-td column-td-h bg-white label-quanity-column'>Label QTY (TODO)</div>
+    <div class='column-td column-td-i bg-white product-proof-column'><a href=''><i class="fa-regular fa-image-polaroid"></i></a></div>
     </div>
 </div>


### PR DESCRIPTION
# Description

Prior to this PR, when a ticket was moved from one departmentStatus into another departmentStatus, the information on the products for that ticket were not dynamically populated.

This PR dynamically populates those products using jquery/js.

## Verification

![image](https://user-images.githubusercontent.com/42784674/204109039-bbc0482d-b3f4-448f-a768-7775f3a734b6.png)
> After a ticket is moved, the product rows are now dynamically populated