### PR TITLE
Add `HoldReasons` Database Table and Add `ticket.holdReasonByDepartment` Attribute

### DIFF
--- a/application/models/holdReason.js
+++ b/application/models/holdReason.js
@@ -1,0 +1,29 @@
+const mongoose = require('mongoose');
+mongoose.Schema.Types.String.set('trim', true);
+const Schema = mongoose.Schema;
+const {getAllDepartments} = require('../enums/departmentsEnum');
+
+function isDepartmentValid(department) {
+    if (!getAllDepartments().includes(department)) {
+        return false;
+    }
+
+    return true;
+}
+
+const HoldReasonSchema = new Schema({
+    department: {
+        type: String,
+        validate: [isDepartmentValid, 'The department "{VALUE}" is not a valid department.'],
+        required: true
+    },
+    reason: {
+        type: String,
+        uppercase: true,
+        required: true
+    }
+}, { timestamps: true });
+
+const HoldStatus = mongoose.model('HoldStatus', HoldReasonSchema);
+
+module.exports = HoldStatus; 

--- a/test/models/holdReason.spec.js
+++ b/test/models/holdReason.spec.js
@@ -1,0 +1,130 @@
+const chance = require('chance').Chance();
+const HoldReason = require('../../application/models/holdReason');
+const databaseService = require('../../application/services/databaseService');
+
+const DEPARTMENT_NAME = 'PRINTING';
+
+describe('validation', () => {
+    let holdReasonAttributes;
+
+    beforeEach(() => {
+        holdReasonAttributes = {
+            department: DEPARTMENT_NAME,
+            reason: chance.string()
+        };
+    });
+
+    describe('verify timestamps on created object', () => {
+        beforeEach(async () => {
+            await databaseService.connectToTestMongoDatabase();
+        });
+
+        afterEach(async () => {
+            await databaseService.closeDatabase();
+        });
+
+        it('should have a "createdAt" attribute once object is saved', async () => {
+            const holdReason = new HoldReason(holdReasonAttributes);
+            let savedHoldStatus = await holdReason.save({validateBeforeSave: false});
+
+            expect(savedHoldStatus.createdAt).toBeDefined();
+        });
+
+        it('should have a "updated" attribute once object is saved', async () => {
+            const holdReason = new HoldReason(holdReasonAttributes);
+            let savedHoldStatus = await holdReason.save({validateBeforeSave: false});
+
+            expect(savedHoldStatus.createdAt).toBeDefined();
+        });
+    });
+
+    describe('attribute: department', () => {
+        it('should be of type String', () => {
+            const holdReason = new HoldReason(holdReasonAttributes);
+
+            expect(holdReason.department).toEqual(expect.any(String));
+        });
+
+        it('should fail if attribute is not defined', async () => {
+            delete holdReasonAttributes.department;
+            const holdReason = new HoldReason(holdReasonAttributes);
+
+            const error = holdReason.validateSync();
+
+            expect(error).not.toBe(undefined);
+        });
+
+        it('should fail if attribute is NOT an accepted value', async () => {
+            const invalidDepartment = chance.string();
+            holdReasonAttributes.department = invalidDepartment;
+            const holdReason = new HoldReason(holdReasonAttributes);
+
+            const error = holdReason.validateSync();
+
+            expect(error).not.toBe(undefined);
+        });
+
+        it('should pass if attribute IS an accepted value', () => {
+            const validDepartment = DEPARTMENT_NAME;
+            holdReasonAttributes.department = validDepartment;
+            const holdReason = new HoldReason(holdReasonAttributes);
+
+            const error = holdReason.validateSync();
+
+            expect(error).toBe(undefined);
+        });
+
+        it('should pass if attribute IS an accepted value surrounded by whitespace', () => {
+            const whitespaceToTrim = '  ';
+            const validDepartment = DEPARTMENT_NAME;
+            holdReasonAttributes.department = whitespaceToTrim + validDepartment + whitespaceToTrim;
+            const holdReason = new HoldReason(holdReasonAttributes);
+
+            const error = holdReason.validateSync();
+
+            expect(error).toBe(undefined);
+        });
+    });
+
+    describe('attribute: reason', () => {
+        it('should be of type String', () => {
+            const holdReason = new HoldReason(holdReasonAttributes);
+
+            expect(holdReason.reason).toEqual(expect.any(String));
+        });
+
+        it('should fail if attribute is not defined', () => {
+            delete holdReasonAttributes.reason;
+            const holdReason = new HoldReason(holdReasonAttributes);
+
+            const error = holdReason.validateSync();
+
+            expect(error).not.toBe(undefined);
+        });
+
+        it('should fail if attribute is empty', () => {
+            holdReasonAttributes.reason = '';
+            const holdReason = new HoldReason(holdReasonAttributes);
+
+            const error = holdReason.validateSync();
+
+            expect(error).not.toBe(undefined);
+        });
+
+        it('should trim the attribute', () => {
+            const reason = chance.string();
+            holdReasonAttributes.reason = ' ' + reason + '   ';
+            const holdReason = new HoldReason(holdReasonAttributes);
+
+            expect(holdReason.reason).toBe(reason);
+        });
+
+        it('should convert to uppercase', () => {
+            const lowerCaseReason = chance.string({casing: 'lower'});
+            holdReasonAttributes.reason = lowerCaseReason;
+            const holdReason = new HoldReason(holdReasonAttributes);
+
+            expect(holdReason.reason).toBe(lowerCaseReason.toUpperCase());
+        });
+    });
+});

--- a/test/models/holdReason.spec.js
+++ b/test/models/holdReason.spec.js
@@ -112,7 +112,7 @@ describe('validation', () => {
         });
 
         it('should trim the attribute', () => {
-            const reason = chance.string();
+            const reason = chance.string().toUpperCase();
             holdReasonAttributes.reason = ' ' + reason + '   ';
             const holdReason = new HoldReason(holdReasonAttributes);
 


### PR DESCRIPTION
# Description

This PR defines a new mongoose database schema called `HoldReasons`. This database table will be used by the application in future PRs to persist user-defined "hold reasons" - but at the moment, this table is not in use.

This PR also adds a new attribute to the `ticket` schema called `holdReasonByDepartment`. This attribute is essentially a javascript object (technically its a javascript map).