### PR TITLE
Add CircleCi CI/CD pipline to Handle Running Tests on PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,26 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+jobs:
+  say-hello:
+    # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
+    # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
+    docker:
+      - image: cimg/base:stable
+    # Add steps to the job
+    # See: https://circleci.com/docs/2.0/configuration-reference/#steps
+    steps:
+      - checkout
+      - run:
+          name: "Say hello"
+          command: "echo Hello, World!"
+
+# Invoke jobs via workflows
+# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+workflows:
+  say-hello-workflow:
+    jobs:
+      - say-hello

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - attach_workspace:
           at: ~/project
-      - heroku/deploy_to_heroku-via-git:
+      - heroku/deploy-via-git:
           force: true # force push when pushing to the heroku remote, see: https://devcenter.heroku.com/articles/git
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,14 +14,12 @@ jobs:
           command: npm run test
           name: Run tests
       - run:
-          command:
-            npm run build
+          command: npm run build
           name: Build app
       - persist_to_workspace:
           root: ~/project
           paths:
             - .
-
   deploy:
     executor: heroku/default
     steps:
@@ -33,10 +31,7 @@ jobs:
 workflows:
   test_my_app:
     jobs:
-      - setup_environment:
       - build_and_test:
-          requires:
-            - setup_environment # only deploy if the setup_environment job has completed
       - deploy:
           requires:
             - build_and_test # only deploy if the build_and_test job has completed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - attach_workspace:
           at: ~/project
       - heroku/deploy-via-git:
-          force: true # force push when pushing to the heroku remote, see: https://devcenter.heroku.com/articles/git
+          force: true
 
 workflows:
   run_tests_and_deploy:
@@ -34,7 +34,7 @@ workflows:
       - run_test_suite
       - deploy_to_heroku:
           requires:
-            - run_test_suite # only deploy_to_heroku if the run_test_suite job has completed
+            - run_test_suite
           filters:
             branches:
-              only: main # only deploy_to_heroku when on main
+              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,41 @@
-# Use the latest 2.1 version of CircleCI pipeline process engine.
-# See: https://circleci.com/docs/2.0/configuration-reference
 version: 2.1
+orbs:
+  node: circleci/node@5.0.2
+  heroku: circleci/heroku@1.2.6
 
-# Define a job to be invoked later in a workflow.
-# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
 jobs:
-  say-hello:
-    # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
-    # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
-    docker:
-      - image: cimg/base:stable
-    # Add steps to the job
-    # See: https://circleci.com/docs/2.0/configuration-reference/#steps
+  build_and_test:
+    executor: node/default
     steps:
       - checkout
+      - node/install-packages:
+          pkg-manager: npm
       - run:
-          name: "Say hello"
-          command: "echo Hello, World!"
+          command: npm run test
+          name: Run tests
+      - run:
+          command: npm run build
+          name: Build app
+      - persist_to_workspace:
+          root: ~/project
+          paths:
+            - .
 
-# Invoke jobs via workflows
-# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+  deploy:
+    executor: heroku/default
+    steps:
+      - attach_workspace:
+          at: ~/project
+      - heroku/deploy-via-git:
+          force: true # force push when pushing to the heroku remote, see: https://devcenter.heroku.com/articles/git
+
 workflows:
-  say-hello-workflow:
+  test_my_app:
     jobs:
-      - say-hello
+      - build_and_test
+      - deploy:
+          requires:
+            - build_and_test # only deploy if the build_and_test job has completed
+          filters:
+            branches:
+              only: main # only deploy when on main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
 workflows:
   test_my_app:
     jobs:
-      - build_and_test:
+      - build_and_test
       - deploy:
           requires:
             - build_and_test # only deploy if the build_and_test job has completed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,10 @@ jobs:
       - node/install-packages:
           pkg-manager: npm
       - run:
-          command: npm run test
+          command: |
+            wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
+            sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
+            npm run test
           name: Run tests
       - run:
           command: npm run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,7 @@ jobs:
           command: npm run test
           name: Run tests
       - run:
-          command: |
-            wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
-            sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
+          command:
             npm run build
           name: Build app
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,11 @@ orbs:
   heroku: circleci/heroku@1.2.6
 
 jobs:
+  setup_environment:
+  command: |
+    wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
+    sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
+    
   build_and_test:
     executor: node/default
     steps:
@@ -32,7 +37,10 @@ jobs:
 workflows:
   test_my_app:
     jobs:
-      - build_and_test
+      - setup_environment:
+      - build_and_test:
+          requires:
+            - setup_environment # only deploy if the setup_environment job has completed
       - deploy:
           requires:
             - build_and_test # only deploy if the build_and_test job has completed

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,6 @@ jobs:
             sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
             npm run test
           name: Run tests
-      - run:
-          command: npm run build
-          name: Build app
       - persist_to_workspace:
           root: ~/project
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,11 +4,6 @@ orbs:
   heroku: circleci/heroku@1.2.6
 
 jobs:
-  setup_environment:
-  command: |
-    wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
-    sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
-    
   build_and_test:
     executor: node/default
     steps:
@@ -19,7 +14,10 @@ jobs:
           command: npm run test
           name: Run tests
       - run:
-          command: npm run build
+          command: |
+            wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
+            sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
+            npm run build
           name: Build app
       - persist_to_workspace:
           root: ~/project

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,21 +20,8 @@ jobs:
           root: ~/project
           paths:
             - .
-  deploy_to_heroku:
-    executor: heroku/default
-    steps:
-      - attach_workspace:
-          at: ~/project
-      - heroku/deploy-via-git:
-          force: true
 
 workflows:
-  run_tests_and_deploy:
+  run_tests:
     jobs:
       - run_test_suite
-      - deploy_to_heroku:
-          requires:
-            - run_test_suite
-          filters:
-            branches:
-              only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,13 +4,13 @@ orbs:
   heroku: circleci/heroku@1.2.6
 
 jobs:
-  build_and_test:
+  run_test_suite:
     executor: node/default
     steps:
       - checkout
       - node/install-packages:
           pkg-manager: npm
-      - run:
+      - run:  # https://stackoverflow.com/a/72633324/9273261
           command: |
             wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
             sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
@@ -20,21 +20,21 @@ jobs:
           root: ~/project
           paths:
             - .
-  deploy:
+  deploy_to_heroku:
     executor: heroku/default
     steps:
       - attach_workspace:
           at: ~/project
-      - heroku/deploy-via-git:
+      - heroku/deploy_to_heroku-via-git:
           force: true # force push when pushing to the heroku remote, see: https://devcenter.heroku.com/articles/git
 
 workflows:
-  test_my_app:
+  run_tests_and_deploy:
     jobs:
-      - build_and_test
-      - deploy:
+      - run_test_suite
+      - deploy_to_heroku:
           requires:
-            - build_and_test # only deploy if the build_and_test job has completed
+            - run_test_suite # only deploy_to_heroku if the run_test_suite job has completed
           filters:
             branches:
-              only: main # only deploy when on main
+              only: main # only deploy_to_heroku when on main


### PR DESCRIPTION
# Description

CircleCi is a CI/CD pipeline tool that can be configured in a github project by adding a the following folder and file: `.circleci/config.yml`. Once this is added to the project, the project is automatically viewable/manageable from the circleCi website via a dashboard: https://app.circleci.com/pipelines/github/gavinvaske/the_recipe_book

I configured the .yml file such that, all the tests and linter run every time a commit is made to a PR, aka `npm run verify` executes