### PR TITLE
Implement Soft Deletions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - checkout
       - run:
           command: |  # https://stackoverflow.com/a/72633324/9273261
-            wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
+            wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
             sudo apt-get update -y
             sudo apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
             sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
             wget http://nz2.archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
             sudo apt-get update -y
             sudo apt-get install -y libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
-            sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb
+            sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2.17_amd64.deb
           name: setup linux environment
       # look for existing cache and restore if found
       - restore_cache:

--- a/application/controllers/holdReasonController.js
+++ b/application/controllers/holdReasonController.js
@@ -5,6 +5,7 @@ const HoldReasonModel = require('../models/holdReason');
 router.use(verifyJwtToken);
 
 const INVALID_REQUEST_ERROR_CODE = 400;
+const SERVER_ERROR_CODE = 500;
 
 router.post('/', async (request, response) => {
     try {
@@ -17,7 +18,17 @@ router.post('/', async (request, response) => {
         console.log(`Error creating a HoldReason Object: ${error.message}`);
         return response.status(INVALID_REQUEST_ERROR_CODE).send(error.message);
     }
+});
 
+router.delete('/:id', async (request, response) => {
+    const {id} = request.params;
+
+    try {
+        await HoldReasonModel.deleteById(id);
+        return response.send(id);
+    } catch(error) {
+        return response.status(SERVER_ERROR_CODE).send(error.message);
+    }
 });
 
 module.exports = router;

--- a/application/controllers/holdReasonController.js
+++ b/application/controllers/holdReasonController.js
@@ -26,7 +26,7 @@ router.delete('/:id', async (request, response) => {
     try {
         await HoldReasonModel.deleteById(id);
         return response.send(id);
-    } catch(error) {
+    } catch (error) {
         return response.status(SERVER_ERROR_CODE).send(error.message);
     }
 });

--- a/application/models/holdReason.js
+++ b/application/models/holdReason.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose');
 mongoose.Schema.Types.String.set('trim', true);
 const Schema = mongoose.Schema;
 const {getAllDepartments} = require('../enums/departmentsEnum');
+const mongoose_delete = require('mongoose-delete');
 
 function isDepartmentValid(department) {
     if (!getAllDepartments().includes(department)) {
@@ -23,6 +24,8 @@ const HoldReasonSchema = new Schema({
         required: true
     }
 }, { timestamps: true });
+
+HoldReasonSchema.plugin(mongoose_delete, {overrideMethods: true});
 
 const HoldReason = mongoose.model('HoldReason', HoldReasonSchema);
 

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -110,16 +110,16 @@ $( document ).ready(function() {
     $('.hold-reason-option .fa-trash-can').on('click', function() {
         const holdReasonId = $(this).data('hold-reason-id');
 
-        $('#delete-hold-reason-btn').data('hold-reason-id-to-delete', holdReasonId)
+        $('#delete-hold-reason-btn').data('hold-reason-id-to-delete', holdReasonId);
     });
 
     $('#delete-hold-reason-btn').on('click', function(){
         const holdReasonId = $('#delete-hold-reason-btn').data('hold-reason-id-to-delete');
         
-        deleteHoldReason(holdReasonId, (response) => {
-            alert('successful deletion, TODO: storm, close the window using jquery here')
+        deleteHoldReason(holdReasonId, () => {
+            alert('successful deletion, TODO: storm, close the window using jquery here');
         });
-    })
+    });
 
     $('#material-selection').change(function() {
         const selectedMaterialId = $('#material-selection').val();

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -62,6 +62,22 @@ $( document ).ready(function() {
         });
     }
 
+    function deleteHoldReason(holdReasonObjectId, callback) {
+        $.ajax({
+            url: `/hold-reasons/${holdReasonObjectId}`,
+            type: 'DELETE',
+            success: function(response) {
+                if (callback) {
+                    callback(response);
+                }
+            },
+            error: function(error) {
+                const errorMessage = error.responseText ? error.responseText : 'N/A';
+                alert(`An error occurred while attempting to DELETE the the specified "hold reason". The error that occurred is: ${errorMessage}`);
+            }
+        }); 
+    }
+
     function findTheTicketIdOfTheRowThisHtmlElementIsIn(htmlElement) {
         try {
             const ticketId = htmlElement.closest('.table-row-wrapper').data('ticket-id');
@@ -90,6 +106,20 @@ $( document ).ready(function() {
             throw Error(error.message);
         }
     }
+
+    $('.hold-reason-option .fa-trash-can').on('click', function() {
+        const holdReasonId = $(this).data('hold-reason-id');
+
+        $('#delete-hold-reason-btn').data('hold-reason-id-to-delete', holdReasonId)
+    });
+
+    $('#delete-hold-reason-btn').on('click', function(){
+        const holdReasonId = $('#delete-hold-reason-btn').data('hold-reason-id-to-delete');
+        
+        deleteHoldReason(holdReasonId, (response) => {
+            alert('successful deletion, TODO: storm, close the window using jquery here')
+        });
+    })
 
     $('#material-selection').change(function() {
         const selectedMaterialId = $('#material-selection').val();

--- a/application/services/holdReasonService.js
+++ b/application/services/holdReasonService.js
@@ -11,8 +11,7 @@ module.exports.getDepartmentToHoldReasons = async () => {
     });
 
     allHoldReasons.forEach((holdReason) => {
-        const {department, reason} = holdReason;
-        departmentToHoldReasons[department].push(reason);
+        departmentToHoldReasons[holdReason.department].push(holdReason);
     });
 
     return departmentToHoldReasons;

--- a/application/views/partials/on-hold-dropdown-option.ejs
+++ b/application/views/partials/on-hold-dropdown-option.ejs
@@ -1,4 +1,4 @@
 <li class="hold-reason-option" <%= holdReason ? '' : 'hidden' %>>
-    <p><%= holdReason %></p>
-    <i class="fa-solid fa-trash-can"></i>
+    <p><%= holdReason.reason %></p>
+    <i data-hold-reason-id="<%= holdReason._id %>" class="fa-solid fa-trash-can"></i>
 </li>

--- a/application/views/partials/on-hold-dropdown.ejs
+++ b/application/views/partials/on-hold-dropdown.ejs
@@ -4,7 +4,10 @@
         <div class='confirmation-window'>
             <p>Values in this custom field will be deleted from all cards on this board.<br><br> This can't be undone. To delete the field and its data, enter the field name: <span class='delete-me-value'></span></p>
             <div class='delete-content-frame'>
-                <input type="text" class='delete' name="fname"><button>Delete Hold Reason</button>
+                <input type="text" class='delete' name="fname">
+                <button id='delete-hold-reason-btn' data-hold-reason-id-to-delete="N/A">
+                    Delete Hold Reason
+                </button>
             </div>
         </div>
         <ul class="hold-reason-options">

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "mailgun.js": "4.2.2",
         "mongodb-memory-server": "8.10.2",
         "mongoose": "6.8.0",
+        "mongoose-delete": "0.5.4",
         "multer": "1.4.5-lts.1",
         "socket.io": "4.5.4",
         "xml2json": "0.12.0"
@@ -6962,6 +6963,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose-delete": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/mongoose-delete/-/mongoose-delete-0.5.4.tgz",
+      "integrity": "sha512-zKkcWFEwTneVG4Oiy+qJRJPFCiGlqOJToHeU3a3meJybWsHCnWxdHkGEkFWNY5cmYEv5av3WwByOhPlQ6I+FmQ==",
+      "peerDependencies": {
+        "mongoose": "4.x || 5.x || 6.x"
       }
     },
     "node_modules/mongoose/node_modules/mongodb": {
@@ -14515,6 +14524,12 @@
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         }
       }
+    },
+    "mongoose-delete": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/mongoose-delete/-/mongoose-delete-0.5.4.tgz",
+      "integrity": "sha512-zKkcWFEwTneVG4Oiy+qJRJPFCiGlqOJToHeU3a3meJybWsHCnWxdHkGEkFWNY5cmYEv5av3WwByOhPlQ6I+FmQ==",
+      "requires": {}
     },
     "mpath": {
       "version": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "mailgun.js": "4.2.2",
     "mongodb-memory-server": "8.10.2",
     "mongoose": "6.8.0",
+    "mongoose-delete": "0.5.4",
     "multer": "1.4.5-lts.1",
     "socket.io": "4.5.4",
     "xml2json": "0.12.0"

--- a/test/models/holdReason.spec.js
+++ b/test/models/holdReason.spec.js
@@ -23,18 +23,35 @@ describe('validation', () => {
             await databaseService.closeDatabase();
         });
 
-        it('should have a "createdAt" attribute once object is saved', async () => {
-            const holdReason = new HoldReason(holdReasonAttributes);
-            let savedHoldReason = await holdReason.save({validateBeforeSave: false});
-
-            expect(savedHoldReason.createdAt).toBeDefined();
+        describe('verify timestamps on created object', () => {
+            it('should have a "createdAt" attribute once object is saved', async () => {
+                const holdReason = new HoldReason(holdReasonAttributes);
+                let savedHoldReason = await holdReason.save({validateBeforeSave: false});
+    
+                expect(savedHoldReason.createdAt).toBeDefined();
+            });
+    
+            it('should have a "updated" attribute once object is saved', async () => {
+                const holdReason = new HoldReason(holdReasonAttributes);
+                let savedHoldReason = await holdReason.save({validateBeforeSave: false});
+    
+                expect(savedHoldReason.createdAt).toBeDefined();
+            });
         });
 
-        it('should have a "updated" attribute once object is saved', async () => {
-            const holdReason = new HoldReason(holdReasonAttributes);
-            let savedHoldReason = await holdReason.save({validateBeforeSave: false});
+        describe('verify soft deletes work', () => {
+            it('should be "soft-deletable"', async () => {
+                const holdReason = new HoldReason(holdReasonAttributes);
+                const holdReasonId = holdReason._id;
 
-            expect(savedHoldReason.createdAt).toBeDefined();
+                await holdReason.save({validateBeforeSave: false});
+                await HoldReason.deleteById(holdReasonId);
+
+                const softDeletedHoldReason = await HoldReason.findOneDeleted({_id: holdReasonId}).exec();
+
+                expect(softDeletedHoldReason).toBeDefined();
+                expect(softDeletedHoldReason.deleted).toBe(true);
+            });
         });
     });
 

--- a/test/models/ticket.spec.js
+++ b/test/models/ticket.spec.js
@@ -930,7 +930,7 @@ describe('validation', () => {
         });   
 
         it('should fail validation if attribute is not a valid mongoose objectId', () => {
-            const invalidTicketGroup = chance.string();
+            const invalidTicketGroup = 123;
             ticketAttributes.ticketGroup = invalidTicketGroup;
             const ticket = new TicketModel(ticketAttributes);
 


### PR DESCRIPTION
# Description

This PR adds the library [mongoose-delete](https://www.npmjs.com/package/mongoose-delete) which overrides many/most of the mongoose methods in order to handle soft delete items and query only items that have not been soft deleted.

In short, this library adds an attribute called `delete = true` to any item which has been deleted, after which, when using mongoose's method `find()` or another one of the similar find methods it offers, it will only return items whose `delete` field is not defined or false, any rows whose delete attribute is true will be excluded from the results.

However, this library provides many additional methods for specifically querying for delete attributes.

There is an entire table showing the mongoose methods that this library overrides or adds, you can find it below:
<img width="1139" alt="image" src="https://user-images.githubusercontent.com/42784674/217679644-37e473a9-1f09-4651-a98d-9ab17fe01278.png">

**NOTE:** This screenshot may/will become outdated, see their docs for an up to date version if needed.