### PR TITLE
Fix EJS Bug that was Crashing `viewTickets.ejs` page

### DIFF
--- a/application/views/partials/ticket-table.ejs
+++ b/application/views/partials/ticket-table.ejs
@@ -360,8 +360,10 @@
                     })
                   %>
                 <% } else if (columnType === locationColumnType) { %>
-                  <%- include('ticketTableColumns/user-column.ejs', {}) 
-                  -%>
+                  <%- include('ticketTableColumns/user-column.ejs', {
+                    ticket: ticket
+                  }) 
+                %>
                 <% } else if (columnType === lengthColumnType) { %>
                   <%- include('ticketTableColumns/text-column.ejs', {
                       columnValue: ticket.totalMaterialLength || 'N/A'


### PR DESCRIPTION
# Description

An ejs error was crashing viewTickets.ejs, it turns out a parital was not getting the template attributes it required to render, this PR resolves that issue.