### PR TITLE
View in progress ticket

### DIFF
--- a/application/controllers/ticketController.js
+++ b/application/controllers/ticketController.js
@@ -8,7 +8,7 @@ const ticketService = require('../services/ticketService');
 const TicketModel = require('../models/ticket');
 const mongooseService = require('../services/mongooseService');
 const MaterialModel = require('../models/material');
-const {departmentToStatusesMappingForTicketObjects, isInProgressDepartmentStatus} = require('../enums/departmentsEnum');
+const {departmentToStatusesMappingForTicketObjects, isInProgressDepartmentStatus, removeDepartmentStatusesAUserIsNotAllowedToSelect} = require('../enums/departmentsEnum');
 const workflowStepService = require('../services/workflowStepService');
 const dateTimeService = require('../services/dateTimeService');
 
@@ -94,10 +94,13 @@ router.post('/update/:ticketId/notes', async (request, response) => {
 
 router.post('/find-department-statuses', (request, response) => {
     const departmentName = request.body.departmentName;
-    const departmentStatuses = departmentToStatusesMappingForTicketObjects[departmentName];
-
+    const allStatusesForOneDepartment = departmentToStatusesMappingForTicketObjects[departmentName];
+    let userSelectableDepartmentStatuses;
+    
     try {
-        if (!departmentStatuses) {
+        userSelectableDepartmentStatuses = removeDepartmentStatusesAUserIsNotAllowedToSelect(allStatusesForOneDepartment);
+
+        if (!userSelectableDepartmentStatuses) {
             throw new Error(`No departmentStatuses found for the department named "${departmentName}"`);
         }
     } catch (error) {
@@ -107,7 +110,7 @@ router.post('/find-department-statuses', (request, response) => {
     }
 
     return response.json({
-        departmentStatuses: departmentStatuses
+        departmentStatuses: userSelectableDepartmentStatuses
     });
 });
 

--- a/application/controllers/ticketController.js
+++ b/application/controllers/ticketController.js
@@ -42,7 +42,7 @@ router.get('/in-progress/:ticketId', async (request, response) => {
             throw new Error(`No ticket was found in the database whose object ID is "${ticketObjectId}"`);
         }
 
-        if (!isInProgressDepartmentStatus(ticket)) {
+        if (!isInProgressDepartmentStatus(ticket.destination.departmentStatus)) {
             return response.status(INVALID_REQUEST_ERROR_CODE).send(`The requested ticket whose object ID is "${ticketObjectId}" does not have a department status of "in-progress"`);
         }
 

--- a/application/controllers/ticketController.js
+++ b/application/controllers/ticketController.js
@@ -8,7 +8,7 @@ const ticketService = require('../services/ticketService');
 const TicketModel = require('../models/ticket');
 const mongooseService = require('../services/mongooseService');
 const MaterialModel = require('../models/material');
-const {departmentStatusesGroupedByDepartment, isInProgressDepartmentStatus} = require('../enums/departmentsEnum');
+const {departmentToStatusesMappingForTicketObjects, isInProgressDepartmentStatus} = require('../enums/departmentsEnum');
 const workflowStepService = require('../services/workflowStepService');
 const dateTimeService = require('../services/dateTimeService');
 
@@ -94,7 +94,7 @@ router.post('/update/:ticketId/notes', async (request, response) => {
 
 router.post('/find-department-statuses', (request, response) => {
     const departmentName = request.body.departmentName;
-    const departmentStatuses = departmentStatusesGroupedByDepartment[departmentName];
+    const departmentStatuses = departmentToStatusesMappingForTicketObjects[departmentName];
 
     try {
         if (!departmentStatuses) {
@@ -159,14 +159,14 @@ router.get('/update/:id', async (request, response) => {
     try {
         const ticket = await TicketModel.findById(request.params.id).exec();
         const materials = await MaterialModel.find().exec();
-        const departmentNames = Object.keys(departmentStatusesGroupedByDepartment);
+        const departmentNames = Object.keys(departmentToStatusesMappingForTicketObjects);
 
         const ticketDestination = ticket.destination;
         const selectedDepartment = ticketDestination && ticketDestination.department;
         const selectedDepartmentStatus = ticketDestination && ticketDestination.departmentStatus;
         const selectedMaterial = ticket.primaryMaterial;
 
-        const departmentStatuses = departmentStatusesGroupedByDepartment ? departmentStatusesGroupedByDepartment[selectedDepartment] : undefined;
+        const departmentStatuses = departmentToStatusesMappingForTicketObjects ? departmentToStatusesMappingForTicketObjects[selectedDepartment] : undefined;
 
         const materialIds = materials.map(material => material.materialId);
 

--- a/application/controllers/ticketController.js
+++ b/application/controllers/ticketController.js
@@ -39,7 +39,7 @@ router.get('/in-progress/:ticketId', async (request, response) => {
         const ticket = await TicketModel.findById(ticketObjectId).exec();
 
         if (!ticket) {
-            throw new Error(`No ticket was found in the database whose object ID is "${ticketObjectId}"`)
+            throw new Error(`No ticket was found in the database whose object ID is "${ticketObjectId}"`);
         }
 
         if (!isInProgressDepartmentStatus(ticket)) {
@@ -48,8 +48,8 @@ router.get('/in-progress/:ticketId', async (request, response) => {
 
         return response.render('viewOneInProgressTicket', {
             ticket
-        })
-    } catch(error) {
+        });
+    } catch (error) {
         return response.status(SERVER_ERROR_CODE).send(error.message);
     }
 });

--- a/application/enums/departmentsEnum.js
+++ b/application/enums/departmentsEnum.js
@@ -96,6 +96,13 @@ module.exports.departmentToStatusesMappingForTicketObjects = {
     [COMPLETE_DEPARTMENT]: []
 };
 
+module.exports.removeDepartmentStatusesAUserIsNotAllowedToSelect = (departmentStatuses) => {
+    return departmentStatuses.filter((departmentStatus) => {
+        const isAllowed = departmentStatus !== IN_PROGRESS;
+        return isAllowed;
+    });
+};
+
 module.exports.productionDepartmentsAndDepartmentStatuses = {
     PRE_PRINTING_DEPARTMENT: this.departmentToStatusesMappingForTicketObjects[PRE_PRINTING_DEPARTMENT],
     PRINTING_DEPARTMENT: this.departmentToStatusesMappingForTicketObjects[PRINTING_DEPARTMENT],

--- a/application/enums/departmentsEnum.js
+++ b/application/enums/departmentsEnum.js
@@ -3,14 +3,14 @@ const NEEDS_ATTENTION = 'NEEDS ATTENTION';
 const WAITING_ON_APPROVAL = 'WAITING ON APPROVAL';
 const WAITING_ON_CUSTOMER = 'WAITING ON CUSTOMER';
 const IN_PROGRESS = 'IN PROGRESS';
-const DIE_OR_PLATE_READY = 'DIE OR PLATE READY';
+const DIE_OR_PLATE_READY = 'DIE OR PLATE READY'; // eslint-disable-line no-unused-vars
 const PROOFING_COMPLETE = 'PROOFING COMPLETE';
 const PRINTING_READY = 'PRINTING READY';
 const PRINTER_ONE_SCHEDULE = 'PRINTER ONE SCHEDULE';
 const PRINTER_TWO_SCHEDULE = 'PRINTER TWO SCHEDULE';
 
-const NEEDS_DIE_LINE = 'NEEDS DIE LINE';
-const NEEDS_PLATE = 'NEEDS PLATE';
+const NEEDS_DIE_LINE = 'NEEDS DIE LINE'; // eslint-disable-line no-unused-vars
+const NEEDS_PLATE = 'NEEDS PLATE'; // eslint-disable-line no-unused-vars
 const SEND_TO_PRINTING = 'SEND TO PRINTING';
 const NEEDS_PROOF = 'NEEDS PROOF';
 const ON_HOLD = 'ON HOLD';
@@ -37,22 +37,19 @@ const SHIPPING_DEPARTMENT = 'SHIPPING';
 const BILLING_DEPARTMENT = 'BILLING';
 const COMPLETE_DEPARTMENT = 'COMPLETED';
 
-module.exports.departmentStatusesGroupedByDepartment = {
+module.exports.departmentToStatusesMappingForTicketObjects = {
     [ORDER_PREP_DEPARTMENT]: [
         NEEDS_ATTENTION,
         ON_HOLD,
         PROOFING_COMPLETE,
         WAITING_ON_CUSTOMER,
-        DIE_OR_PLATE_READY,
         WAITING_ON_APPROVAL
     ],
     [ART_PREP_DEPARTMENT]: [
         NEEDS_ATTENTION,
         ON_HOLD,
         IN_PROGRESS,
-        NEEDS_PROOF,
-        NEEDS_DIE_LINE,
-        NEEDS_PLATE
+        NEEDS_PROOF
     ],
     [PRE_PRINTING_DEPARTMENT]: [
         NEEDS_ATTENTION,
@@ -100,27 +97,17 @@ module.exports.departmentStatusesGroupedByDepartment = {
 };
 
 module.exports.productionDepartmentsAndDepartmentStatuses = {
-    PRE_PRINTING_DEPARTMENT: this.departmentStatusesGroupedByDepartment[PRE_PRINTING_DEPARTMENT],
-    PRINTING_DEPARTMENT: this.departmentStatusesGroupedByDepartment[PRINTING_DEPARTMENT],
-    CUTTING_DEPARTMENT: this.departmentStatusesGroupedByDepartment[CUTTING_DEPARTMENT],
-    WINDING_DEPARTMENT: this.departmentStatusesGroupedByDepartment[WINDING_DEPARTMENT],
-    PACKAGING_DEPARTMENT: this.departmentStatusesGroupedByDepartment[PACKAGING_DEPARTMENT]
+    PRE_PRINTING_DEPARTMENT: this.departmentToStatusesMappingForTicketObjects[PRE_PRINTING_DEPARTMENT],
+    PRINTING_DEPARTMENT: this.departmentToStatusesMappingForTicketObjects[PRINTING_DEPARTMENT],
+    CUTTING_DEPARTMENT: this.departmentToStatusesMappingForTicketObjects[CUTTING_DEPARTMENT],
+    WINDING_DEPARTMENT: this.departmentToStatusesMappingForTicketObjects[WINDING_DEPARTMENT],
+    PACKAGING_DEPARTMENT: this.departmentToStatusesMappingForTicketObjects[PACKAGING_DEPARTMENT]
 };
 
 module.exports.COMPLETE_DEPARTMENT = COMPLETE_DEPARTMENT;
 
-module.exports.getAllDepartmentStatuses = () => {
-    let allDepartmentStatuses = [];
-
-    Object.values(this.departmentStatusesGroupedByDepartment).forEach((departmentStatusesForOneDepartment) => {
-        allDepartmentStatuses.push(...departmentStatusesForOneDepartment);
-    });
-
-    return allDepartmentStatuses;
-};
-
 module.exports.getAllDepartments = () => {
-    return Object.keys(this.departmentStatusesGroupedByDepartment);
+    return Object.keys(this.departmentToStatusesMappingForTicketObjects);
 };
 
 module.exports.getAllDepartmentsWithDepartmentStatuses = () => {
@@ -128,7 +115,7 @@ module.exports.getAllDepartmentsWithDepartmentStatuses = () => {
     let allDepartments = this.getAllDepartments();
 
     allDepartments.forEach((department) => {
-        const containsAtLeastOneDepartmentStatus = this.departmentStatusesGroupedByDepartment[department].length > 0; // eslint-disable-line no-magic-numbers
+        const containsAtLeastOneDepartmentStatus = this.departmentToStatusesMappingForTicketObjects[department].length > 0; // eslint-disable-line no-magic-numbers
 
         if (containsAtLeastOneDepartmentStatus) {
             departmentsWithAtLeastOneDepartmentStatus.push(department);

--- a/application/enums/departmentsEnum.js
+++ b/application/enums/departmentsEnum.js
@@ -140,4 +140,4 @@ module.exports.getAllDepartmentsWithDepartmentStatuses = () => {
 
 module.exports.isInProgressDepartmentStatus = (departmentStatus) => {
     return departmentStatus === IN_PROGRESS;
-}
+};

--- a/application/enums/departmentsEnum.js
+++ b/application/enums/departmentsEnum.js
@@ -137,3 +137,7 @@ module.exports.getAllDepartmentsWithDepartmentStatuses = () => {
 
     return departmentsWithAtLeastOneDepartmentStatus;
 };
+
+module.exports.isInProgressDepartmentStatus = (departmentStatus) => {
+    return departmentStatus === IN_PROGRESS;
+}

--- a/application/models/destination.js
+++ b/application/models/destination.js
@@ -1,7 +1,7 @@
 const mongoose = require('mongoose');
 mongoose.Schema.Types.String.set('trim', true);
 const Schema = mongoose.Schema;
-const {getAllDepartments, departmentStatusesGroupedByDepartment} = require('../enums/departmentsEnum');
+const {getAllDepartments, departmentToStatusesMappingForTicketObjects} = require('../enums/departmentsEnum');
 
 function isDepartmentAndDepartmentStatusCombinationValid(department, departmentStatus) {
     const lengthOfEmptyArray = 0;
@@ -10,7 +10,7 @@ function isDepartmentAndDepartmentStatusCombinationValid(department, departmentS
         return false;
     }
 
-    const allowedStatuses = departmentStatusesGroupedByDepartment[department];
+    const allowedStatuses = departmentToStatusesMappingForTicketObjects[department];
     const noDepartmentStatusesExistForThisDepartment = allowedStatuses.length === lengthOfEmptyArray;
 
     if (noDepartmentStatusesExistForThisDepartment && !departmentStatus) {

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -650,7 +650,7 @@ $( document ).ready(function() {
         const ticketAttributesToUpdate = {
             destination: {
                 department,
-                departmentStatus: 'IN PROGRESSs'
+                departmentStatus: 'IN PROGRESS'
             }
         };
 

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -643,6 +643,25 @@ $( document ).ready(function() {
         $(this).closest('.table-row-wrapper').find('.start-job-bg-overlay').addClass('active');
     });
 
+    $('.status-section').on('click', '.start-ticket-button', function() {
+        alert('you clkicked start');
+        
+        // Step 1) Update ticket: set the departmentStatus to "in-progress" within the specified department
+        const ticketObjectId = $(this).data('ticket-id');
+        const department = $(this).data('department');
+
+        const ticketAttributesToUpdate = {
+            destination: {
+                department,
+                departmentStatus: 'IN PROGRESS'
+            }
+        };
+
+        updateTicket(ticketAttributesToUpdate, ticketObjectId, () => {
+            window.location.href = `/tickets/in-progress/${ticketObjectId}`;
+        });
+    });
+
     $('.status-section').on('click', '.start-job-bg-overlay .fa-xmark-large', function() {
         $('.start-job-bg-overlay').removeClass('active');
     });

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -644,9 +644,6 @@ $( document ).ready(function() {
     });
 
     $('.status-section').on('click', '.start-ticket-button', function() {
-        alert('you clkicked start');
-        
-        // Step 1) Update ticket: set the departmentStatus to "in-progress" within the specified department
         const ticketObjectId = $(this).data('ticket-id');
         const department = $(this).data('department');
 

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -650,7 +650,7 @@ $( document ).ready(function() {
         const ticketAttributesToUpdate = {
             destination: {
                 department,
-                departmentStatus: 'IN PROGRESS'
+                departmentStatus: 'IN PROGRESSs'
             }
         };
 

--- a/application/services/ticketService.js
+++ b/application/services/ticketService.js
@@ -1,5 +1,5 @@
 const {PRODUCT_NUMBER_IS_FOR_AN_EXTRA_CHARGE} = require('../services/chargeService');
-const {departmentStatusesGroupedByDepartment, getAllDepartmentsWithDepartmentStatuses, COMPLETE_DEPARTMENT} = require('../enums/departmentsEnum');
+const {departmentToStatusesMappingForTicketObjects, getAllDepartmentsWithDepartmentStatuses, COMPLETE_DEPARTMENT} = require('../enums/departmentsEnum');
 const TicketModel = require('../models/ticket');
 
 function isEmptyObject(value) {
@@ -109,7 +109,7 @@ function buildTicketsGroupedByDestinationDataStructure(departmentsWithStatuses) 
     departmentsWithStatuses.forEach((department) => {
         ticketsGroupedByDestination[department] = {};
 
-        const departmentStatuses = departmentStatusesGroupedByDepartment[department];
+        const departmentStatuses = departmentToStatusesMappingForTicketObjects[department];
 
         departmentStatuses.forEach((departmentStatus) => {
             ticketsGroupedByDestination[department][departmentStatus] = [];

--- a/application/views/partials/start-job-modal.ejs
+++ b/application/views/partials/start-job-modal.ejs
@@ -7,6 +7,7 @@
             </div>
             <div class='modal-body flex-center-center-column'>
                 <h1 class='start-modal-ticket-number'><%= ticket.ticketNumber || 'N/A' %></h1>
+                <h1 class='start-modal-ticket-number'><%= ticket.destination || 'N/A' %></h1>
                 <select name="machine-list" id="machine">
                     <option>Press 1</option>
                     <option>Press 2</option>
@@ -15,7 +16,7 @@
                 </select>
             </div>
             <div class='modal-footer flex-center-space-evenly-row'>
-                <button class='btn btn-primary'>Cancel</button><button class='btn btn-primary'>Start Job</button>
+                <button class='btn btn-primary'>Cancel</button><button data-department="<%= ticket.destination ? ticket.destination.department : 'N/A' %>" data-ticket-id="<%= ticket._id %>" class='btn btn-primary start-ticket-button'>Start Job</button>
             </div>
         </div>
     </div>

--- a/application/views/partials/start-job-modal.ejs
+++ b/application/views/partials/start-job-modal.ejs
@@ -7,7 +7,6 @@
             </div>
             <div class='modal-body flex-center-center-column'>
                 <h1 class='start-modal-ticket-number'><%= ticket.ticketNumber || 'N/A' %></h1>
-                <h1 class='start-modal-ticket-number'><%= ticket.destination || 'N/A' %></h1>
                 <select name="machine-list" id="machine">
                     <option>Press 1</option>
                     <option>Press 2</option>

--- a/application/views/viewOneInProgressTicket.ejs
+++ b/application/views/viewOneInProgressTicket.ejs
@@ -1,0 +1,1 @@
+<h1>Ahhhhhhhhh :)</h1>

--- a/application/views/viewTickets.ejs
+++ b/application/views/viewTickets.ejs
@@ -40,15 +40,12 @@
     <% const orderPrepOnHold = orderPrepTicketsGroupedByDepartmentStatus['ON HOLD'] %>
     <% const orderPrepProofingComplete = orderPrepTicketsGroupedByDepartmentStatus['PROOFING COMPLETE'] %>
     <% const orderPrepWaitingOnCustomerTickets = orderPrepTicketsGroupedByDepartmentStatus['WAITING ON CUSTOMER'] %>
-    <% const orderPrepDieOrPlateReady = orderPrepTicketsGroupedByDepartmentStatus['DIE OR PLATE READY'] %>
     <% const orderPrepWaitingOnApproval = orderPrepTicketsGroupedByDepartmentStatus['WAITING ON APPROVAL'] %>
 
     <% const artPrepNeedsAttentionTickets = artPrepTicketsGroupedByDepartmentStatus['NEEDS ATTENTION'] %>
     <% const artPrepOnHold = artPrepTicketsGroupedByDepartmentStatus['ON HOLD'] %>
     <% const artPrepInProgressTickets = artPrepTicketsGroupedByDepartmentStatus['IN PROGRESS'] %>
     <% const artPrepNeedsProofTickets = artPrepTicketsGroupedByDepartmentStatus['NEEDS PROOF'] %>
-    <% const artPrepNeedsDieLineTickets = artPrepTicketsGroupedByDepartmentStatus['NEEDS DIE LINE'] %>
-    <% const artPrepNeedsPlateTickets = artPrepTicketsGroupedByDepartmentStatus['NEEDS PLATE'] %>
 
     <% const prePrintingNeedsAttentionTickets = prePrintingTicketsGroupedByDepartmentStatus['NEEDS ATTENTION'] %>
     <% const prePrintingOnHoldTickets = prePrintingTicketsGroupedByDepartmentStatus['ON HOLD'] %>
@@ -91,6 +88,9 @@
     <% const orderPrepReadyToOrderTickets = [] %>
     <% const orderPrepInProgressTickets = [] %>
     <% const orderPrepWaitingOnApprovalTickets = [] %>
+
+    <% const artPrepNeedsDieLineTickets = [] %>
+    <% const artPrepNeedsPlateTickets = [] %>
 
     <% const prePrintingSendToPressTickets = [] %>
   

--- a/test/enums/departmentsEnum.spec.js
+++ b/test/enums/departmentsEnum.spec.js
@@ -1,62 +1,77 @@
-const {getAllDepartmentStatuses, getAllDepartments, productionDepartmentsAndDepartmentStatuses, isInProgressDepartmentStatus} = require('../../application/enums/departmentsEnum');
+const {getAllDepartments, productionDepartmentsAndDepartmentStatuses, isInProgressDepartmentStatus, departmentToStatusesMappingForTicketObjects} = require('../../application/enums/departmentsEnum');
 const chance = require('chance').Chance();
 
 describe('departmentsEnum', () => {
-    it('should return the list of departmentStatus', () => {
-        const expectedNumberOfDepartmentStatuses = 40;
-        const expectedNumberOfUniqueDepartmentStatuses = 23;
-
-        const departmentStatuses = getAllDepartmentStatuses();
-        const uniqueDepartmentStatuses = new Set(departmentStatuses);
-
-        console.log(uniqueDepartmentStatuses.size);
-
-        expect(departmentStatuses.length).toBe(expectedNumberOfDepartmentStatuses);
-        expect(uniqueDepartmentStatuses.size).toBe(expectedNumberOfUniqueDepartmentStatuses);
+    describe('getAllDepartments()', () => {
+        it('should return the list of departments', () => {
+            const expectedNumberOfDepartments = 10;
+    
+            const departments = getAllDepartments();
+    
+            expect(departments.length).toBe(expectedNumberOfDepartments);
+        });
     });
 
-    it('should return the list of departments', () => {
-        const expectedNumberOfDepartments = 10;
-
-        const departments = getAllDepartments();
-
-        expect(departments.length).toBe(expectedNumberOfDepartments);
+    describe('productionDepartmentsAndDepartmentStatuses', () => {
+        it('should return the correct number of production departments', () => {
+            const expectedNumberOfDepartments = 5;
+    
+            const productionDepartments = Object.keys(productionDepartmentsAndDepartmentStatuses);
+    
+            expect(productionDepartments.length).toBe(expectedNumberOfDepartments);
+        });
+    
+        it('should have at least one departmentStatus for all production departments', () => {
+            let doesDepartmentContainZeroDepartmentStatuses = false;
+            const emptyLength = 0;
+    
+            Object.keys(productionDepartmentsAndDepartmentStatuses).forEach((department) => {
+                const departmentStatuses = productionDepartmentsAndDepartmentStatuses[department];
+                if (!departmentStatuses || departmentStatuses.length === emptyLength) {
+                    doesDepartmentContainZeroDepartmentStatuses = true;
+                }
+            });
+    
+            expect(doesDepartmentContainZeroDepartmentStatuses).toBe(false);
+        });
+    
+        it('should have the correct number of production departmentStatuses', () => {
+            let expectedNumberOfProductionDepartmentStatuses = 21;
+            let allProductionDepartmentStatuses = [];
+    
+            Object.keys(productionDepartmentsAndDepartmentStatuses).forEach((department) => {
+                const departmentStatuses = productionDepartmentsAndDepartmentStatuses[department];
+                if (departmentStatuses) {
+                    allProductionDepartmentStatuses.push(...departmentStatuses);
+                }
+            });
+    
+            expect(expectedNumberOfProductionDepartmentStatuses).toBe(allProductionDepartmentStatuses.length);
+        });
     });
 
-    it('should return the correct number of production departments', () => {
-        const expectedNumberOfDepartments = 5;
-
-        const productionDepartments = Object.keys(productionDepartmentsAndDepartmentStatuses);
-
-        expect(productionDepartments.length).toBe(expectedNumberOfDepartments);
-    });
-
-    it('should have at least one departmentStatus for all production departments', () => {
-        let doesDepartmentContainZeroDepartmentStatuses = false;
-        const emptyLength = 0;
-
-        Object.keys(productionDepartmentsAndDepartmentStatuses).forEach((department) => {
-            const departmentStatuses = productionDepartmentsAndDepartmentStatuses[department];
-            if (!departmentStatuses || departmentStatuses.length === emptyLength) {
-                doesDepartmentContainZeroDepartmentStatuses = true;
-            }
+    describe('departmentToStatusesMappingForTicketObjects', () => {
+        it('should have the correct number of departmentStatuses', () => {
+            let expectedNumberOfProductionDepartmentStatuses = 37;
+            let allProductionDepartmentStatuses = [];
+    
+            Object.keys(departmentToStatusesMappingForTicketObjects).forEach((department) => {
+                const departmentStatuses = departmentToStatusesMappingForTicketObjects[department];
+                if (departmentStatuses) {
+                    allProductionDepartmentStatuses.push(...departmentStatuses);
+                }
+            });
+    
+            expect(allProductionDepartmentStatuses.length).toBe(expectedNumberOfProductionDepartmentStatuses);
         });
 
-        expect(doesDepartmentContainZeroDepartmentStatuses).toBe(false);
-    });
-
-    it('should have the correct number of production departmentStatuses', () => {
-        let expectedNumberOfProductionDepartmentStatuses = 21;
-        let allProductionDepartmentStatuses = [];
-
-        Object.keys(productionDepartmentsAndDepartmentStatuses).forEach((department) => {
-            const departmentStatuses = productionDepartmentsAndDepartmentStatuses[department];
-            if (departmentStatuses) {
-                allProductionDepartmentStatuses.push(...departmentStatuses);
-            }
+        it('should return the correct number of production departments', () => {
+            const expectedNumberOfDepartments = 10;
+    
+            const productionDepartments = Object.keys(departmentToStatusesMappingForTicketObjects);
+    
+            expect(productionDepartments.length).toBe(expectedNumberOfDepartments);
         });
-
-        expect(expectedNumberOfProductionDepartmentStatuses).toBe(allProductionDepartmentStatuses.length);
     });
 
     describe('isInProgressDepartmentStatus()', () => {

--- a/test/enums/departmentsEnum.spec.js
+++ b/test/enums/departmentsEnum.spec.js
@@ -1,4 +1,5 @@
-const {getAllDepartmentStatuses, getAllDepartments, productionDepartmentsAndDepartmentStatuses} = require('../../application/enums/departmentsEnum');
+const {getAllDepartmentStatuses, getAllDepartments, productionDepartmentsAndDepartmentStatuses, isInProgressDepartmentStatus} = require('../../application/enums/departmentsEnum');
+const chance = require('chance').Chance();
 
 describe('departmentsEnum', () => {
     it('should return the list of departmentStatus', () => {
@@ -56,5 +57,19 @@ describe('departmentsEnum', () => {
         });
 
         expect(expectedNumberOfProductionDepartmentStatuses).toBe(allProductionDepartmentStatuses.length);
+    });
+
+    describe('isInProgressDepartmentStatus()', () => {
+        it('should return false if status IS NOT "IN PROGRESS"', () => {
+            const departmentStatus = chance.word();
+            
+            expect(isInProgressDepartmentStatus(departmentStatus)).toBe(false)
+        });
+
+        it('should return true if status IS "IN PROGRESS"', () => {
+            const departmentStatus = "IN PROGRESS";
+            
+            expect(isInProgressDepartmentStatus(departmentStatus)).toBe(true)
+        });
     });
 });

--- a/test/enums/departmentsEnum.spec.js
+++ b/test/enums/departmentsEnum.spec.js
@@ -1,4 +1,10 @@
-const {getAllDepartments, productionDepartmentsAndDepartmentStatuses, isInProgressDepartmentStatus, departmentToStatusesMappingForTicketObjects} = require('../../application/enums/departmentsEnum');
+const {
+    getAllDepartments, 
+    productionDepartmentsAndDepartmentStatuses, 
+    isInProgressDepartmentStatus, 
+    departmentToStatusesMappingForTicketObjects, 
+    removeDepartmentStatusesAUserIsNotAllowedToSelect
+} = require('../../application/enums/departmentsEnum');
 const chance = require('chance').Chance();
 
 describe('departmentsEnum', () => {
@@ -47,6 +53,44 @@ describe('departmentsEnum', () => {
             });
     
             expect(expectedNumberOfProductionDepartmentStatuses).toBe(allProductionDepartmentStatuses.length);
+        });
+    });
+
+    describe('removeDepartmentStatusesAUserIsNotAllowedToSelect()', () => {
+        it('should throw error if non-array is passed in', () => {
+            const invalidParam = undefined;
+
+            expect(() => removeDepartmentStatusesAUserIsNotAllowedToSelect(invalidParam)).toThrow();
+        });
+
+        it('should handle an empty array', () => {
+            const departmentStatusesBeforeFiltering = [];
+
+            const departmentStatusesAfterFiltering = removeDepartmentStatusesAUserIsNotAllowedToSelect(departmentStatusesBeforeFiltering);
+
+            expect(departmentStatusesAfterFiltering.length).toBe(departmentStatusesBeforeFiltering.length);
+        });
+
+        it('should not filter anything', () => {
+            const departmentStatusesWhichShouldNotBeRemoved = chance.n(chance.string, chance.integer({min: 1, max: 20}));
+
+            const departmentStatusesAfterFiltering = removeDepartmentStatusesAUserIsNotAllowedToSelect(departmentStatusesWhichShouldNotBeRemoved);
+
+            expect(departmentStatusesAfterFiltering.length).toBe(departmentStatusesWhichShouldNotBeRemoved.length);
+        });
+
+        it('should filter out "IN PROGRESS" statuses', () => {
+            const departmentStatusesWhichShouldNotBeRemoved = chance.n(chance.string, chance.integer({min: 1, max: 20}));
+            const departmentStatusThatShouldBeRemoved = 'IN PROGRESS';
+
+            const departmentStatusesAfterFiltering = removeDepartmentStatusesAUserIsNotAllowedToSelect([
+                departmentStatusThatShouldBeRemoved,
+                ...departmentStatusesWhichShouldNotBeRemoved,
+                departmentStatusThatShouldBeRemoved,
+                departmentStatusThatShouldBeRemoved
+            ]);
+
+            expect(departmentStatusesAfterFiltering.length).toBe(departmentStatusesWhichShouldNotBeRemoved.length);
         });
     });
 

--- a/test/enums/departmentsEnum.spec.js
+++ b/test/enums/departmentsEnum.spec.js
@@ -63,13 +63,13 @@ describe('departmentsEnum', () => {
         it('should return false if status IS NOT "IN PROGRESS"', () => {
             const departmentStatus = chance.word();
             
-            expect(isInProgressDepartmentStatus(departmentStatus)).toBe(false)
+            expect(isInProgressDepartmentStatus(departmentStatus)).toBe(false);
         });
 
         it('should return true if status IS "IN PROGRESS"', () => {
-            const departmentStatus = "IN PROGRESS";
+            const departmentStatus = 'IN PROGRESS';
             
-            expect(isInProgressDepartmentStatus(departmentStatus)).toBe(true)
+            expect(isInProgressDepartmentStatus(departmentStatus)).toBe(true);
         });
     });
 });

--- a/test/models/destination.spec.js
+++ b/test/models/destination.spec.js
@@ -1,6 +1,6 @@
 const chance = require('chance').Chance();
 const Destination = require('../../application/models/destination');
-const {departmentStatusesGroupedByDepartment} = require('../../application/enums/departmentsEnum');
+const {departmentToStatusesMappingForTicketObjects} = require('../../application/enums/departmentsEnum');
 const mongoose = require('mongoose');
 
 const DEPARTMENT_WITH_STATUSES = 'PRINTING';
@@ -11,7 +11,7 @@ describe('validation', () => {
 
     beforeEach(async () => {
         let department = DEPARTMENT_WITH_STATUSES;
-        let departmentStatus = chance.pickone(departmentStatusesGroupedByDepartment[department]);
+        let departmentStatus = chance.pickone(departmentToStatusesMappingForTicketObjects[department]);
 
         destinationAttributes = {
             department: department,
@@ -72,7 +72,7 @@ describe('validation', () => {
 
         it('should pass if attribute IS an accepted value', async () => {
             const validDepartment = DEPARTMENT_WITH_STATUSES;
-            const validStatus = chance.pickone(departmentStatusesGroupedByDepartment[validDepartment]);
+            const validStatus = chance.pickone(departmentToStatusesMappingForTicketObjects[validDepartment]);
             destinationAttributes.department = validDepartment;
             destinationAttributes.departmentStatus = validStatus;
             const destination = new Destination(destinationAttributes);
@@ -90,7 +90,7 @@ describe('validation', () => {
         it('should pass if attribute IS an accepted value surrounded by whitespace', async () => {
             const whitespaceToTrim = '  ';
             const validDepartment = DEPARTMENT_WITH_STATUSES;
-            const validStatus = chance.pickone(departmentStatusesGroupedByDepartment[validDepartment]);
+            const validStatus = chance.pickone(departmentToStatusesMappingForTicketObjects[validDepartment]);
             destinationAttributes.department = whitespaceToTrim + validDepartment + whitespaceToTrim;
             destinationAttributes.departmentStatus = whitespaceToTrim + validStatus + whitespaceToTrim;
             const destination = new Destination(destinationAttributes);

--- a/test/models/ticket.spec.js
+++ b/test/models/ticket.spec.js
@@ -3,7 +3,7 @@ const TicketModel = require('../../application/models/ticket');
 const WorkflowStepModel = require('../../application/models/WorkflowStep');
 const databaseService = require('../../application/services/databaseService');
 const {standardPriority, getAllPriorities} = require('../../application/enums/priorityEnum');
-const {getAllDepartmentsWithDepartmentStatuses, departmentStatusesGroupedByDepartment} = require('../../application/enums/departmentsEnum');
+const {getAllDepartmentsWithDepartmentStatuses, departmentToStatusesMappingForTicketObjects} = require('../../application/enums/departmentsEnum');
 
 const LENGTH_OF_ONE = 1;
 const EMPTY_LENGTH = 0;
@@ -753,7 +753,7 @@ describe('validation', () => {
                 const randomDepartment = chance.pickone(getAllDepartmentsWithDepartmentStatuses());
                 const newTicketDestination = {
                     department: randomDepartment,
-                    departmentStatus: chance.pickone(departmentStatusesGroupedByDepartment[randomDepartment])
+                    departmentStatus: chance.pickone(departmentToStatusesMappingForTicketObjects[randomDepartment])
                 };
     
                 let savedTicket = await ticket.save({validateBeforeSave: false});
@@ -769,7 +769,7 @@ describe('validation', () => {
                 const randomDepartment = chance.pickone(getAllDepartmentsWithDepartmentStatuses());
                 const newTicketDestination = {
                     department: randomDepartment,
-                    departmentStatus: chance.pickone(departmentStatusesGroupedByDepartment[randomDepartment])
+                    departmentStatus: chance.pickone(departmentToStatusesMappingForTicketObjects[randomDepartment])
                 };
                 let savedTicket = await ticket.save({validateBeforeSave: false});
                 await TicketModel.findOneAndUpdate({_id: savedTicket._id}, {$set: {destination: newTicketDestination}}, {runValidators: true}).exec();
@@ -806,7 +806,7 @@ describe('validation', () => {
     
                 for (let i=0; i < numberOfUpdatesToTicketDestination; i++) {
                     const department = chance.pickone(departments);
-                    const departmentStatus = chance.pickone(departmentStatusesGroupedByDepartment[department]);
+                    const departmentStatus = chance.pickone(departmentToStatusesMappingForTicketObjects[department]);
     
                     newTicketDestination = {
                         department,
@@ -829,7 +829,7 @@ describe('validation', () => {
                 const randomDepartment = chance.pickone(getAllDepartmentsWithDepartmentStatuses());
                 const newTicketDestination = {
                     department: randomDepartment,
-                    departmentStatus: chance.pickone(departmentStatusesGroupedByDepartment[randomDepartment])
+                    departmentStatus: chance.pickone(departmentToStatusesMappingForTicketObjects[randomDepartment])
                 };
                 const savedTicket = await ticket.save({validateBeforeSave: false});
 
@@ -844,7 +844,7 @@ describe('validation', () => {
                 const randomDepartment = chance.pickone(getAllDepartmentsWithDepartmentStatuses());
                 const newTicketDestination = {
                     department: randomDepartment,
-                    departmentStatus: chance.pickone(departmentStatusesGroupedByDepartment[randomDepartment])
+                    departmentStatus: chance.pickone(departmentToStatusesMappingForTicketObjects[randomDepartment])
                 };
                 let savedTicket = await ticket.save({validateBeforeSave: false});
 
@@ -882,7 +882,7 @@ describe('validation', () => {
     
                 for (let i=0; i < numberOfUpdatesToTicketDestination; i++) {
                     const department = chance.pickone(departments);
-                    const departmentStatus = chance.pickone(departmentStatusesGroupedByDepartment[department]);
+                    const departmentStatus = chance.pickone(departmentToStatusesMappingForTicketObjects[department]);
     
                     newTicketDestination = {
                         department,

--- a/test/models/workflowStep.spec.js
+++ b/test/models/workflowStep.spec.js
@@ -1,6 +1,6 @@
 const chance = require('chance').Chance();
 const WorkflowStep = require('../../application/models/WorkflowStep');
-const {departmentStatusesGroupedByDepartment} = require('../../application/enums/departmentsEnum');
+const {departmentToStatusesMappingForTicketObjects} = require('../../application/enums/departmentsEnum');
 const mongoose = require('mongoose');
 
 const DEPARTMENT_WITH_STATUSES = 'PRINTING';
@@ -10,7 +10,7 @@ describe('validation', () => {
 
     beforeEach(() => {
         let department = DEPARTMENT_WITH_STATUSES;
-        let departmentStatus = chance.pickone(departmentStatusesGroupedByDepartment[department]);
+        let departmentStatus = chance.pickone(departmentToStatusesMappingForTicketObjects[department]);
 
         workFlowStepAttributes = {
             ticketId: new mongoose.Types.ObjectId(),

--- a/test/services/ticketService.spec.js
+++ b/test/services/ticketService.spec.js
@@ -1,6 +1,6 @@
 const chance = require('chance').Chance();
 const ticketService = require('../../application/services/ticketService');
-const {getAllDepartmentsWithDepartmentStatuses, departmentStatusesGroupedByDepartment, getAllDepartmentStatuses, COMPLETE_DEPARTMENT} = require('../../application/enums/departmentsEnum');
+const {getAllDepartmentsWithDepartmentStatuses, departmentToStatusesMappingForTicketObjects, COMPLETE_DEPARTMENT} = require('../../application/enums/departmentsEnum');
 
 const mockTicketModel = require('../../application/models/ticket');
 jest.mock('../../application/models/ticket');
@@ -205,6 +205,11 @@ describe('ticketService test suite', () => {
             const emptyTicketsArray = [];
             const groupedTicketsByDepartment = ticketService.groupTicketsByDestination(emptyTicketsArray);
             let departmentStatusesInDataStructure = [];
+            let allDepartmentStatuses = [];
+
+            Object.values(departmentToStatusesMappingForTicketObjects).forEach((departmentStatusesForOneDepartment) => {
+                allDepartmentStatuses.push(...departmentStatusesForOneDepartment);
+            });
 
             Object.keys(groupedTicketsByDepartment).forEach((departmentName) => {
                 const group = groupedTicketsByDepartment[departmentName];
@@ -217,7 +222,7 @@ describe('ticketService test suite', () => {
 
             console.log(departmentStatusesInDataStructure);
 
-            expect(departmentStatusesInDataStructure.length).toBe(getAllDepartmentStatuses().length);
+            expect(departmentStatusesInDataStructure.length).toBe(allDepartmentStatuses.length);
         });
 
         it('should ignore tickets whose department and/or departmentStatus is unknown', () => {
@@ -249,7 +254,7 @@ function countNumberOfTicketsGroupedByDestination(ticketsGroupedByDestination) {
 
 function buildATicketWithAValidDesintation() {
     const departmentWithAtLeastOneDepartmentStatus = chance.pickone(getAllDepartmentsWithDepartmentStatuses());
-    const departmentStatus = chance.pickone(departmentStatusesGroupedByDepartment[departmentWithAtLeastOneDepartmentStatus]);
+    const departmentStatus = chance.pickone(departmentToStatusesMappingForTicketObjects[departmentWithAtLeastOneDepartmentStatus]);
 
     return {
         destination: {

--- a/test/services/workflowStepService.spec.js
+++ b/test/services/workflowStepService.spec.js
@@ -1,6 +1,6 @@
 const workflowStepService = require('../../application/services/workflowStepService');
 const chance = require('chance').Chance();
-const {productionDepartmentsAndDepartmentStatuses, getAllDepartments, departmentStatusesGroupedByDepartment} = require('../../application/enums/departmentsEnum');
+const {productionDepartmentsAndDepartmentStatuses, getAllDepartments, departmentToStatusesMappingForTicketObjects} = require('../../application/enums/departmentsEnum');
 
 const TIME_SPENT_IN_DEPARTMENT = 'timeSpentInDepartment';
 const TIME_PER_DEPARTMENT_STATUS = 'timePerDepartmentStatus';
@@ -70,7 +70,7 @@ describe('workflowStepService test suite', () => {
 
         it('should only count the time a ticket has been in a production department/departmentStatus', () => {
             const nonProductionDepartment = getNonProductionDepartments()[0];
-            const nonProductionDepartmentDepartmentStatuses = departmentStatusesGroupedByDepartment[nonProductionDepartment];
+            const nonProductionDepartmentDepartmentStatuses = departmentToStatusesMappingForTicketObjects[nonProductionDepartment];
             const productionDepartment = Object.keys(productionDepartmentsAndDepartmentStatuses)[0];
             const productionDepartmentDepartmentStatuses = productionDepartmentsAndDepartmentStatuses[productionDepartment];
             const durationSpentWithNonProductionDepartmentStatus = chance.floating({min: 0});


### PR DESCRIPTION
# Description

This PR does a couple things (woops).

  1. Adds a new view called `viewOneInProgressTicket.ejs` which is rendered when a user selects `Start Ticket` via a modal on `viewTickets.ejs`
  2. Updates the departmentStatuses that a ticket can be moved to. The list of acceptable departmentStatuses a ticket can be moved to are found in `departmentsEnum.ejs`
  3. Ensures that a user cannot manually set an "IN PROGRESS" departmentStatus on a ticket, this is only allowed to be done programmatically

Previously a `TICKET` mongoDb object was only allowed to have specific strings (an enum) set onto it's `destination.department` and `destination.departmentStatus` attributes.

It was recently brought up that this list of strings needed to change, so this PR makes that change.

The list of strings that can be set onto this attribute are user selectable, and thus the frontend displays the list of newly updated strings, and some work was needed to filter out a few values that are not allowed to be set manually by the user, but were able to be set programmatically in the backend. Specifically, a user cannot set a ticket.destination.departmentStatus of `IN PROGRESS`. This is only allowed to be set programmatically, so this PR adds some code as well to make sure the user does not see this option in their selectable list on the front end.

### Verification
![image](https://user-images.githubusercontent.com/42784674/205518673-0ea4eba8-215e-4cbb-a859-488ddee7c187.png)
> `viewTickets.ejs` still loads fine

![image](https://user-images.githubusercontent.com/42784674/205518775-933f2bfd-54b6-4633-8a4f-a49336c6a39f.png)
> The user selectable departmentStatus lists are populated correctly when a user selects a department, such as `Printing` (notice, the lack of "IN PROGRESS" in the list) even though the database validation rules do support this value.