### PR TITLE
Update Attributes on `Destination` Schema

### DIFF
--- a/application/models/destination.js
+++ b/application/models/destination.js
@@ -35,12 +35,12 @@ const destinationSchema = new Schema({
     departmentStatus: {
         type: String
     },
-    assignees: {
-        type: [Schema.Types.ObjectId],
+    assignee: {
+        type: Schema.Types.ObjectId,
         ref: 'User'
     },
-    machines: {
-        type: [Schema.Types.ObjectId],
+    machine: {
+        type: Schema.Types.ObjectId,
         ref: 'Machine'
     }
 }, { timestamps: true });

--- a/application/models/destination.js
+++ b/application/models/destination.js
@@ -38,6 +38,10 @@ const destinationSchema = new Schema({
     assignees: {
         type: [Schema.Types.ObjectId],
         ref: 'User'
+    },
+    machines: {
+        type: [Schema.Types.ObjectId],
+        ref: 'Machine'
     }
 }, { timestamps: true });
 

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -936,7 +936,7 @@ $( document ).ready(function() {
 
     function mapTicketRowColumnSelectorToValues(ticket) {
         console.log(ticket);
-        const machineName = (ticket.destination.machines && ticket.destination.machines.length > emptyLength) ? ticket.destination.machines[0].name : '';
+        const machineName = ticket.destination.machine ? ticket.destination.machine.name : '';
         const numberOfProducts = ticket.products ? ticket.products.length : ZERO;
         return {
             [ticketNumberColumn]: ticket.shippingAttention,

--- a/test/models/destination.spec.js
+++ b/test/models/destination.spec.js
@@ -177,4 +177,23 @@ describe('validation', () => {
             expect(destination.assignees).toEqual(emptyArray);
         });
     });
+
+    describe('attribute: machines', () => {
+        it('should have one element which is a valid mongoose objectId', () => {
+            destinationAttributes.machines = [
+                new mongoose.Types.ObjectId()
+            ];
+            const destination = new Destination(destinationAttributes);
+
+            expect(mongoose.Types.ObjectId.isValid(destination.machines[0])).toBe(true);
+        });
+
+        it('should default to an empty array if attribute is not defined', () => {
+            delete destinationAttributes.machines;
+            const emptyArray = [];
+            const destination = new Destination(destinationAttributes);
+
+            expect(destination.machines).toEqual(emptyArray);
+        });
+    });
 });

--- a/test/models/destination.spec.js
+++ b/test/models/destination.spec.js
@@ -16,8 +16,8 @@ describe('validation', () => {
         destinationAttributes = {
             department: department,
             departmentStatus: departmentStatus,
-            assignees: [],
-            machines: []
+            assignee: new mongoose.Types.ObjectId(),
+            machine: new mongoose.Types.ObjectId()
         };
     });
 
@@ -159,41 +159,35 @@ describe('validation', () => {
         });
     });
 
-    describe('attribute: assignees', () => {
+    describe('attribute: assignee', () => {
         it('should have one element which is a valid mongoose objectId', () => {
-            destinationAttributes.assignees = [
-                new mongoose.Types.ObjectId()
-            ];
+            destinationAttributes.assignee = new mongoose.Types.ObjectId();
             const destination = new Destination(destinationAttributes);
 
-            expect(mongoose.Types.ObjectId.isValid(destination.assignees[0])).toBe(true);
+            expect(mongoose.Types.ObjectId.isValid(destination.assignee)).toBe(true);
         });
 
         it('should default to an empty array if attribute is not defined', () => {
-            delete destinationAttributes.assignees;
-            const emptyArray = [];
+            delete destinationAttributes.assignee;
             const destination = new Destination(destinationAttributes);
 
-            expect(destination.assignees).toEqual(emptyArray);
+            expect(destination.assignee).not.toBeDefined();
         });
     });
 
-    describe('attribute: machines', () => {
+    describe('attribute: machine', () => {
         it('should have one element which is a valid mongoose objectId', () => {
-            destinationAttributes.machines = [
-                new mongoose.Types.ObjectId()
-            ];
+            destinationAttributes.machine = new mongoose.Types.ObjectId();
             const destination = new Destination(destinationAttributes);
 
-            expect(mongoose.Types.ObjectId.isValid(destination.machines[0])).toBe(true);
+            expect(mongoose.Types.ObjectId.isValid(destination.machine)).toBe(true);
         });
 
         it('should default to an empty array if attribute is not defined', () => {
-            delete destinationAttributes.machines;
-            const emptyArray = [];
+            delete destinationAttributes.machine;
             const destination = new Destination(destinationAttributes);
 
-            expect(destination.machines).toEqual(emptyArray);
+            expect(destination.machine).not.toBeDefined();
         });
     });
 });

--- a/test/models/workflowStep.spec.js
+++ b/test/models/workflowStep.spec.js
@@ -17,8 +17,8 @@ describe('validation', () => {
             destination: {
                 department: department,
                 departmentStatus: departmentStatus,
-                assignees: [],
-                machines: []
+                assignee: new mongoose.Types.ObjectId(),
+                machine: new mongoose.Types.ObjectId()
             }
         };
     });


### PR DESCRIPTION
# Description

This PR does 2 things:
  1. Reverts one commit from #206 that removed the "machines" attribute from the mongoose `destination` schema
  2. Converts the `machines` attribute and `assignees` attribute on the mongoose `destination` schema to their singular equivalent