### PR TITLE
Add attribute: `ticket.totalMaterialLength` and Update Column Names in `viewTickets.ejs`

### DIFF
--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -230,6 +230,20 @@ const ticketSchema = new Schema({
             return sum;
         }
     },
+    totalMaterialLength: {
+        type: Number,
+        required: true,
+        default: function() {
+            let sum = 0; // eslint-disable-line no-magic-numbers
+
+            if (this.products.length) {
+                this.products.forEach((product) => {
+                    sum = sum + product.totalFeet;
+                });
+            }
+            return sum;
+        }
+    },
     customerName: {
         type: String,
         required: true,

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -929,16 +929,6 @@ $( document ).ready(function() {
     const assigneeNameColumn = '.assignee-name-column';
     const assigneeProfilePictureColumn = '.assignee-picture-url-column';
 
-    function sumTheLengthOfMaterialForEachProduct(products) {
-        let totalMaterialLength = 0;
-
-        products && products.forEach((product) => {
-            totalMaterialLength += product.totalFeet;
-        });
-
-        return totalMaterialLength;
-    }
-
     function getDieCuttingFinishFromTheFirstProduct(products) {
         if (!products || products.length === ZERO) {
             return;
@@ -954,28 +944,24 @@ $( document ).ready(function() {
         const productDie = (ticket.products && ticket.products.length > ZERO) ? ticket.products[0].productDie : 'N/A';
         const assigneeName = ticket.destination.assignee ? ticket.destination.assignee.fullName : 'N/A';
         const assigneeProfilePicture = ticket.destination.assignee ? ticket.destination.assignee.profilePicture : '';
-        const totalLengthOfMaterialInFeet = sumTheLengthOfMaterialForEachProduct(ticket.products);
         const dieCuttingFinish = getDieCuttingFinishFromTheFirstProduct(ticket.products);
-
-        console.log(`assigneeName => ${assigneeName}`);
-        console.log(`assigneeProfilePicture => ${assigneeProfilePicture}`);
 
         return {
             [ticketNumberColumn]: `#${ticket.ticketNumber}`,
-            [departmentNameColumn]: ticket.destination ? ticket.destination.department : '-',
-            [departmentStatusNameColumn]: ticket.destination ? ticket.destination.departmentStatus : '-',
+            [departmentNameColumn]: ticket.destination ? ticket.destination.department : undefined,
+            [departmentStatusNameColumn]: ticket.destination ? ticket.destination.departmentStatus : undefined,
             [assigneeNameColumn]: assigneeName,
             [assigneeProfilePictureColumn]: assigneeProfilePicture,
             [holdStatusColumn]: 'TODO: .hold-status-column',
-            [lengthColumn]: totalLengthOfMaterialInFeet,
-            [materialColumn]: ticket.primaryMaterial ? ticket.primaryMaterial : '-',
+            [lengthColumn]: ticket.totalMaterialLength,
+            [materialColumn]: ticket.primaryMaterial,
             [dieColumn]: productDie,
             [totalRollsColumn]: ticket.totalWindingRolls,
             [groupedColumn]: 'TODO: .grouped-column',
             [productCountColumn]: numberOfProducts,
             [dueDateColumn]: formatDate(ticket.shipDate, {month:'short', day:'numeric'}),
             [fromColumn]: 'TODO: .from-column',
-            [dieFinishColumn]: dieCuttingFinish ? dieCuttingFinish : '-',
+            [dieFinishColumn]: dieCuttingFinish,
             [sentDateColumn]: 'TODO: .sent-date-column',
             [followUpDateColumn]: 'TODO: .follow-up-date-column'
         };

--- a/application/views/viewTickets.ejs
+++ b/application/views/viewTickets.ejs
@@ -108,10 +108,10 @@
               <div class='column-header column-header-c'>Ticket Number</div>
               <div class='column-header column-header-d'>Status</div>
               <div class='column-header column-header-e'>Hold Status</div>
-              <div class='column-header column-header-f'>Length</div>
-              <div class='column-header column-header-g'>Material</div>
-              <div class='column-header column-header-h'>Products</div>
-              <div class='column-header column-header-i'>Due Date</div>
+              <div class='column-header column-header-f'></div>
+              <div class='column-header column-header-g'></div>
+              <div class='column-header column-header-h'></div>
+              <div class='column-header column-header-i'></div>
             </div>
             <div id='order-prep-on-hold-table' class='table-body flex-center-center-column'>
               <% orderPrepOnHold.forEach((ticket, index) => { %>
@@ -131,7 +131,7 @@
                   <div class='column-td column-td-b bg-white row-number'><%= index + 1 %></div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %> </div>
                   <div class='column-td column-td-d bg-white department-status-column'>ON HOLD</div>
-                  <div class='column-td column-td-e bg-white hold-status-column'></div>
+                  <div class='column-td column-td-e bg-white'>*TODO*</div>
                   <div class='column-td column-td-f bg-white'></div>
                   <div class='column-td column-td-g bg-white'></div>
                   <div class='column-td column-td-h bg-white'></div>
@@ -243,8 +243,8 @@
                   <div class='column-td column-td-d bg-white department-status-column'>WAITING ON CUSTOMER</div>
                   <div class='column-td column-td-e bg-white'></div>
                   <div class='column-td column-td-f bg-white'></div>
-                  <div class='column-td column-td-g bg-white follow-up-date-column'>July 2 (TODO)</div>
-                  <div class='column-td column-td-h bg-white sent-date-column'>July 1 (TODO)</div>
+                  <div class='column-td column-td-g bg-white follow-up-date-column'>*TODO*</div>
+                  <div class='column-td column-td-h bg-white'>*TODO*</div>
                   <div class='column-td column-td-i bg-white due-date-column'><%= helperMethods.getSimpleDate(ticket.shipDate) %></div>
                 </div>
                 <%- include('partials/products-wrapper.ejs', {
@@ -274,7 +274,7 @@
               <div class='column-header column-header-d'>Status</div>
               <div class='column-header column-header-e'></div>
               <div class='column-header column-header-f'></div>
-              <div class='column-header column-header-g'>Follow Up Date </div>
+              <div class='column-header column-header-g'>Follow Up Date</div>
               <div class='column-header column-header-h'>Sent Date</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
@@ -298,8 +298,8 @@
                   <div class='column-td column-td-d bg-white department-status-column'>WAITING ON APPROVAL</div>
                   <div class='column-td column-td-e bg-white'></div>
                   <div class='column-td column-td-f bg-white'></div>
-                  <div class='column-td column-td-g bg-white follow-up-date-column'>July 2 (TODO)</div>
-                  <div class='column-td column-td-h bg-white sent-date-column'>July 1 (TODO)</div>
+                  <div class='column-td column-td-g bg-white follow-up-date-column'>*TODO*</div>
+                  <div class='column-td column-td-h bg-white'>*TODO*</div>
                   <div class='column-td column-td-i bg-white due-date-column'><%= helperMethods.getSimpleDate(ticket.shipDate) %></div>
                 </div>
                 <%- include('partials/products-wrapper.ejs', {
@@ -367,7 +367,7 @@
                   <div class='column-td column-td-h bg-white'>
                     <div class='user-cell bg-blue tooltip'>SV
                       <span class="tooltiptext">Storm Vaske (TODO)</span>
-                    </div><span class='department-name from-column'>Press 1 (TODO)</span>
+                    </div><span class='department-name'>Press 1 (TODO)</span>
                   </div>
                   <div class='column-td column-td-i bg-white due-date-column'><%= helperMethods.getSimpleDate(ticket.shipDate) %></div>
                 </div>
@@ -397,9 +397,9 @@
               <div class='column-header column-header-c'>Ticket Number</div>
               <div class='column-header column-header-d'>Status</div>
               <div class='column-header column-header-e'>Hold Status</div>
-              <div class='column-header column-header-f'>Length</div>
-              <div class='column-header column-header-g'>Material</div>
-              <div class='column-header column-header-h'>Products</div>
+              <div class='column-header column-header-f'></div>
+              <div class='column-header column-header-g'></div>
+              <div class='column-header column-header-h'>From</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
             <div id='art-prep-on-hold-table' class='table-body flex-center-center-column'>
@@ -420,7 +420,7 @@
                   <div class='column-td column-td-b bg-white row-number'><%= index + 1 %></div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %> </div>
                   <div class='column-td column-td-d bg-white department-status-column'>ON HOLD</div>
-                  <div class='column-td column-td-e bg-white hold-status-column'></div>
+                  <div class='column-td column-td-e bg-white'>*TODO*</div>
                   <div class='column-td column-td-f bg-white'></div>
                   <div class='column-td column-td-g bg-white'></div>
                   <div class='column-td column-td-h bg-white'></div>
@@ -451,7 +451,7 @@
               <div class='column-header column-header-b'>#</div>
               <div class='column-header column-header-c'>Ticket Number</div>
               <div class='column-header column-header-d'>Status</div>
-              <div class='column-header column-header-e'></div>
+              <div class='column-header column-header-e'>Location</div>
               <div class='column-header column-header-f'></div>
               <div class='column-header column-header-g'></div>
               <div class='column-header column-header-h'></div>
@@ -508,8 +508,8 @@
               <div class='column-header column-header-d'>Status</div>
               <div class='column-header column-header-e'></div>
               <div class='column-header column-header-f'></div>
-              <div class='column-header column-header-g'>Follow Up Date </div>
-              <div class='column-header column-header-h'>Sent Date</div>
+              <div class='column-header column-header-g'></div>
+              <div class='column-header column-header-h'>Proofs</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
             <div id='art-prep-needs-proof-table' class='table-body flex-center-center-column'>
@@ -532,8 +532,8 @@
                   <div class='column-td column-td-d bg-white department-status-column'>NEEDS PROOF</div>
                   <div class='column-td column-td-e bg-white'></div>
                   <div class='column-td column-td-f bg-white'></div>
-                  <div class='column-td column-td-g bg-white follow-up-date-column'>July 2 (TODO)</div>
-                  <div class='column-td column-td-h bg-white sent-date-column'>July 1 (TODO)</div>
+                  <div class='column-td column-td-g bg-white follow-up-date-column'>*TODO*</div>
+                  <div class='column-td column-td-h bg-white'>*TODO*</div>
                   <div class='column-td column-td-i bg-white due-date-column'><%= helperMethods.getSimpleDate(ticket.shipDate) %></div>
                 </div>
                 <%- include('partials/products-wrapper.ejs', {
@@ -573,7 +573,7 @@
               <div class='column-header column-header-d'>Status</div>
               <div class='column-header column-header-e'></div>
               <div class='column-header column-header-f'></div>
-              <div class='column-header column-header-g'> </div>
+              <div class='column-header column-header-g'></div>
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
@@ -629,7 +629,7 @@
               <div class='column-header column-header-e'></div>
               <div class='column-header column-header-f'></div>
               <div class='column-header column-header-g'></div>
-              <div class='column-header column-header-h'>Products</div>
+              <div class='column-header column-header-h'>From</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
             <div id='pre-printing-on-hold-table' class='table-body flex-center-center-column'>
@@ -681,10 +681,10 @@
               <div class='column-header column-header-b'>#</div>
               <div class='column-header column-header-c'>Ticket Number</div>
               <div class='column-header column-header-d'>Status</div>
-              <div class='column-header column-header-e'></div>
+              <div class='column-header column-header-e'>Location</div>
               <div class='column-header column-header-f'></div>
               <div class='column-header column-header-g'></div>
-              <div class='column-header column-header-h'>Products</div>
+              <div class='column-header column-header-h'></div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
             <div id='pre-printing-in-progress-table' class='table-body flex-center-center-column'>
@@ -738,7 +738,7 @@
               <div class='column-header column-header-d'>Status</div>
               <div class='column-header column-header-e'></div>
               <div class='column-header column-header-f'></div>
-              <div class='column-header column-header-g'> </div>
+              <div class='column-header column-header-g'></div>
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
@@ -825,8 +825,8 @@
                   <div class='column-td column-td-b bg-white row-number'><%= index + 1 %></div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %> </div>
                   <div class='column-td column-td-d bg-white department-status-column'>ON HOLD</div>
-                  <div class='column-td column-td-e bg-white hold-status-column'></div>
-                  <div class='column-td column-td-f bg-white length-column'>1,920 ft (TODO)</div>
+                  <div class='column-td column-td-e bg-white'>*TODO*</div>
+                  <div class='column-td column-td-f bg-white length-column'><%= ticket.totalMaterialLength || 'N/A' %></div>
                   <div class='column-td column-td-g bg-white material-column'><%= ticket.primaryMaterial || 'N/A' %></div>
                   <div class='column-td column-td-h bg-white product-count-column'><%= ticket.products.length %></div>
                   <div class='column-td column-td-i bg-white due-date-column'><%= helperMethods.getSimpleDate(ticket.shipDate) %></div>
@@ -883,9 +883,9 @@
                   <div class='column-td column-td-e bg-white'>
                     <div class='user-cell bg-blue tooltip'>SV
                       <span class="tooltiptext">Storm Vaske (TODO)</span>
-                    </div><span class='department-name location-column'>Press 1 (TODO)</span>
+                    </div><span class='department-name'>Press 1 (TODO)</span>
                   </div>
-                  <div class='column-td column-td-f bg-white length-column'>1,920 ft (TODO)</div>
+                  <div class='column-td column-td-f bg-white length-column'><%= ticket.totalMaterialLength || 'N/A' %></div>
                   <div class='column-td column-td-g bg-white material-column'><%= ticket.primaryMaterial || 'N/A' %></div>
                   <div class='column-td column-td-h bg-white product-count-column'><%= ticket.products.length %></div>
                   <div class='column-td column-td-i bg-white due-date-column'><%= helperMethods.getSimpleDate(ticket.shipDate) %></div>
@@ -940,7 +940,7 @@
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber %></div>
                   <div class='column-td column-td-d bg-red text-white department-status-column'>PRINTING READY</div>
                   <div class='column-td column-td-e bg-white'></div>
-                  <div class='column-td column-td-f bg-white length-column'>1,920 ft (TODO)</div>
+                  <div class='column-td column-td-f bg-white length-column'><%= ticket.totalMaterialLength || 'N/A' %></div>
                   <div class='column-td column-td-g bg-white material-column'><%= ticket.primaryMaterial || 'N/A' %></div>
                   <div class='column-td column-td-h bg-white product-count-column'><%= ticket.products.length %></div>
                   <div class='column-td column-td-i bg-white due-date-column'><%= helperMethods.getSimpleDate(ticket.shipDate) %></div>
@@ -995,7 +995,7 @@
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-red text-white department-status-column'>PRINTER ONE SCHEDULE</div>
                   <div class='column-td column-td-e bg-white'></div>
-                  <div class='column-td column-td-f bg-white length-column'>1,920 ft (TODO)</div>
+                  <div class='column-td column-td-f bg-white length-column'><%= ticket.totalMaterialLength || 'N/A' %></div>
                   <div class='column-td column-td-g bg-white material-column'><%= ticket.primaryMaterial || 'N/A' %></div>
                   <div class='column-td column-td-h bg-white product-count-column'><%= ticket.products.length %></div>
                   <div class='column-td column-td-i bg-white due-date-column'><%= helperMethods.getSimpleDate(ticket.shipDate) %></div>
@@ -1050,7 +1050,7 @@
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %> </div>
                   <div class='column-td column-td-d bg-white department-status-column'>PRINTER TWO SCHEDULE</div>
                   <div class='column-td column-td-e bg-white'></div>
-                  <div class='column-td column-td-f bg-white length-column'>1,920 ft (TODO)</div>
+                  <div class='column-td column-td-f bg-white length-column'><%= ticket.totalMaterialLength || 'N/A' %></div>
                   <div class='column-td column-td-g bg-white material-column'><%= ticket.primaryMaterial || 'N/A' %></div>
                   <div class='column-td column-td-h bg-white product-count-column'><%= ticket.products.length %></div>
                   <div class='column-td column-td-i bg-white due-date-column'><%= helperMethods.getSimpleDate(ticket.shipDate) %></div>
@@ -1091,9 +1091,9 @@
               <div class='column-header column-header-c'>Ticket Number</div>
               <div class='column-header column-header-d'>Status</div>
               <div class='column-header column-header-e'>Hold Status</div>
-              <div class='column-header column-header-f'>Die</div>
-              <div class='column-header column-header-g'>Length</div>
-              <div class='column-header column-header-h'>Finish</div>
+              <div class='column-header column-header-f'>Length</div>
+              <div class='column-header column-header-g'>Material</div>
+              <div class='column-header column-header-h'>From</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
             <div id='cutting-on-hold-table' class='table-body flex-center-center-column'>
@@ -1114,10 +1114,10 @@
                   <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %> </div>
                   <div class='column-td column-td-d bg-white department-status-column'>ON HOLD</div>
-                  <div class='column-td column-td-e bg-white'></div>
-                  <div class='column-td column-td-f bg-white length-column'>1,920 ft (TODO)</div>
+                  <div class='column-td column-td-e bg-white'>*TODO*</div>
+                  <div class='column-td column-td-f bg-white length-column'><%= ticket.totalMaterialLength || 'N/A' %></div>
                   <div class='column-td column-td-g bg-white material-column'><%= ticket.primaryMaterial || 'N/A' %></div>
-                  <div class='column-td column-td-h bg-white'>FROM (TODO)</div>
+                  <div class='column-td column-td-h bg-white'>*TODO*</div>
                   <div class='column-td column-td-i bg-white due-date-column'><%= helperMethods.getSimpleDate(ticket.shipDate) %></div>
                 </div>
                 <%- include('partials/products-wrapper.ejs', {
@@ -1146,8 +1146,8 @@
               <div class='column-header column-header-c'>Ticket Number</div>
               <div class='column-header column-header-d'>Status</div>
               <div class='column-header column-header-e'>Location</div>
-              <div class='column-header column-header-f'>Die</div>
-              <div class='column-header column-header-g'>Length</div>
+              <div class='column-header column-header-f'>Length</div>
+              <div class='column-header column-header-g'>Die</div>
               <div class='column-header column-header-h'>Finish</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
@@ -1174,7 +1174,7 @@
                       <span class="tooltiptext">Storm Vaske (TODO)</span>
                     </div><span class='department-name'>Press 1 (TODO)</span>
                   </div>
-                  <div class='column-td column-td-f bg-white length-column'>1,920 ft (TODO)</div>
+                  <div class='column-td column-td-f bg-white length-column'><%= ticket.totalMaterialLength || 'N/A' %></div>
                   <div class='column-td column-td-g bg-white die-column'><%= ticket.products && ticket.products[0].productDie %></div>
                   <div class='column-td column-td-h bg-white die-finish-column'><%= ticket.products && ticket.products[0].dieCuttingFinish %></div>
                   <div class='column-td column-td-i bg-white due-date-column'><%= helperMethods.getSimpleDate(ticket.shipDate) %></div>
@@ -1205,8 +1205,8 @@
               <div class='column-header column-header-c'>Ticket Number</div>
               <div class='column-header column-header-d'>Status</div>
               <div class='column-header column-header-e'></div>
-              <div class='column-header column-header-f'>Die</div>
-              <div class='column-header column-header-g'>Length</div>
+              <div class='column-header column-header-f'>Length</div>
+              <div class='column-header column-header-g'>Die</div>
               <div class='column-header column-header-h'>Finish</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
@@ -1229,7 +1229,7 @@
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber %></div>
                   <div class='column-td column-td-d bg-white department-status-column'>CUTTING READY</div>
                   <div class='column-td column-td-e bg-white'></div>
-                  <div class='column-td column-td-f bg-white length-column'>1,920 ft (TODO)</div>
+                  <div class='column-td column-td-f bg-white length-column'><%= ticket.totalMaterialLength || 'N/A' %></div>
                   <div class='column-td column-td-g bg-white die-column'><%= ticket.products && ticket.products[0].productDie %></div>
                   <div class='column-td column-td-h bg-white die-finish-column'><%= ticket.products && ticket.products[0].dieCuttingFinish %></div>
                   <div class='column-td column-td-i bg-white due-date-column'><%= helperMethods.getSimpleDate(ticket.shipDate) %></div>
@@ -1315,8 +1315,8 @@
               <div class='column-header column-header-c'>Ticket Number</div>
               <div class='column-header column-header-d'>Status</div>
               <div class='column-header column-header-e'></div>
-              <div class='column-header column-header-f'>Die</div>
-              <div class='column-header column-header-g'>Length</div>
+              <div class='column-header column-header-f'>Length</div>
+              <div class='column-header column-header-g'>Die</div>
               <div class='column-header column-header-h'>Finish</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
@@ -1339,7 +1339,7 @@
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber %> </div>
                   <div class='column-td column-td-d bg-white department-status-column'>DELTA TWO SCHEDULE</div>
                   <div class='column-td column-td-e bg-white'></div>
-                  <div class='column-td column-td-f bg-white length-column'>1,920 ft (TODO)</div>
+                  <div class='column-td column-td-f bg-white length-column'><%= ticket.totalMaterialLength || 'N/A' %></div>
                   <div class='column-td column-td-g bg-white die-column'><%= ticket.products && ticket.products[0].productDie %></div>
                   <div class='column-td column-td-h bg-white die-finish-column'><%= ticket.products && ticket.products[0].dieCuttingFinish %></div>
                   <div class='column-td column-td-i bg-white due-date-column'><%= helperMethods.getSimpleDate(ticket.shipDate) %></div>
@@ -1371,8 +1371,8 @@
               <div class='column-header column-header-d'>Status</div>
               <div class='column-header column-header-e'></div>
               <div class='column-header column-header-f'>Length</div>
-              <div class='column-header column-header-g'>Material</div>
-              <div class='column-header column-header-h'>Products</div>
+              <div class='column-header column-header-g'>Die</div>
+              <div class='column-header column-header-h'>Finish</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
             <div id='cutting-rotoflex-one-schedule-table' class='table-body flex-center-center-column'>
@@ -1394,7 +1394,7 @@
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber %></div>
                   <div class='column-td column-td-d bg-white department-status-column'>ROTOFLEX ONE SCHEDULE</div>
                   <div class='column-td column-td-e bg-white'></div>
-                  <div class='column-td column-td-f bg-white length-column'>1,920 ft (TODO)</div>
+                  <div class='column-td column-td-f bg-white length-column'><%= ticket.totalMaterialLength || 'N/A' %></div>
                   <div class='column-td column-td-g bg-white die-column'><%= ticket.products && ticket.products[0].productDie %></div>
                   <div class='column-td column-td-h bg-white die-finish-column'><%= ticket.products && ticket.products[0].dieCuttingFinish %></div>
                   <div class='column-td column-td-i bg-white due-date-column'><%= helperMethods.getSimpleDate(ticket.shipDate) %></div>
@@ -1434,9 +1434,9 @@
               <div class='column-header column-header-b'>#</div>
               <div class='column-header column-header-c'>Ticket Number</div>
               <div class='column-header column-header-d'>Status</div>
-              <div class='column-header column-header-e'>Location</div>
+              <div class='column-header column-header-e'>Hold Status</div>
               <div class='column-header column-header-f'></div>
-              <div class='column-header column-header-g'>Rolls</div>
+              <div class='column-header column-header-g'>Total Rolls</div>
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
@@ -1458,7 +1458,7 @@
                   <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-white department-status-column'>ON HOLD</div>
-                  <div class='column-td column-td-e bg-white'></div>
+                  <div class='column-td column-td-e bg-white'>*TODO*</div>
                   <div class='column-td column-td-f bg-white'></div>
                   <div class='column-td column-td-g bg-white total-rolls-column'><%= ticket.totalWindingRolls %></div>
                   <div class='column-td column-td-h bg-white product-count-column'><%= ticket.products.length %></div>
@@ -1548,7 +1548,7 @@
               <div class='column-header column-header-b'>#</div>
               <div class='column-header column-header-c'>Ticket Number</div>
               <div class='column-header column-header-d'>Status</div>
-              <div class='column-header column-header-e'>Location</div>
+              <div class='column-header column-header-e'></div>
               <div class='column-header column-header-f'></div>
               <div class='column-header column-header-g'>Rolls</div>
               <div class='column-header column-header-h'>Products</div>
@@ -1613,9 +1613,9 @@
               <div class='column-header column-header-b'>#</div>
               <div class='column-header column-header-c'>Ticket Number</div>
               <div class='column-header column-header-d'>Status</div>
-              <div class='column-header column-header-e'>Location</div>
+              <div class='column-header column-header-e'>Hold Status</div>
               <div class='column-header column-header-f'></div>
-              <div class='column-header column-header-g'>Rolls</div>
+              <div class='column-header column-header-g'>Grouped</div>
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
@@ -1637,9 +1637,9 @@
                   <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-white department-status-column'>ON HOLD</div>
-                  <div class='column-td column-td-e bg-white'></div>
+                  <div class='column-td column-td-e bg-white'>*TODO*</div>
                   <div class='column-td column-td-f bg-white'></div>
-                  <div class='column-td column-td-g bg-white'>GROUPED (TODO)</div>
+                  <div class='column-td column-td-g bg-white'>*TODO*</div>
                   <div class='column-td column-td-h bg-white product-count-column'><%= ticket.products.length %></div>
                   <div class='column-td column-td-i bg-white due-date-column'><%= helperMethods.getSimpleDate(ticket.shipDate) %></div>
                 </div>
@@ -1670,7 +1670,7 @@
               <div class='column-header column-header-d'>Status</div>
               <div class='column-header column-header-e'>Location</div>
               <div class='column-header column-header-f'></div>
-              <div class='column-header column-header-g'>Rolls</div>
+              <div class='column-header column-header-g'>Grouped</div>
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
@@ -1698,7 +1698,7 @@
                     </div><span class='department-name'>Press 1 (TODO)</span>
                   </div>
                   <div class='column-td column-td-f bg-white'></div>
-                  <div class='column-td column-td-g bg-white'>GROUPED (TODO)</div>
+                  <div class='column-td column-td-g bg-white'>*TODO*</div>
                   <div class='column-td column-td-h bg-white product-count-column'><%= ticket.products.length %></div>
                   <div class='column-td column-td-i bg-white due-date-column'><%= helperMethods.getSimpleDate(ticket.shipDate) %></div>
                 </div>
@@ -1727,9 +1727,9 @@
               <div class='column-header column-header-b'>#</div>
               <div class='column-header column-header-c'>Ticket Number</div>
               <div class='column-header column-header-d'>Status</div>
-              <div class='column-header column-header-e'>Location</div>
+              <div class='column-header column-header-e'></div>
               <div class='column-header column-header-f'></div>
-              <div class='column-header column-header-g'>Rolls</div>
+              <div class='column-header column-header-g'>Grouped</div>
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
@@ -1753,7 +1753,7 @@
                   <div class='column-td column-td-d bg-white department-status-column'>PACKAGING READY</div>
                   <div class='column-td column-td-e bg-white'></div>
                   <div class='column-td column-td-f bg-white'></div>
-                  <div class='column-td column-td-g bg-white'>GROUPED (TODO)</div>
+                  <div class='column-td column-td-g bg-white'>*TODO*</div>
                   <div class='column-td column-td-h bg-white product-count-column'><%= ticket.products.length %></div>
                   <div class='column-td column-td-i bg-white due-date-column'><%= helperMethods.getSimpleDate(ticket.shipDate) %></div>
                 </div>
@@ -1792,7 +1792,7 @@
               <div class='column-header column-header-b'>#</div>
               <div class='column-header column-header-c'>Ticket Number</div>
               <div class='column-header column-header-d'>Status</div>
-              <div class='column-header column-header-e'></div>
+              <div class='column-header column-header-e'>Hold Status</div>
               <div class='column-header column-header-f'></div>
               <div class='column-header column-header-g'>Grouped</div>
               <div class='column-header column-header-h'>Products</div>
@@ -1816,9 +1816,9 @@
                   <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-white department-status-column'>ON HOLD</div>
-                  <div class='column-td column-td-e bg-white'></div>
+                  <div class='column-td column-td-e bg-white'>*TODO*</div>
                   <div class='column-td column-td-f bg-white'></div>
-                  <div class='column-td column-td-g bg-white'>GROUPED (TODO)</div>
+                  <div class='column-td column-td-g bg-white'>*TODO*</div>
                   <div class='column-td column-td-h bg-white product-count-column'><%= ticket.products.length %></div>
                   <div class='column-td column-td-i bg-white due-date-column'><%= helperMethods.getSimpleDate(ticket.shipDate) %></div>
                 </div>
@@ -1873,7 +1873,7 @@
                   <div class='column-td column-td-d bg-purple text-white department-status-column'>IN PROGRESS</div>
                   <div class='column-td column-td-e bg-white'></div>
                   <div class='column-td column-td-f bg-white'></div>
-                  <div class='column-td column-td-g bg-white'>GROUPED (TODO)</div>
+                  <div class='column-td column-td-g bg-white'>*TODO*</div>
                   <div class='column-td column-td-h bg-white product-count-column'><%= ticket.products.length %></div>
                   <div class='column-td column-td-i bg-white due-date-column'><%= helperMethods.getSimpleDate(ticket.shipDate) %></div>
                 </div>
@@ -1928,7 +1928,7 @@
                   <div class='column-td column-td-d bg-white department-status-column'>SHIPPING READY</div>
                   <div class='column-td column-td-e bg-white'></div>
                   <div class='column-td column-td-f bg-white'></div>
-                  <div class='column-td column-td-g bg-white'>GROUPED (TODO)</div>
+                  <div class='column-td column-td-g bg-white'>*TODO*</div>
                   <div class='column-td column-td-h bg-white product-count-column'><%= ticket.products.length %></div>
                   <div class='column-td column-td-i bg-white due-date-column'><%= helperMethods.getSimpleDate(ticket.shipDate) %></div>
                 </div>
@@ -1955,13 +1955,13 @@
             <div class='table-header flex-center-center-row'>
               <div class='column-header column-header-a'></div>
               <div class='column-header column-header-b'>#</div>
-              <div class='column-header column-header-c'>Type</div>
+              <div class='column-header column-header-c'>Ticket Number</div>
               <div class='column-header column-header-d'>Status</div>
               <div class='column-header column-header-e'></div>
               <div class='column-header column-header-f'></div>
               <div class='column-header column-header-g'></div>
-              <div class='column-header column-header-h'></div>
-              <div class='column-header column-header-i'>Arrival Date</div>
+              <div class='column-header column-header-h'>Products</div>
+              <div class='column-header column-header-i'>Due Date</div>
             </div>
             <div id='shipping-farmed-out-tickets-table' class='table-body flex-center-center-column'>
               <% shippingFarmedOutTicketsTickets.forEach((ticket, index) => { %>
@@ -1979,7 +1979,7 @@
                   ) %>
                   </div>
                   <div class='column-td column-td-b bg-white row-number'><%= index + 1 %></div>
-                  <div class='column-td column-td-c bg-white ticket-number-column'>Plate (TODO)</div>
+                  <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-white department-status-column'>FARMED OUT TICKETS</div>
                   <div class='column-td column-td-e bg-white'></div>
                   <div class='column-td column-td-f bg-white'></div>
@@ -2022,9 +2022,9 @@
               <div class='column-header column-header-b'>#</div>
               <div class='column-header column-header-c'>Ticket Number</div>
               <div class='column-header column-header-d'>Status</div>
-              <div class='column-header column-header-e'></div>
+              <div class='column-header column-header-e'>Hold Status</div>
               <div class='column-header column-header-f'></div>
-              <div class='column-header column-header-g'>Grouped</div>
+              <div class='column-header column-header-g'></div>
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
@@ -2046,7 +2046,7 @@
                   <div class='column-td column-td-b bg-white row-number'><%= index + 1 %> </div>
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber || 'N/A' %></div>
                   <div class='column-td column-td-d bg-white department-status-column'>ON HOLD</div>
-                  <div class='column-td column-td-e bg-white'></div>
+                  <div class='column-td column-td-e bg-white'>*TODO*</div>
                   <div class='column-td column-td-f bg-white'></div>
                   <div class='column-td column-td-g bg-white'></div>
                   <div class='column-td column-td-h bg-white product-count-column'><%= ticket.products.length %></div>
@@ -2079,7 +2079,7 @@
               <div class='column-header column-header-d'>Status</div>
               <div class='column-header column-header-e'></div>
               <div class='column-header column-header-f'></div>
-              <div class='column-header column-header-g'>Grouped</div>
+              <div class='column-header column-header-g'></div>
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
@@ -2134,7 +2134,7 @@
               <div class='column-header column-header-d'>Status</div>
               <div class='column-header column-header-e'></div>
               <div class='column-header column-header-f'></div>
-              <div class='column-header column-header-g'>Grouped</div>
+              <div class='column-header column-header-g'></div>
               <div class='column-header column-header-h'>Products</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>

--- a/application/views/viewTickets.ejs
+++ b/application/views/viewTickets.ejs
@@ -1260,8 +1260,8 @@
               <div class='column-header column-header-c'>Ticket Number</div>
               <div class='column-header column-header-d'>Status</div>
               <div class='column-header column-header-e'></div>
-              <div class='column-header column-header-f'>Die</div>
-              <div class='column-header column-header-g'>Length</div>
+              <div class='column-header column-header-f'>Length</div>
+              <div class='column-header column-header-g'>Die</div>
               <div class='column-header column-header-h'>Finish</div>
               <div class='column-header column-header-i'>Due Date</div>
             </div>
@@ -1284,7 +1284,7 @@
                   <div class='column-td column-td-c bg-white ticket-number-column'>#<%= ticket.ticketNumber %></div>
                   <div class='column-td column-td-d bg-white department-status-column'>DELTA ONE SCHEDULE</div>
                   <div class='column-td column-td-e bg-white'></div>
-                  <div class='column-td column-td-f bg-white length-column'>1,920 ft (TODO)</div>
+                  <div class='column-td column-td-f bg-white length-column'><%= ticket.totalMaterialLength %> </div>
                   <div class='column-td column-td-g bg-white die-column'><%= ticket.products && ticket.products[0].productDie %></div>
                   <div class='column-td column-td-h bg-white die-finish-column'><%= ticket.products && ticket.products[0].dieCuttingFinish %></div>
                   <div class='column-td column-td-i bg-white due-date-column'><%= helperMethods.getSimpleDate(ticket.shipDate) %></div>

--- a/test/models/ticket.spec.js
+++ b/test/models/ticket.spec.js
@@ -553,6 +553,32 @@ describe('validation', () => {
         });
     });
 
+    describe('attribute: totalMaterialLength', () => {
+        beforeEach(() => {
+            const products = [
+                {
+                    totalFeet: chance.integer({min: 1})
+                },
+                {
+                    totalFeet: chance.integer({min: 1})
+                }
+            ];
+            ticketAttributes.products = products;
+        });
+
+        it('should be a number', () => {
+            const ticket = new TicketModel(ticketAttributes);
+
+            expect(ticket.totalMaterialLength).toEqual(expect.any(Number));
+        });
+
+        it('should compute the attribute correctly', async () => {
+            const ticket = new TicketModel(ticketAttributes);
+
+            expect(ticket.totalMaterialLength).toEqual(ticketAttributes.products[0].totalFeet + ticketAttributes.products[1].totalFeet);
+        });
+    });
+
     describe('attribute: destination', () => {
         it('should pass validation if attribute is not defined', () => {
             delete ticketAttributes.destination;


### PR DESCRIPTION
# Description

This PR does 2 things:
  1. It adds a newly "calculated" attribute to the `Ticket` mongoose schema called `totalMaterialLength`. Each ticket has a different attribute called `products` which is an array of objects. Each of those products has an attribute called `totalFeet`. The attribute `totalMaterialLength` is a summation of each product.totalFeet. (**Formula:** ticket.totalMaterialLength += ticket.products[n].totalFeet)
  2. This PR changes a lot of the column names in the 37 html tables that live in `viewTickets.ejs`. Many of the column names in that file were outdated, and this PR makes them up to date with the data they are going to store.