### PR TITLE
Update Schema Validation Rules on `Product`/`Destination` Objects

### DIFF
--- a/application/models/destination.js
+++ b/application/models/destination.js
@@ -38,10 +38,6 @@ const destinationSchema = new Schema({
     assignees: {
         type: [Schema.Types.ObjectId],
         ref: 'User'
-    },
-    machines: {
-        type: [Schema.Types.ObjectId],
-        ref: 'Machine'
     }
 }, { timestamps: true });
 

--- a/application/models/product.js
+++ b/application/models/product.js
@@ -68,7 +68,9 @@ function convertStringCurrency(numberAsString) {
 }
 
 function validateProductDie(productDie) {
-    return PRODUCT_DIE_REGEX.test(productDie);
+    const isAPressProof = productDie.toUpperCase() === 'PRESS PROOF';
+
+    return PRODUCT_DIE_REGEX.test(productDie) || isAPressProof;
 }
 
 function numberMustBeGreaterThanZero(number) {

--- a/test/models/destination.spec.js
+++ b/test/models/destination.spec.js
@@ -177,23 +177,4 @@ describe('validation', () => {
             expect(destination.assignees).toEqual(emptyArray);
         });
     });
-
-    describe('attribute: machines', () => {
-        it('should have one element which is a valid mongoose objectId', () => {
-            destinationAttributes.machines = [
-                new mongoose.Types.ObjectId()
-            ];
-            const destination = new Destination(destinationAttributes);
-
-            expect(mongoose.Types.ObjectId.isValid(destination.machines[0])).toBe(true);
-        });
-
-        it('should default to an empty array if attribute is not defined', () => {
-            delete destinationAttributes.machines;
-            const emptyArray = [];
-            const destination = new Destination(destinationAttributes);
-
-            expect(destination.machines).toEqual(emptyArray);
-        });
-    });
 });

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -154,7 +154,7 @@ describe('validation', () => {
         });
 
         it('should pass validation if string is "Press Proof"', () => {
-            const validProductDie = 'Press Proof'
+            const validProductDie = 'Press Proof';
             productAttributes.ToolNo1 = validProductDie;
             const product = new ProductModel(productAttributes);
 

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -153,6 +153,26 @@ describe('validation', () => {
             expect(error).toBe(undefined);
         });
 
+        it('should pass validation if string is "Press Proof"', () => {
+            const validProductDie = 'Press Proof'
+            productAttributes.ToolNo1 = validProductDie;
+            const product = new ProductModel(productAttributes);
+
+            const error = product.validateSync();
+            expect(error).toBe(undefined);
+        });
+        
+        it('should pass validation if string is "Press Proof" no matter what the capitalization is', () => {
+            const validProductDie = 'PreSS prOoF';
+            productAttributes.ToolNo1 = validProductDie;
+            const product = new ProductModel(productAttributes);
+
+            console.log(`press proof => ${product.productDie}`)
+
+            const error = product.validateSync();
+            expect(error).toBe(undefined);
+        });
+
         it('should contain attribute', () => {
             const product = new ProductModel(productAttributes);
 

--- a/test/models/product.spec.js
+++ b/test/models/product.spec.js
@@ -167,8 +167,6 @@ describe('validation', () => {
             productAttributes.ToolNo1 = validProductDie;
             const product = new ProductModel(productAttributes);
 
-            console.log(`press proof => ${product.productDie}`)
-
             const error = product.validateSync();
             expect(error).toBe(undefined);
         });


### PR DESCRIPTION
# Description

It was determined that the attribute "machines" which previously lived on `destination` schema was no longer required, and thus it was removed in this PR.

Also, seperately, I updated the validation rules to allow for the attribute `product.productDie` to allow for the string "Press Proof". Previously, this string would fail validation, but now it is allowed.