### PR TITLE
Feature: Format Date Columns on `viewTickets.ejs`

### DIFF
--- a/application/controllers/ticketController.js
+++ b/application/controllers/ticketController.js
@@ -148,7 +148,7 @@ router.get('/duration/:id', async (request, response) => {
         const listDuration = workflowStepService.getHowLongTicketHasHadADepartmentStatus(workflowStepTimeLedgerForTicket, department, departmentStatus);
         
         return response.json({
-            'date-created': dateTimeService.getSimpleDate(ticket.createdAt),
+            'date-created': dateTimeService.getDate(ticket.createdAt),
             'overall-duration': dateTimeService.prettifyDuration(overallDuration),
             'production-duration': dateTimeService.prettifyDuration(productionDuration),
             'department-duration': dateTimeService.prettifyDuration(departmentDuration),

--- a/application/services/dateTimeService.js
+++ b/application/services/dateTimeService.js
@@ -66,6 +66,23 @@ module.exports.prettifyDuration = (durationInMinutes) => { // eslint-disable-lin
     return `${years}yr ${months}m`;
 };
 
-module.exports.getSimpleDate = (date) => {
-    return new Date(date).toLocaleDateString('en-US');
+module.exports.getDate = (utcDate) => {
+    if (!utcDate) {
+        return '';
+    }
+
+    return new Date(utcDate).toLocaleDateString('en-US');
 };
+
+module.exports.getDayNumberAndMonth = (utcDate) => {
+    if (!utcDate) {
+        return '';
+    }
+    
+    const date = new Date(utcDate).toLocaleString('en-US', {day: '2-digit', month: 'long', timeZone: 'UTC'});
+    const dateParts = date.split(' ');
+    const monthName = dateParts[0]
+    const twoDigitDayOfMonth = dateParts[1]
+
+    return `${twoDigitDayOfMonth} ${monthName}`
+}

--- a/application/services/dateTimeService.js
+++ b/application/services/dateTimeService.js
@@ -81,8 +81,8 @@ module.exports.getDayNumberAndMonth = (utcDate) => {
     
     const date = new Date(utcDate).toLocaleString('en-US', {day: '2-digit', month: 'long', timeZone: 'UTC'});
     const dateParts = date.split(' ');
-    const monthName = dateParts[0]
-    const twoDigitDayOfMonth = dateParts[1]
+    const monthName = dateParts[0];
+    const twoDigitDayOfMonth = dateParts[1];
 
-    return `${twoDigitDayOfMonth} ${monthName}`
-}
+    return `${twoDigitDayOfMonth} ${monthName}`;
+};

--- a/application/services/ejsService.js
+++ b/application/services/ejsService.js
@@ -4,7 +4,8 @@ const dateTimeService = require('./dateTimeService');
 
 const helperMethods = {
     prettifyDuration: dateTimeService.prettifyDuration,
-    getSimpleDate: dateTimeService.getSimpleDate,
+    getDate: dateTimeService.getDate,
+    getDayNumberAndMonth: dateTimeService.getDayNumberAndMonth,
     getOverallTicketDuration: workflowStepService.getOverallTicketDuration,
     getHowLongTicketHasBeenInProduction: workflowStepService.getHowLongTicketHasBeenInProduction,
     getHowLongTicketHasBeenInDepartment: workflowStepService.getHowLongTicketHasBeenInDepartment,

--- a/application/views/partials/ticket-table.ejs
+++ b/application/views/partials/ticket-table.ejs
@@ -396,7 +396,7 @@
                   %>
                 <% } else if (columnType === dueDateColumnType) { %>
                   <%- include('ticketTableColumns/text-column.ejs', {
-                      columnValue: helperMethods.getSimpleDate(ticket.shipDate)
+                      columnValue: helperMethods.getDayNumberAndMonth(ticket.shipDate)
                     }) 
                   %>
                 <% } else if (columnType === fromColumnType) { %>
@@ -411,12 +411,12 @@
                   %>
                 <% } else if (columnType === sentDateColumnType) { %>
                   <%- include('ticketTableColumns/text-column.ejs', {
-                      columnValue: 'TODO'
+                      columnValue: helperMethods.getDayNumberAndMonth(ticket.sentDate)
                     })
                   %>
                 <% } else if (columnType === followUpDateColumnType) { %>
                   <%- include('ticketTableColumns/date-picker-column.ejs', {
-                      columnValue: 'TODO'
+                      columnValue: helperMethods.getDayNumberAndMonth(ticket.followUpDate)
                     })
                   %>
                 <% } else if (columnType === proofsColumn) { %>

--- a/test/services/dateTimeService.spec.js
+++ b/test/services/dateTimeService.spec.js
@@ -218,12 +218,41 @@ describe('dateTimeService test suite', () => {
         });
     });
 
-    describe('getSimpleDate()', () => {
+    describe('getDate()', () => {
         it('should convert date according to format mm/dd/yyyy', () => {
             const dateString = '2022-11-06T20:45:04.176+00:00';
             const expectedDate = '11/6/2022';
 
-            const actualDate = dateTimeService.getSimpleDate(dateString);
+            const actualDate = dateTimeService.getDate(dateString);
+
+            expect(actualDate).toBe(expectedDate);
+        });
+
+        it('should return an empty string if undefined value is passed into method', () => {
+            const undefinedDate = undefined;
+            const expectedDate = '';
+
+            const actualDate = dateTimeService.getDate(undefinedDate);
+
+            expect(actualDate).toBe(expectedDate);
+        });
+    });
+
+    describe('getDayNumberAndMonth()', () => {
+        it('should convert date according to format "dd month" (ex: "01 February")', () => {
+            const dateString = '2022-11-08T20:45:04.176+00:00';
+            const expectedDate = '08 November';
+
+            const actualDate = dateTimeService.getDayNumberAndMonth(dateString);
+
+            expect(actualDate).toBe(expectedDate);
+        });
+
+        it('should return an empty string if undefined value is passed into method', () => {
+            const undefinedDate = undefined;
+            const expectedDate = '';
+
+            const actualDate = dateTimeService.getDayNumberAndMonth(undefinedDate);
 
             expect(actualDate).toBe(expectedDate);
         });

--- a/test/services/ejsService.spec.js
+++ b/test/services/ejsService.spec.js
@@ -5,8 +5,12 @@ describe('ejsService test suite', () => {
         expect(ejsService.prettifyDuration).toBeDefined();
     });
     
-    it('should have a method named getSimpleDate()', () => {
-        expect(ejsService.getSimpleDate).toBeDefined();
+    it('should have a method named getDate()', () => {
+        expect(ejsService.getDate).toBeDefined();
+    });
+
+    it('should have a method named getDate()', () => {
+        expect(ejsService.getDayNumberAndMonth).toBeDefined();
     });
 
     it('should have a method named getOverallTicketDuration()', () => {


### PR DESCRIPTION
# Description

There are columns in tables on the viewTickets page that we wished to format such as "01 February".

This PR makes that happen

## Verification
<img width="954" alt="image" src="https://user-images.githubusercontent.com/42784674/216858071-6788bc72-5fa4-463a-964f-9585593b978c.png">
> The column now displays dates in the correct format