### PR TITLE
Save `ticket.followUpDate` to Database after User Selects a Date on the UI

### DIFF
--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -1133,7 +1133,7 @@ $( document ).ready(function() {
 
         const ticketAttributeToUpdate = {
             followUpDate: selectedDate
-        }
+        };
 
         updateTicket(ticketAttributeToUpdate, ticketId);
     });

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -1126,4 +1126,15 @@ $( document ).ready(function() {
             }
         });
     }
+
+    $('.status-section').on('change', '#datepicker', function() {
+        const selectedDate = $(this).val();
+        const ticketId = $(this).data('ticket-id');
+
+        const ticketAttributeToUpdate = {
+            followUpDate: selectedDate
+        }
+
+        updateTicket(ticketAttributeToUpdate, ticketId);
+    });
 });

--- a/application/views/partials/follow-up-date-picker.ejs
+++ b/application/views/partials/follow-up-date-picker.ejs
@@ -1,1 +1,1 @@
-<div class='date-picker-wrapper'><input type="text" id="datepicker"></div>
+<div class='date-picker-wrapper'><input type="text" id="datepicker" value="<%= helperMethods.getSimpleDate(ticket.followUpDate) %>" data-ticket-id="<%= ticket.id %>"></div>

--- a/application/views/viewTickets.ejs
+++ b/application/views/viewTickets.ejs
@@ -243,7 +243,7 @@
                   <div class='column-td column-td-d bg-white department-status-column'>WAITING ON CUSTOMER</div>
                   <div class='column-td column-td-e bg-white'></div>
                   <div class='column-td column-td-f bg-white'></div>
-                  <div class='column-td column-td-g bg-white follow-up-date-column'>** TODO ** <%- include('partials/follow-up-date-picker') -%></div>
+                  <div class='column-td column-td-g bg-white follow-up-date-column'><%- include('partials/follow-up-date-picker', {ticket: ticket}) -%></div>
                   <div class='column-td column-td-h bg-white'>*TODO*</div>
                   <div class='column-td column-td-i bg-white due-date-column'><%= helperMethods.getSimpleDate(ticket.shipDate) %></div>
                 </div>


### PR DESCRIPTION
# Description

Previously, a datepicker was added to the user interface that allowed the user to select a date.

However, the selected date did not persist to the database and thus, on refresh, the date disappeared.

This PR saves the data they select and handles fetching it again on page refresh so the date stays.

## Verification
![image](https://user-images.githubusercontent.com/42784674/211947709-33fec9e8-6009-4589-9014-4e986f4f803c.png)
> After page refresh, the date the user had  previously selected still exists