### PR TITLE
Add 2 Attributes to `Ticket` Schema: `sentDate` and `followUpDate`

### DIFF
--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -235,6 +235,14 @@ const ticketSchema = new Schema({
         required: true,
         alias: 'Company'
     },
+    sentDate: {
+        type: Date,
+        required: false
+    },
+    followUpDate: {
+        type: Date,
+        required: false
+    },
 }, { timestamps: true });
 
 ticketSchema.pre('save', function(next) {

--- a/test/models/ticket.spec.js
+++ b/test/models/ticket.spec.js
@@ -36,7 +36,9 @@ describe('validation', () => {
             BillState: chance.string(),
             destination: {},
             departmentNotes: {},
-            Company: chance.string()
+            Company: chance.string(),
+            sentDate: chance.date({string: true}),
+            followUpDate: chance.date({string: true})
         };
     });
 
@@ -734,6 +736,60 @@ describe('validation', () => {
             const error = ticket.validateSync();
     
             expect(error).toBeDefined();
+        });
+    });
+
+    describe('attribute: sentDate', () => {
+        it('should contain attribute', () => {
+            const ticket = new TicketModel(ticketAttributes);
+
+            expect(ticket.sentDate).toBeDefined();
+        });
+
+        it('should fail if date is invalid', () => {
+            const invalidDate = chance.word();
+            ticketAttributes.sentDate = invalidDate;
+            const ticket = new TicketModel(ticketAttributes);
+
+            const error = ticket.validateSync();
+
+            expect(error).not.toBe(undefined);
+        });
+
+        it('should NOT fail validation if attribute is missing', () => {
+            delete ticketAttributes.sentDate;
+            const ticket = new TicketModel(ticketAttributes);
+
+            const error = ticket.validateSync();
+
+            expect(error).toBe(undefined);
+        });
+    });
+
+    describe('attribute: followUpDate', () => {
+        it('should contain attribute', () => {
+            const ticket = new TicketModel(ticketAttributes);
+
+            expect(ticket.followUpDate).toBeDefined();
+        });
+
+        it('should fail if date is invalid', () => {
+            const invalidDate = chance.word();
+            ticketAttributes.followUpDate = invalidDate;
+            const ticket = new TicketModel(ticketAttributes);
+
+            const error = ticket.validateSync();
+
+            expect(error).not.toBe(undefined);
+        });
+
+        it('should NOT fail validation if attribute is missing', () => {
+            delete ticketAttributes.followUpDate;
+            const ticket = new TicketModel(ticketAttributes);
+
+            const error = ticket.validateSync();
+
+            expect(error).toBe(undefined);
         });
     });
 


### PR DESCRIPTION
# Description

It was determined that there are 2 dates that are important to persist called `sentDate` and `followUpDate`. These 2 date attributes are used to determine when certain events occurred during a `ticket` object's lifecycle.

This PR adds those 2 attribute via mongoose schema definitions, and also adds tests.