### PR TITLE
Dynamically Populate Fields on `/tickets/in-progress` View

### DIFF
--- a/application/controllers/ticketController.js
+++ b/application/controllers/ticketController.js
@@ -38,7 +38,11 @@ router.get('/in-progress/:ticketId', async (request, response) => {
     const ticketObjectId = request.params.ticketId;
     try {
         const ticket = await TicketModel.findById(ticketObjectId).exec();
-        const material = await MaterialModel.findOne({materialId: ticket.primaryMaterial}).exec();
+
+        const now = new Date();
+        const ticketCreationDate = new Date(ticket.createdAt);
+        const ageOfTicketInMilliseconds = dateTimeService.howManyMillisecondsHavePassedBetweenDateTimes(now, ticketCreationDate);
+        const ageOfTicketInMinutes = dateTimeService.convertMillisecondsToMinutes(ageOfTicketInMilliseconds);
 
         if (!ticket) {
             throw new Error(`No ticket was found in the database whose object ID is "${ticketObjectId}"`);
@@ -50,7 +54,7 @@ router.get('/in-progress/:ticketId', async (request, response) => {
 
         return response.render('viewOneInProgressTicket', {
             ticket,
-            material
+            ageOfTicket: dateTimeService.prettifyDuration(ageOfTicketInMinutes)
         });
     } catch (error) {
         return response.status(SERVER_ERROR_CODE).send(error.message);

--- a/application/controllers/ticketController.js
+++ b/application/controllers/ticketController.js
@@ -38,6 +38,7 @@ router.get('/in-progress/:ticketId', async (request, response) => {
     const ticketObjectId = request.params.ticketId;
     try {
         const ticket = await TicketModel.findById(ticketObjectId).exec();
+        const material = await MaterialModel.findOne({materialId: ticket.primaryMaterial}).exec();
 
         if (!ticket) {
             throw new Error(`No ticket was found in the database whose object ID is "${ticketObjectId}"`);
@@ -48,7 +49,8 @@ router.get('/in-progress/:ticketId', async (request, response) => {
         }
 
         return response.render('viewOneInProgressTicket', {
-            ticket
+            ticket,
+            material
         });
     } catch (error) {
         return response.status(SERVER_ERROR_CODE).send(error.message);

--- a/application/enums/departmentsEnum.js
+++ b/application/enums/departmentsEnum.js
@@ -101,11 +101,11 @@ module.exports.removeDepartmentStatusesAUserIsNotAllowedToSelect = (departmentSt
 };
 
 module.exports.productionDepartmentsAndDepartmentStatuses = {
-    PRE_PRINTING_DEPARTMENT: this.departmentToStatusesMappingForTicketObjects[PRE_PRINTING_DEPARTMENT],
-    PRINTING_DEPARTMENT: this.departmentToStatusesMappingForTicketObjects[PRINTING_DEPARTMENT],
-    CUTTING_DEPARTMENT: this.departmentToStatusesMappingForTicketObjects[CUTTING_DEPARTMENT],
-    WINDING_DEPARTMENT: this.departmentToStatusesMappingForTicketObjects[WINDING_DEPARTMENT],
-    PACKAGING_DEPARTMENT: this.departmentToStatusesMappingForTicketObjects[PACKAGING_DEPARTMENT]
+    [PRE_PRINTING_DEPARTMENT]: this.departmentToStatusesMappingForTicketObjects[PRE_PRINTING_DEPARTMENT],
+    [PRINTING_DEPARTMENT]: this.departmentToStatusesMappingForTicketObjects[PRINTING_DEPARTMENT],
+    [CUTTING_DEPARTMENT]: this.departmentToStatusesMappingForTicketObjects[CUTTING_DEPARTMENT],
+    [WINDING_DEPARTMENT]: this.departmentToStatusesMappingForTicketObjects[WINDING_DEPARTMENT],
+    [PACKAGING_DEPARTMENT]: this.departmentToStatusesMappingForTicketObjects[PACKAGING_DEPARTMENT]
 };
 
 module.exports.COMPLETE_DEPARTMENT = COMPLETE_DEPARTMENT;

--- a/application/services/dateTimeService.js
+++ b/application/services/dateTimeService.js
@@ -6,14 +6,17 @@ const MINUTES_PER_WEEK = 10080;
 const MINUTES_PER_AVERAGE_MONTH = (DAYS_PER_YEAR / MONTHS_PER_YEAR) * MINUTES_PER_DAY;
 const MINUTES_PER_YEAR = DAYS_PER_YEAR * MINUTES_PER_DAY;
 
+const MILLISECONDS_PER_SECOND = 1000;
+const SECONDS_PER_MINUTE = 60;
+
 module.exports.howManyMillisecondsHavePassedBetweenDateTimes = (dateTime1, dateTime2) => {
     return Math.abs(dateTime2 - dateTime1);
 };
 
 module.exports.convertMillisecondsToMinutes = (numberOfMilliseconds) => {
-    const millisecondsPerMinute = 60000;
+    const milliSecondsPerMinute = MILLISECONDS_PER_SECOND * SECONDS_PER_MINUTE;
 
-    return numberOfMilliseconds / millisecondsPerMinute;
+    return numberOfMilliseconds / milliSecondsPerMinute;
 };
 
 module.exports.prettifyDuration = (durationInMinutes) => { // eslint-disable-line complexity

--- a/application/services/workflowStepService.js
+++ b/application/services/workflowStepService.js
@@ -126,17 +126,13 @@ module.exports.getHowLongTicketHasBeenInProduction = (workflowStepLedgerForTicke
     }
 
     let totalTimeInMinutes = 0;
-    const zeroMinutes = 0;
 
     Object.keys(productionDepartmentsAndDepartmentStatuses).forEach((department) => {
-        const departmentStatusesForThisDepartment = productionDepartmentsAndDepartmentStatuses[department];
-
-        departmentStatusesForThisDepartment.forEach((departmentStatus) => {
-            if (workflowStepLedgerForTicket[department]) {
-                const durationWithThisDepartmentStatus = workflowStepLedgerForTicket[department][TIME_PER_DEPARTMENT_STATUS][departmentStatus];
-                totalTimeInMinutes += durationWithThisDepartmentStatus ? durationWithThisDepartmentStatus : zeroMinutes;
-            }
-        });
+        const ticketHasSpentTimeInThisProductionDepartment = workflowStepLedgerForTicket[department];
+    
+        if (ticketHasSpentTimeInThisProductionDepartment) {
+            totalTimeInMinutes += workflowStepLedgerForTicket[department][TIME_SPENT_IN_DEPARTMENT];
+        }
     });
 
     return totalTimeInMinutes;

--- a/application/views/viewOneInProgressTicket.ejs
+++ b/application/views/viewOneInProgressTicket.ejs
@@ -18,26 +18,29 @@
         <div class='middle-col flex-top-center-column half-width'>
             <div class='card'>
                 <div class='ticket-details-wrapper'>
-                    <h3 class='ticket-info'>Customer Name Goes Here</h3>
+                    <h3 class='ticket-info'><%= ticket.customerName ? ticket.customerName : 'N/A' %></h3>
                     <div class='highlight-frame-small flex-center-center-row'>
                         <div class='col col-1'>
                             <div class='box'>
                                 <span>Created</span>
+                                <p><%= helperMethods.getDayNumberAndMonth(ticket.createdAt) %></p>
                             </div>
                         </div>
                         <div class='col col-2'>
                             <div class='box'>
                                 <span>Due</span>
+                                <p><%= helperMethods.getDayNumberAndMonth(ticket.shipDate) %></p>
                             </div>
                         </div>
                         <div class='col col-3'>
                             <div class='box'>
                                 <span>Age</span>
+                                <p>TODO: Calculate Age</p>
                             </div>
                         </div>
                         <div class='col col-4'>
                             <div class='box'>
-                                <span>Rush</span>
+                                <span><%= ticket.priority %></span>
                             </div>
                         </div>
                     </div>
@@ -48,6 +51,7 @@
                                     <i class="fas fa-toilet-paper-alt"></i>
                                 </div>
                                 <span>Material</span>
+                                <p><%= material.name %> (<%= material.materialId %>)</p>
                             </div>
                         </div>
                         <div class='col col-2'>
@@ -56,6 +60,7 @@
                                     <i class="fas fa-spray-can"></i>
                                 </div>
                                 <span>Finish</span>
+                                <p><%= ticket.products[0].finishType %></p>
                             </div>
                         </div>
                         <div class='col col-3'>
@@ -64,6 +69,7 @@
                                     <i class="fas fa-th"></i>
                                 </div>
                                 <span>Die</span>
+                                <p><%= ticket.products[0].productDie %></p>
                             </div>
                         </div>
                         <div class='col col-4'>
@@ -72,6 +78,7 @@
                                     <i class="fas fa-shoe-prints"></i>
                                 </div>
                                 <span>Total Feet</span>
+                                <p><%= ticket.totalMaterialLength %></p>
                             </div>
                         </div>
                     </div>
@@ -94,7 +101,7 @@
                                     <div class='col-td'><%= product.productNumber %></div>
                                     <div class='col-td'><%= product.labelQty || 'N/A'%></div>
                                     <div class='col-td'><%= product.totalFrames || 'N/A'%></div>
-                                    <div class='col-td'>50</div>
+                                    <div class='col-td'><%= product.totalFeet || 'N/A' %></div>
                                 </div>
                             <% }) %>
                         </div>
@@ -140,7 +147,7 @@
                         <div class='flex-center-center-row flex-wrap'>
                             <div class='product-attribute-frame'>
                                 <span>Material</span>
-                                <span><%= product.primaryMaterial || 'N/A' %> (???)</span>
+                                <span><%= material.name %> (<%= material.materialId %>)</span>
                             </div>
                             <div class='product-attribute-frame'>
                                 <span>S. Across</span>

--- a/application/views/viewOneInProgressTicket.ejs
+++ b/application/views/viewOneInProgressTicket.ejs
@@ -35,7 +35,7 @@
                         <div class='col col-3'>
                             <div class='box'>
                                 <span>Age</span>
-                                <p>TODO: Calculate Age</p>
+                                <p><%= ageOfTicket %></p>
                             </div>
                         </div>
                         <div class='col col-4'>
@@ -51,7 +51,7 @@
                                     <i class="fas fa-toilet-paper-alt"></i>
                                 </div>
                                 <span>Material</span>
-                                <p><%= material.name %> (<%= material.materialId %>)</p>
+                                <p><%= ticket.primaryMaterial %></p>
                             </div>
                         </div>
                         <div class='col col-2'>
@@ -147,7 +147,7 @@
                         <div class='flex-center-center-row flex-wrap'>
                             <div class='product-attribute-frame'>
                                 <span>Material</span>
-                                <span><%= material.name %> (<%= material.materialId %>)</span>
+                                <span><%= product.primaryMaterial %></span>
                             </div>
                             <div class='product-attribute-frame'>
                                 <span>S. Across</span>

--- a/test/services/workflowStepService.spec.js
+++ b/test/services/workflowStepService.spec.js
@@ -1,6 +1,6 @@
 const workflowStepService = require('../../application/services/workflowStepService');
 const chance = require('chance').Chance();
-const {productionDepartmentsAndDepartmentStatuses, getAllDepartments, departmentToStatusesMappingForTicketObjects} = require('../../application/enums/departmentsEnum');
+const {productionDepartmentsAndDepartmentStatuses, getAllDepartments} = require('../../application/enums/departmentsEnum');
 
 const TIME_SPENT_IN_DEPARTMENT = 'timeSpentInDepartment';
 const TIME_PER_DEPARTMENT_STATUS = 'timePerDepartmentStatus';
@@ -70,21 +70,15 @@ describe('workflowStepService test suite', () => {
 
         it('should only count the time a ticket has been in a production department/departmentStatus', () => {
             const nonProductionDepartment = getNonProductionDepartments()[0];
-            const nonProductionDepartmentDepartmentStatuses = departmentToStatusesMappingForTicketObjects[nonProductionDepartment];
-            const productionDepartment = Object.keys(productionDepartmentsAndDepartmentStatuses)[0];
-            const productionDepartmentDepartmentStatuses = productionDepartmentsAndDepartmentStatuses[productionDepartment];
+            const productionDepartment = chance.pickone(Object.keys(productionDepartmentsAndDepartmentStatuses));
             const durationSpentWithNonProductionDepartmentStatus = chance.floating({min: 0});
             const durationSpentWithProductionDepartmentStatus = chance.floating({min: 0});
             const workflowStepLedger = {
                 [nonProductionDepartment]: {
-                    [TIME_PER_DEPARTMENT_STATUS]: {
-                        [nonProductionDepartmentDepartmentStatuses[0]]: durationSpentWithNonProductionDepartmentStatus
-                    }
+                    [TIME_SPENT_IN_DEPARTMENT]: durationSpentWithNonProductionDepartmentStatus
                 },
                 [productionDepartment]: {
-                    [TIME_PER_DEPARTMENT_STATUS]: {
-                        [productionDepartmentDepartmentStatuses[0]]: durationSpentWithProductionDepartmentStatus
-                    }
+                    [TIME_SPENT_IN_DEPARTMENT]: durationSpentWithProductionDepartmentStatus
                 }
             };
 


### PR DESCRIPTION
# Description

Prior to this PR, there was a view that was rendered when a user visited `/tickets/in-progress/:ticketId` which showed information about the ticket associated in the database to the `:ticketId`.

This page was mostly hardcoded and styled, but this PR makes the hardcoded parts dynamic. All values seen in the screenshot below are dynamically rendered.

## Verification
<img width="1037" alt="image" src="https://user-images.githubusercontent.com/42784674/222287546-f859ef72-8199-4643-a384-1c22719d4da1.png">
> Attributes now populate dynamically on this view