### PR TITLE
Refactor: Only Query for Duration Info when User Hovers Element

### DIFF
--- a/application/controllers/ticketController.js
+++ b/application/controllers/ticketController.js
@@ -26,12 +26,9 @@ router.get('/', async (request, response) => {
         .exec();
 
     const ticketsGroupedByDestination = ticketService.groupTicketsByDestination(tickets);
-    const ticketIds = await ticketService.findDistinctTicketIdsWichAreNotCompletedAndHaveADefinedDestination();
-    const workflowStepTimeLedger = await workflowStepService.computeTimeTicketsHaveSpentInEachWorkflowStep(ticketIds);
 
     return response.render('viewTickets', {
-        ticketsGroupedByDestination,
-        workflowStepTimeLedger
+        ticketsGroupedByDestination
     });
 });
 

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -600,6 +600,25 @@ $( document ).ready(function() {
         $('.departments-dropdown').removeClass('active');
     });
 
+    $(document).on('mouseover', '.duration-dropdown-trigger', function() {
+        const ticketRowId = $(this).parents('.table-row-wrapper').attr('id');
+        const ticketId = ticketRowId.replace('ticket-row-', '');
+        const ticketRow = findTicketRow(ticketId);
+
+        if (!ticketId || !ticketRow) {
+            alert('Uh oh, failed to refresh the duration information for this ticket')
+            return;
+        }
+        
+        findDurationInformationForOneTicket(ticketId, (durationInformation) => {
+            ticketRow.find('.date-created-target').text(durationInformation['date-created']);
+            ticketRow.find('.overall-duration-target').text(durationInformation['overall-duration']);
+            ticketRow.find('.production-duration-target').text(durationInformation['production-duration']);
+            ticketRow.find('.department-duration-target').text(durationInformation['department-duration']);
+            ticketRow.find('.list-duration-target').text(durationInformation['list-duration']);
+        });
+    })
+
     $('.back-out-hover').hover(function(){
         $('.move-ticket').removeClass('active');
         $('.departments-dropdown').removeClass('active');
@@ -981,14 +1000,6 @@ $( document ).ready(function() {
     }
 
     function populateTicketRowDropdownOptions(ticketRow, ticket) {
-        findDurationInformationForOneTicket(ticket._id, (durationInformation) => {
-            ticketRow.find('.date-created-target').text(durationInformation['date-created']);
-            ticketRow.find('.overall-duration-target').text(durationInformation['overall-duration']);
-            ticketRow.find('.production-duration-target').text(durationInformation['production-duration']);
-            ticketRow.find('.department-duration-target').text(durationInformation['department-duration']);
-            ticketRow.find('.list-duration-target').text(durationInformation['list-duration']);
-        });
-
         ticketRow.find('.view-ticket-link').attr('href',`/tickets/${ticket._id}`);
         ticketRow.find('.edit-ticket-link').attr('href',`/tickets/update/${ticket._id}`);
         ticketRow.find('.archive-ticket-link').attr('href',`/tickets/delete/${ticket._id}`);

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -606,7 +606,7 @@ $( document ).ready(function() {
         const ticketRow = findTicketRow(ticketId);
 
         if (!ticketId || !ticketRow) {
-            alert('Uh oh, failed to refresh the duration information for this ticket')
+            alert('Uh oh, failed to refresh the duration information for this ticket');
             return;
         }
         
@@ -617,7 +617,7 @@ $( document ).ready(function() {
             ticketRow.find('.department-duration-target').text(durationInformation['department-duration']);
             ticketRow.find('.list-duration-target').text(durationInformation['list-duration']);
         });
-    })
+    });
 
     $('.back-out-hover').hover(function(){
         $('.move-ticket').removeClass('active');

--- a/application/views/partials/ticket-dropdown-options.ejs
+++ b/application/views/partials/ticket-dropdown-options.ejs
@@ -60,15 +60,12 @@
         <li class="duration-dropdown-trigger back-out-hover">
             <i class="fa-regular fa-clock-two"></i>Duration
             <div class='duration-dropdown-options'>
-                <% const department = ticket.destination ? ticket.destination.department : undefined %>
-                <% const departmentStatus = ticket.destination ? ticket.destination.departmentStatus : undefined %>
-                <% const workflowTimeLedgerForTicket = (workflowStepTimeLedger && Object.keys(workflowStepTimeLedger).length > 0) ? workflowStepTimeLedger[ticket.id] : undefined %>
                 <ul>
-                    <li class='date-creation'>Date Created - <span class='text-blue date-created-target'><%= ticket.createdAt ? helperMethods.getSimpleDate(ticket.createdAt) : 'N/A' %></span></li>
-                    <li class='overall-duration'>Overall - <span class='text-blue overall-duration-target'><%= helperMethods.prettifyDuration(helperMethods.getOverallTicketDuration(workflowTimeLedgerForTicket)) %></span></li>
-                    <li class='production-duration'>Production - <span class='text-blue production-duration-target'><%= helperMethods.prettifyDuration(helperMethods.getHowLongTicketHasBeenInProduction(workflowTimeLedgerForTicket)) %></span></li>
-                    <li class='department-duration'>Department - <span class='text-blue department-duration-target'><%= helperMethods.prettifyDuration(helperMethods.getHowLongTicketHasBeenInDepartment(workflowTimeLedgerForTicket, department)) %></span></li>
-                    <li class='list-duration'>Current List - <span class='text-blue list-duration-target'><%= helperMethods.prettifyDuration(helperMethods.getHowLongTicketHasHadADepartmentStatus(workflowTimeLedgerForTicket, department, departmentStatus)) %></span></li>
+                    <li class='date-creation'>Date Created - <span class='text-blue date-created-target'>N/A</span></li>
+                    <li class='overall-duration'>Overall - <span class='text-blue overall-duration-target'>N/A</span></li>
+                    <li class='production-duration'>Production - <span class='text-blue production-duration-target'>N/A</span></li>
+                    <li class='department-duration'>Department - <span class='text-blue department-duration-target'>N/A</span></li>
+                    <li class='list-duration'>Current List - <span class='text-blue list-duration-target'>N/A</span></li>
                 </ul>
             </div>
             <i class="fa-regular fa-chevron-right"></i>


### PR DESCRIPTION
# Description

Previously, every row in a table had a dropdown called "duration" which was populated on page refresh.

The calculations required to populate this "duration" for every row in the table on refresh slowed down the page and the calculation itself took 150ms which made up a vast majority of the 250ms it took for the page to load.

Instead of that, I refactored in this PR and do not populate the dropdown "duration" on page load, instead, I only  fetch that information if the user hovers their mouse over "duration" and then I use AJAX to fetch and populate that hovered "duration".

After these changes, the page `viewTickets.ejs` now loads in 100ms versus before it took 250ms to load. Heck yeah!!!

## Verification
![image](https://user-images.githubusercontent.com/42784674/204112536-db457165-83e1-4f12-a4e3-228e3ca4918a.png)
