### PR TITLE
Fix Broken Ticket Upload Endpoint

### DIFF
--- a/application/controllers/ticketController.js
+++ b/application/controllers/ticketController.js
@@ -1,7 +1,6 @@
 const router = require('express').Router();
 const {verifyJwtToken} = require('../middleware/authorize');
 const {upload} = require('../middleware/upload');
-const fs = require('fs');
 const parser = require('xml2json');
 const ticketService = require('../services/ticketService');
 const TicketModel = require('../models/ticket');

--- a/application/controllers/ticketController.js
+++ b/application/controllers/ticketController.js
@@ -201,11 +201,10 @@ router.get('/form', (request, response) => {
 });
 
 router.post('/', upload.single('job-xml'), async (request, response) => {
-    const jobFilePath = fileService.getUploadedFilePath(request.file.filename);
+    const xmlFile = fileService.getUploadedFile(request.file.filename);
 
     try {
-        const jobAsXml = fs.readFileSync(jobFilePath);
-        const rawUploadedTicketAsJson = JSON.parse(parser.toJson(jobAsXml))['Root'];
+        const rawUploadedTicketAsJson = JSON.parse(parser.toJson(xmlFile.fileContents))['Root'];
 
         ticketService.removeEmptyObjectAttributes(rawUploadedTicketAsJson);
 
@@ -222,7 +221,7 @@ router.post('/', upload.single('job-xml'), async (request, response) => {
     
         return response.redirect('/tickets/form');
     } finally {
-        fileService.deleteOneFileFromFileSystem(jobFilePath);
+        fileService.deleteOneFileFromFileSystem(xmlFile);
     }
 });
 


### PR DESCRIPTION
# Description

A recent PR broke an endpoint that allowed users to upload a file and that file would be converted to a `ticket` object in the database.

This PR fixes that issue and makes everything work again.