### PR TITLE
Add `ticket.ticketGroup` Attribute

### DIFF
--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -273,6 +273,11 @@ const ticketSchema = new Schema({
         required: false,
         default: {},
         validate: [validateKeysAreAllValidDepartments, 'The attribute "departmentToHoldReason" must only contain keys which are valid departments']
+    },
+    ticketGroup: {
+        type: Schema.Types.ObjectId,
+        ref: 'TicketGroup',
+        required: false
     }
 }, { timestamps: true });
 

--- a/application/models/ticketGroup.js
+++ b/application/models/ticketGroup.js
@@ -1,0 +1,19 @@
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+function isArrayLengthGreaterThanZero(items) {
+    return items && items.length > 0;
+}
+
+const ticketGroupSchema = new Schema({
+    ticketIdsInGroup: {
+        type: [Schema.Types.ObjectId],
+        ref: 'Ticket',
+        required: true,
+        validate: [isArrayLengthGreaterThanZero, '"{PATH}" cannot be an empty array']
+    }
+});
+
+const TicketGroup = mongoose.model('TicketGroup', ticketGroupSchema);
+
+module.exports = TicketGroup;

--- a/application/models/ticketGroup.js
+++ b/application/models/ticketGroup.js
@@ -1,8 +1,10 @@
 const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
+const ZERO = 0;
+
 function isArrayLengthGreaterThanZero(items) {
-    return items && items.length > 0;
+    return items && items.length > ZERO;
 }
 
 const ticketGroupSchema = new Schema({

--- a/application/models/ticketGroup.js
+++ b/application/models/ticketGroup.js
@@ -9,6 +9,7 @@ const ticketGroupSchema = new Schema({
     ticketIdsInGroup: {
         type: [Schema.Types.ObjectId],
         ref: 'Ticket',
+        default: undefined,
         required: true,
         validate: [isArrayLengthGreaterThanZero, '"{PATH}" cannot be an empty array']
     }

--- a/test/models/ticket.spec.js
+++ b/test/models/ticket.spec.js
@@ -4,6 +4,7 @@ const WorkflowStepModel = require('../../application/models/WorkflowStep');
 const databaseService = require('../../application/services/databaseService');
 const {standardPriority, getAllPriorities} = require('../../application/enums/priorityEnum');
 const {getAllDepartmentsWithDepartmentStatuses, departmentToStatusesMappingForTicketObjects, getAllDepartments} = require('../../application/enums/departmentsEnum');
+const mongoose = require('mongoose');
 
 const LENGTH_OF_ONE = 1;
 const EMPTY_LENGTH = 0;
@@ -39,7 +40,8 @@ describe('validation', () => {
             Company: chance.string(),
             sentDate: chance.date({string: true}),
             followUpDate: chance.date({string: true}),
-            departmentToHoldReason: {}
+            departmentToHoldReason: {},
+            ticketGroup: new mongoose.Types.ObjectId()
         };
     });
 
@@ -900,6 +902,38 @@ describe('validation', () => {
             };
             const ticket = new TicketModel(ticketAttributes);
             
+            const error = ticket.validateSync();
+
+            expect(error).not.toBe(undefined);
+        });
+    });
+
+    describe('attribute: ticketGroup', () => {
+        it('should pass validation if attribute is not defined', () => {
+            delete ticketAttributes.ticketGroup;
+            const ticket = new TicketModel(ticketAttributes);
+
+            const error = ticket.validateSync();
+
+            expect(error).toBe(undefined);
+        });
+
+        it('should pass validation when attribute is a valid mongoose objectId', () => {
+            ticketAttributes.ticketGroup = new mongoose.Types.ObjectId();
+            const ticket = new TicketModel(ticketAttributes);
+
+            const error = ticket.validateSync();
+            const isAttributeAValidMongooseObjectId = mongoose.Types.ObjectId.isValid(ticket.ticketGroup);
+
+            expect(error).toBe(undefined);
+            expect(isAttributeAValidMongooseObjectId).toBe(true);
+        });   
+
+        it('should fail validation if attribute is not a valid mongoose objectId', () => {
+            const invalidTicketGroup = chance.string();
+            ticketAttributes.ticketGroup = invalidTicketGroup;
+            const ticket = new TicketModel(ticketAttributes);
+
             const error = ticket.validateSync();
 
             expect(error).not.toBe(undefined);

--- a/test/models/ticketGroup.spec.js
+++ b/test/models/ticketGroup.spec.js
@@ -59,5 +59,5 @@ describe('validation', () => {
 
             expect(error).not.toBe(undefined);
         });
-    })
-})
+    });
+});

--- a/test/models/ticketGroup.spec.js
+++ b/test/models/ticketGroup.spec.js
@@ -1,0 +1,63 @@
+const chance = require('chance').Chance();
+const TicketGroupModel = require('../../application/models/ticketGroup');
+const mongoose = require('mongoose');
+
+describe('validation', () => {
+    let ticketGroupAttributes;
+
+    beforeEach(() => {
+        ticketGroupAttributes = {
+            ticketIdsInGroup: [
+                new mongoose.Types.ObjectId()
+            ]
+        };
+    });
+
+    it('should validate if all attributes are defined successfully', () => {
+        const ticketGroup = new TicketGroupModel(ticketGroupAttributes);
+    
+        const error = ticketGroup.validateSync();
+
+        expect(error).toBe(undefined);
+    });
+
+    describe('attribute: ticketIdsInGroup', () => {
+        it('should fail validation if attribute is not defined', () => {
+            delete ticketGroupAttributes.ticketIdsInGroup;
+            const ticketGroup = new TicketGroupModel(ticketGroupAttributes);
+
+            const error = ticketGroup.validateSync();
+
+            expect(error).not.toBe(undefined);
+        });
+
+        it('should fail validation if attribute is an empty array', () => {
+            ticketGroupAttributes.ticketIdsInGroup = [];
+            const ticketGroup = new TicketGroupModel(ticketGroupAttributes);
+
+            const error = ticketGroup.validateSync();
+
+            expect(error).not.toBe(undefined);
+        });
+
+        it('should pass validation if attribute an array of mongoose object Ids', () => {
+            const mongooseObjectId = new mongoose.Types.ObjectId();
+            ticketGroupAttributes.ticketIdsInGroup = [mongooseObjectId];
+            const ticketGroup = new TicketGroupModel(ticketGroupAttributes);
+
+            const error = ticketGroup.validateSync();
+
+            expect(error).toBe(undefined);
+        });
+
+        it('should fail validation if attribute an array containing non-mongoose object Id(s)', () => {
+            const invalidDataType = chance.string();
+            ticketGroupAttributes.ticketIdsInGroup = [invalidDataType];
+            const ticketGroup = new TicketGroupModel(ticketGroupAttributes);
+
+            const error = ticketGroup.validateSync();
+
+            expect(error).not.toBe(undefined);
+        });
+    })
+})


### PR DESCRIPTION
# Description

Currently there is a database table called `tickets`. The need for each ticket to be able to store a reference to other tickets was brought up.

This PR adds a new attribute (`ticket.ticketGroup`) which provides the ability for a group of tickets to be stored on each ticket.