### PR TITLE
Feature: Compute Net Material Usage on Inventory Page

### DIFF
--- a/application/controllers/materialInventoryController.js
+++ b/application/controllers/materialInventoryController.js
@@ -25,7 +25,7 @@ router.get('/', async (request, response) => {
         const lengthOfAllMaterialsInInventory = purchaseOrderService.computeLengthOfMaterial(purchaseOrdersThatHaveArrived);
         const lengthOfAllMaterialsOrdered = purchaseOrderService.computeLengthOfMaterial(purchaseOrdersThatHaveNotArrived);
 
-        const materialObjectIdToLengthUsedByTickets = await ticketService.getLengthOfEachMaterialUsedByTickets(distinctMaterialIds)
+        const materialObjectIdToLengthUsedByTickets = await ticketService.getLengthOfEachMaterialUsedByTickets(distinctMaterialIds);
 
         const materialInventories = allMaterials.map((material) => {
             const feetOfMaterialAlreadyUsedByTickets = materialObjectIdToLengthUsedByTickets[material.materialId] || 0;

--- a/application/controllers/materialInventoryController.js
+++ b/application/controllers/materialInventoryController.js
@@ -34,10 +34,13 @@ router.get('/', async (request, response) => {
             return materialInventoryService.buildMaterialInventory(material, purchaseOrdersForMaterial, feetOfMaterialAlreadyUsedByTickets);
         });
 
+        const netLengthOfMaterialInInventory = materialInventoryService.computeNetLengthOfMaterialInInventory(materialInventories);
+
         return response.render('viewMaterialInventory', {
             materialInventories,
             lengthOfAllMaterialsInInventory,
             lengthOfAllMaterialsOrdered,
+            netLengthOfMaterialInInventory,
             totalPurchaseOrders: allPurchaseOrders.length
         });
 

--- a/application/controllers/materialInventoryController.js
+++ b/application/controllers/materialInventoryController.js
@@ -4,17 +4,20 @@ const {verifyJwtToken} = require('../middleware/authorize');
 const materialInventoryService = require('../services/materialInventoryService');
 const materialService = require('../services/materialService');
 const purchaseOrderService = require('../services/purchaseOrderService');
+const ticketService = require('../services/ticketService');
+const mongooseService = require('../services/mongooseService');
 
 router.use(verifyJwtToken);
 
 router.get('/', async (request, response) => {
     try {
         const allMaterials = await materialService.getAllMaterials();
+
+        const distinctMaterialObjectIds = mongooseService.getObjectIds(allMaterials);
         const distinctMaterialIds = materialService.getMaterialIds(allMaterials);
 
-        const allPurchaseOrders = await purchaseOrderService.getPurchaseOrdersForMaterials(distinctMaterialIds);
-
-        const materialIdToPurchaseOrders = materialInventoryService.mapMaterialIdToPurchaseOrders(distinctMaterialIds, allPurchaseOrders);
+        const allPurchaseOrders = await purchaseOrderService.getPurchaseOrdersForMaterials(distinctMaterialObjectIds);
+        const materialIdToPurchaseOrders = materialInventoryService.mapMaterialIdToPurchaseOrders(distinctMaterialObjectIds, allPurchaseOrders);
 
         const purchaseOrdersThatHaveArrived = purchaseOrderService.findPurchaseOrdersThatHaveArrived(allPurchaseOrders);
         const purchaseOrdersThatHaveNotArrived = purchaseOrderService.findPurchaseOrdersThatHaveNotArrived(allPurchaseOrders);
@@ -22,9 +25,13 @@ router.get('/', async (request, response) => {
         const lengthOfAllMaterialsInInventory = purchaseOrderService.computeLengthOfMaterial(purchaseOrdersThatHaveArrived);
         const lengthOfAllMaterialsOrdered = purchaseOrderService.computeLengthOfMaterial(purchaseOrdersThatHaveNotArrived);
 
+        const materialObjectIdToLengthUsedByTickets = await ticketService.getLengthOfEachMaterialUsedByTickets(distinctMaterialIds)
+
         const materialInventories = allMaterials.map((material) => {
+            const feetOfMaterialAlreadyUsedByTickets = materialObjectIdToLengthUsedByTickets[material.materialId] || 0;
             const purchaseOrdersForMaterial = materialIdToPurchaseOrders[material._id];
-            return materialInventoryService.buildMaterialInventory(material, purchaseOrdersForMaterial);
+
+            return materialInventoryService.buildMaterialInventory(material, purchaseOrdersForMaterial, feetOfMaterialAlreadyUsedByTickets);
         });
 
         return response.render('viewMaterialInventory', {

--- a/application/services/materialInventoryService.js
+++ b/application/services/materialInventoryService.js
@@ -29,3 +29,11 @@ module.exports.buildMaterialInventory = (material, allPurchaseOrdersForMaterial,
         purchaseOrdersForMaterial: purchaseOrdersThatHaveNotArrived
     };
 };
+
+module.exports.computeNetLengthOfMaterialInInventory = (materialInventories) => {
+    const initialValue = 0;
+
+    return materialInventories.reduce((accumulator, currentMaterialInventory) => {
+        return accumulator + currentMaterialInventory.netLengthOfMaterialInStock;
+    }, initialValue)
+}

--- a/application/services/materialInventoryService.js
+++ b/application/services/materialInventoryService.js
@@ -1,4 +1,5 @@
 const purchaseOrderService = require('../services/purchaseOrderService');
+const ticketService = require('../services/ticketService');
 
 module.exports.mapMaterialIdToPurchaseOrders = (materialIds, purchaseOrders) => {
     const materialIdToPurchaseOrders = {};
@@ -16,14 +17,16 @@ module.exports.mapMaterialIdToPurchaseOrders = (materialIds, purchaseOrders) => 
     return materialIdToPurchaseOrders;
 };
 
-module.exports.buildMaterialInventory = (material, allPurchaseOrdersForMaterial) => {
+module.exports.buildMaterialInventory = (material, allPurchaseOrdersForMaterial, feetOfMaterialAlreadyUsedByTickets) => {
     const purchaseOrdersThatHaveArrived = purchaseOrderService.findPurchaseOrdersThatHaveArrived(allPurchaseOrdersForMaterial);
     const purchaseOrdersThatHaveNotArrived = purchaseOrderService.findPurchaseOrdersThatHaveNotArrived(allPurchaseOrdersForMaterial);
+    const lengthOfMaterialInStock = purchaseOrderService.computeLengthOfMaterial(purchaseOrdersThatHaveArrived);
 
     return {
         material,
         lengthOfMaterialOrdered: purchaseOrderService.computeLengthOfMaterial(purchaseOrdersThatHaveNotArrived),
-        lengthOfMaterialInStock: purchaseOrderService.computeLengthOfMaterial(purchaseOrdersThatHaveArrived),
+        lengthOfMaterialInStock: lengthOfMaterialInStock,
+        netLengthOfMaterialInStock: (lengthOfMaterialInStock - feetOfMaterialAlreadyUsedByTickets),
         purchaseOrdersForMaterial: purchaseOrdersThatHaveNotArrived
     };
 };

--- a/application/services/materialInventoryService.js
+++ b/application/services/materialInventoryService.js
@@ -1,5 +1,4 @@
 const purchaseOrderService = require('../services/purchaseOrderService');
-const ticketService = require('../services/ticketService');
 
 module.exports.mapMaterialIdToPurchaseOrders = (materialIds, purchaseOrders) => {
     const materialIdToPurchaseOrders = {};

--- a/application/services/materialInventoryService.js
+++ b/application/services/materialInventoryService.js
@@ -35,5 +35,5 @@ module.exports.computeNetLengthOfMaterialInInventory = (materialInventories) => 
 
     return materialInventories.reduce((accumulator, currentMaterialInventory) => {
         return accumulator + currentMaterialInventory.netLengthOfMaterialInStock;
-    }, initialValue)
-}
+    }, initialValue);
+};

--- a/application/services/materialService.js
+++ b/application/services/materialService.js
@@ -1,8 +1,8 @@
 const MaterialModel = require('../models/material');
 
 module.exports.getMaterialIds = (materials) => {
-    return materials.map((material) => {
-        return material._id;
+    return materials.map(({materialId}) => {
+        return materialId;
     });
 };
 

--- a/application/services/mongooseService.js
+++ b/application/services/mongooseService.js
@@ -2,7 +2,7 @@ module.exports.getObjectIds = (objects) => {
     return objects.map(({_id}) => {
         return _id;
     });
-}
+};
 
 module.exports.parseHumanReadableMessages = (error) => {
     try {

--- a/application/services/mongooseService.js
+++ b/application/services/mongooseService.js
@@ -1,3 +1,9 @@
+module.exports.getObjectIds = (objects) => {
+    return objects.map(({_id}) => {
+        return _id;
+    });
+}
+
 module.exports.parseHumanReadableMessages = (error) => {
     try {
         const aNonMongooseErrorOccurred = !error.errors && error.message;

--- a/application/services/ticketService.js
+++ b/application/services/ticketService.js
@@ -142,14 +142,14 @@ module.exports.getLengthOfEachMaterialUsedByTickets = async (materialIds) => {
         { $match: { primaryMaterial: { $in: materialIds } } },
         { $group: { _id: '$primaryMaterial', lengthUsed: { $sum: '$totalMaterialLength'}}}
     ]);
-    const materialObjectIdToLengthUsedByTickets = {};
+    const materialIdToLengthUsedByTickets = {};
 
     lengthOfEachMaterialAlreadyUsedByTickets.forEach((oneMaterialUsage) => {
         const materialId = oneMaterialUsage._id;
         const lengthUsed = oneMaterialUsage.lengthUsed;
         
-        materialObjectIdToLengthUsedByTickets[materialId] = lengthUsed;
+        materialIdToLengthUsedByTickets[materialId] = lengthUsed;
     });
 
-    return materialObjectIdToLengthUsedByTickets;
+    return materialIdToLengthUsedByTickets;
 };

--- a/application/services/ticketService.js
+++ b/application/services/ticketService.js
@@ -136,3 +136,20 @@ module.exports.groupTicketsByDestination = (tickets) => {
 
     return ticketsGroupedByDestination;
 };
+
+module.exports.getLengthOfEachMaterialUsedByTickets = async (materialIds) => {
+    const lengthOfEachMaterialAlreadyUsedByTickets = await TicketModel.aggregate([
+        { $match: { primaryMaterial: { $in: materialIds } } },
+        { $group: { _id: "$primaryMaterial", lengthUsed: { $sum: "$totalMaterialLength"}}}
+    ]);
+    const materialObjectIdToLengthUsedByTickets = {};
+
+    lengthOfEachMaterialAlreadyUsedByTickets.forEach((oneMaterialUsage) => {
+        const materialId = oneMaterialUsage._id;
+        const lengthUsed = oneMaterialUsage.lengthUsed;
+        
+        materialObjectIdToLengthUsedByTickets[materialId] = lengthUsed;
+    });
+
+    return materialObjectIdToLengthUsedByTickets;
+}

--- a/application/services/ticketService.js
+++ b/application/services/ticketService.js
@@ -140,7 +140,7 @@ module.exports.groupTicketsByDestination = (tickets) => {
 module.exports.getLengthOfEachMaterialUsedByTickets = async (materialIds) => {
     const lengthOfEachMaterialAlreadyUsedByTickets = await TicketModel.aggregate([
         { $match: { primaryMaterial: { $in: materialIds } } },
-        { $group: { _id: "$primaryMaterial", lengthUsed: { $sum: "$totalMaterialLength"}}}
+        { $group: { _id: '$primaryMaterial', lengthUsed: { $sum: '$totalMaterialLength'}}}
     ]);
     const materialObjectIdToLengthUsedByTickets = {};
 
@@ -152,4 +152,4 @@ module.exports.getLengthOfEachMaterialUsedByTickets = async (materialIds) => {
     });
 
     return materialObjectIdToLengthUsedByTickets;
-}
+};

--- a/application/views/viewMaterialInventory.ejs
+++ b/application/views/viewMaterialInventory.ejs
@@ -12,7 +12,7 @@
         <h1 class='total-length-of-material-in-inventory'><%= lengthOfAllMaterialsInInventory || 'N/A' %></h1>
       </div>
       <div class='card col col-one third-width'>
-        <span>Net</span>
+        <span>Net Feet</span>
         <h1 class='net-length-of-material-in-inventory'><%= netLengthOfMaterialInInventory || 'N/A' %></h1>
       </div>
       <div class='card col col-two'>

--- a/application/views/viewMaterialInventory.ejs
+++ b/application/views/viewMaterialInventory.ejs
@@ -11,6 +11,10 @@
         <span>Feet On Hand</span>
         <h1 class='total-length-of-material-in-inventory'><%= lengthOfAllMaterialsInInventory || 'N/A' %></h1>
       </div>
+      <div class='card col col-one third-width'>
+        <span>Net</span>
+        <h1 class='net-length-of-material-in-inventory'><%= netLengthOfMaterialInInventory || 'N/A' %></h1>
+      </div>
       <div class='card col col-two'>
         <span>Feet On Order</span>
         <h1 class='total-length-of-material-ordered'><%= lengthOfAllMaterialsOrdered || 'N/A' %></h1>

--- a/application/views/viewMaterialInventory.ejs
+++ b/application/views/viewMaterialInventory.ejs
@@ -116,12 +116,16 @@
           </div>
           <div class='col col-left'>
             <span>Actual</span>
-            <h2 class='material-length-in-stock'><%= materialInventory.lengthOfMaterialInStock %></h2>
+            <h2 class='material-length-in-stock'><%= materialInventory.lengthOfMaterialInStock %></h2> <!--  TODO: Do we really even want this? Or do we only care about NET -->
           </div>
           <div class='divide-line'></div>
           <div class='col col-right'>
             <span>Ordered</span>
             <h2 class='material-length-ordered'><%= materialInventory.lengthOfMaterialOrdered %></h2>
+          </div>
+          <div class='col col-right'>
+            <span>Net</span>
+            <h2 class='material-length-ordered'><%= materialInventory.netLengthOfMaterialInStock %></h2>
           </div>
         </div>
 

--- a/application/views/viewMaterialInventory.ejs
+++ b/application/views/viewMaterialInventory.ejs
@@ -120,7 +120,7 @@
           </div>
           <div class='col col-left'>
             <span>Actual</span>
-            <h2 class='material-length-in-stock'><%= materialInventory.lengthOfMaterialInStock %></h2> <!--  TODO: Do we really even want this? Or do we only care about NET -->
+            <h2 class='material-length-in-stock'><%= materialInventory.lengthOfMaterialInStock %></h2>
           </div>
           <div class='divide-line'></div>
           <div class='col col-right'>

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "cypress": "12.1.0",
         "eslint": "8.29.0",
         "jest": "29.3.1",
+        "jest-when": "3.5.2",
         "nodemon": "2.0.20",
         "start-server-and-test": "1.15.2"
       },
@@ -6185,6 +6186,15 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-when": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/jest-when/-/jest-when-3.5.2.tgz",
+      "integrity": "sha512-4rDvnhaWh08RcPsoEVXgxRnUIE9wVIbZtGqZ5x2Wm9Ziz9aQs89PipQFmOK0ycbEhVAgiV3MUeTXp3Ar4s2FcQ==",
+      "dev": true,
+      "peerDependencies": {
+        "jest": ">= 25"
       }
     },
     "node_modules/jest-worker": {
@@ -14012,6 +14022,13 @@
         "jest-util": "^29.5.0",
         "string-length": "^4.0.1"
       }
+    },
+    "jest-when": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/jest-when/-/jest-when-3.5.2.tgz",
+      "integrity": "sha512-4rDvnhaWh08RcPsoEVXgxRnUIE9wVIbZtGqZ5x2Wm9Ziz9aQs89PipQFmOK0ycbEhVAgiV3MUeTXp3Ar4s2FcQ==",
+      "dev": true,
+      "requires": {}
     },
     "jest-worker": {
       "version": "29.5.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "cypress": "12.1.0",
     "eslint": "8.29.0",
     "jest": "29.3.1",
+    "jest-when": "3.5.2",
     "nodemon": "2.0.20",
     "start-server-and-test": "1.15.2"
   },

--- a/test/services/materialInventoryService.spec.js
+++ b/test/services/materialInventoryService.spec.js
@@ -1,4 +1,5 @@
 const chance = require('chance').Chance();
+const { when } = require('jest-when');
 const materialInventoryService = require('../../application/services/materialInventoryService');
 const mockPurchaseOrderService = require('../../application/services/purchaseOrderService');
 
@@ -44,7 +45,11 @@ describe('materialInventoryService test suite', () => {
     });
 
     describe('buildMaterialInventory', () => {
-        let purchaseOrdersThatHaveArrived, purchaseOrdersThatHaveNotArrived, material, purchaseOrders;
+        let purchaseOrdersThatHaveArrived, 
+            purchaseOrdersThatHaveNotArrived, 
+            material,
+            purchaseOrders,
+            feetOfMaterialAlreadyUsedByTickets;
 
         afterEach(() => {
             jest.resetAllMocks();
@@ -63,18 +68,28 @@ describe('materialInventoryService test suite', () => {
                 ...purchaseOrdersThatHaveArrived,
                 ...purchaseOrdersThatHaveNotArrived
             ];
-            mockPurchaseOrderService.findPurchaseOrdersThatHaveArrived.mockReturnValue(purchaseOrdersThatHaveArrived);
-            mockPurchaseOrderService.findPurchaseOrdersThatHaveNotArrived.mockReturnValue(purchaseOrdersThatHaveNotArrived);
-            mockPurchaseOrderService.computeLengthOfMaterial.mockReturnValue(chance.integer({min: 0}));
+            feetOfMaterialAlreadyUsedByTickets = 0;
+
+            when(mockPurchaseOrderService.findPurchaseOrdersThatHaveArrived)
+                .calledWith(purchaseOrders)
+                .mockReturnValue(purchaseOrdersThatHaveArrived);
+
+            when(mockPurchaseOrderService.findPurchaseOrdersThatHaveNotArrived)
+                .calledWith(purchaseOrders)
+                .mockReturnValue(purchaseOrdersThatHaveNotArrived);
+
+            when(mockPurchaseOrderService.computeLengthOfMaterial)
+                .calledWith(purchaseOrders)
+                .mockReturnValue(chance.integer({min: 0}));
         });
         it('should not throw an error', () => {
             expect(() => {
-                materialInventoryService.buildMaterialInventory({}, []);
+                materialInventoryService.buildMaterialInventory({}, [], feetOfMaterialAlreadyUsedByTickets);
             }).not.toThrowError();
         });
 
         it('should call correct methods', () => {
-            materialInventoryService.buildMaterialInventory(material, purchaseOrders);
+            materialInventoryService.buildMaterialInventory(material, purchaseOrders, feetOfMaterialAlreadyUsedByTickets);
 
             expect(mockPurchaseOrderService.findPurchaseOrdersThatHaveArrived).toHaveBeenCalledTimes(1);
             expect(mockPurchaseOrderService.findPurchaseOrdersThatHaveNotArrived).toHaveBeenCalledTimes(1);
@@ -82,18 +97,29 @@ describe('materialInventoryService test suite', () => {
             expect(mockPurchaseOrderService.computeLengthOfMaterial).toHaveBeenCalledWith(purchaseOrdersThatHaveNotArrived);
         });
 
-        it('should name this test better', () => {
-            const lengthOfPurchaseOrdersThatHaveNotArrived = chance.integer({min: 1});
-            const lengthOfPurchaseOrdersThatHaveArrived = chance.integer({min: 1});
-            mockPurchaseOrderService.computeLengthOfMaterial.mockReturnValueOnce(lengthOfPurchaseOrdersThatHaveNotArrived).mockReturnValueOnce(lengthOfPurchaseOrdersThatHaveArrived);
+        it('should return a materialInventory object with correctly calculated attributes', () => {
+            const lengthOfMaterialOrdered = chance.integer({min: 1});
+            const lengthOfMaterialInStock = chance.integer({min: 1});
+
+            when(mockPurchaseOrderService.computeLengthOfMaterial)
+                .calledWith(purchaseOrdersThatHaveArrived)
+                .mockReturnValue(lengthOfMaterialInStock);
+
+            when(mockPurchaseOrderService.computeLengthOfMaterial)
+                .calledWith(purchaseOrdersThatHaveNotArrived)
+                .mockReturnValue(lengthOfMaterialOrdered);
+
+            feetOfMaterialAlreadyUsedByTickets = chance.integer();
+            const netLengthOfMaterialInStock = lengthOfMaterialInStock - feetOfMaterialAlreadyUsedByTickets;
             const expectedMaterialInventory = {
                 material,
-                lengthOfMaterialOrdered: lengthOfPurchaseOrdersThatHaveNotArrived,
-                lengthOfMaterialInStock: lengthOfPurchaseOrdersThatHaveArrived,
+                netLengthOfMaterialInStock,
+                lengthOfMaterialOrdered,
+                lengthOfMaterialInStock,
                 purchaseOrdersForMaterial: purchaseOrdersThatHaveNotArrived
             };
 
-            const materialInventory = materialInventoryService.buildMaterialInventory(material, purchaseOrders);
+            const materialInventory = materialInventoryService.buildMaterialInventory(material, purchaseOrders, feetOfMaterialAlreadyUsedByTickets);
         
             expect(materialInventory).toEqual(expectedMaterialInventory);
         });
@@ -126,7 +152,7 @@ describe('materialInventoryService test suite', () => {
 
             expect(actualNetLengthOfMaterial).toBe(expectedNetLengthOfMaterial);
         });
-    })
+    });
 });
 
 function buildPurchaseOrder(materialId) {

--- a/test/services/materialInventoryService.spec.js
+++ b/test/services/materialInventoryService.spec.js
@@ -98,6 +98,35 @@ describe('materialInventoryService test suite', () => {
             expect(materialInventory).toEqual(expectedMaterialInventory);
         });
     });
+
+    describe('computeNetLengthOfMaterialInInventory', () => {
+        let materialInventories;
+
+        it('should return 0 when input is an empty array', () => {
+            materialInventories = [];
+            const expectedNetLengthOfMaterial = 0;
+
+            const actualNetLengthOfMaterial = materialInventoryService.computeNetLengthOfMaterialInInventory(materialInventories);
+
+            expect(actualNetLengthOfMaterial).toBe(expectedNetLengthOfMaterial);
+        });
+
+        it('should return the summation of each materialInventories "netLengthOfMaterialInStock" attribute', () => {
+            const netLengthOfMaterial1 = chance.integer();
+            const netLengthOfMaterial2 = chance.integer();
+            const netLengthOfMaterial3 = chance.integer();
+            materialInventories = [
+                { netLengthOfMaterialInStock: netLengthOfMaterial1 },
+                { netLengthOfMaterialInStock: netLengthOfMaterial2 },
+                { netLengthOfMaterialInStock: netLengthOfMaterial3 }
+            ];
+            const expectedNetLengthOfMaterial = netLengthOfMaterial1 + netLengthOfMaterial2 + netLengthOfMaterial3;
+
+            const actualNetLengthOfMaterial = materialInventoryService.computeNetLengthOfMaterialInInventory(materialInventories);
+
+            expect(actualNetLengthOfMaterial).toBe(expectedNetLengthOfMaterial);
+        });
+    })
 });
 
 function buildPurchaseOrder(materialId) {

--- a/test/services/materialService.spec.js
+++ b/test/services/materialService.spec.js
@@ -9,11 +9,11 @@ describe('materialService test suite', () => {
         let materials, materialIds;
         
         beforeEach(() => {
-            materialIds = chance.n(chance.string, chance.integer({min: 0, max: 20}));
+            materialIds = chance.n(chance.string, chance.d12());
             materials = buildMaterials(materialIds);
         });
 
-        it('should parse _id attribute from all materials', () => {
+        it('should parse materialId attribute from all materials', () => {
             const actualMaterialIds = materialService.getMaterialIds(materials);
 
             expect(actualMaterialIds.sort()).toEqual(materialIds.sort());
@@ -57,11 +57,11 @@ describe('materialService test suite', () => {
             const materials = await materialService.getAllMaterials();
 
             expect(materials).toBeDefined();
-            expect(materials.length).toBe(0); // eslint-disable-line no-magic-numbers
+            expect(materials.length).toBe(0);
         });
 
         it ('should return the materials from the database', async () => {
-            materialsInDatabase = buildMaterials(chance.n(chance.string, chance.integer({min: 0, max: 100})));
+            materialsInDatabase = buildMaterials(chance.n(chance.string, chance.d100()));
             execFunction = jest.fn().mockResolvedValue(materialsInDatabase);
         
             const materials = await materialService.getAllMaterials();
@@ -75,7 +75,7 @@ describe('materialService test suite', () => {
 function buildMaterials(materialIds) {
     return materialIds.map((materialId) => {
         return {
-            _id: materialId
+            materialId
         };
     });
 }

--- a/test/services/mongooseService.spec.js
+++ b/test/services/mongooseService.spec.js
@@ -20,47 +20,75 @@ function getOneMongooseError(errorType) {
 }
 
 describe('mongooseService test cases', () => {
-    let error;
-    beforeEach(() => {
-        error = {
-            'errors': {
-                ...getOneMongooseError('ValidatorError')
-            },
-            '_message': chance.string(),
-            'name': chance.word(),
-            'message': chance.string()
-        };
+    describe('parseHumanReadableMessages()', () => {
+        let error;
+
+        beforeEach(() => {
+            error = {
+                'errors': {
+                    ...getOneMongooseError('ValidatorError')
+                },
+                '_message': chance.string(),
+                'name': chance.word(),
+                'message': chance.string()
+            };
+        });
+
+        it('should return an unknown error', () => {
+            const humanReadableErrorMessages = mongooseService.parseHumanReadableMessages(undefined);
+    
+            expect(humanReadableErrorMessages.length).toBe(1);
+            expect(humanReadableErrorMessages[0]).toBe('Uh oh, an unknown error occurred, please contact the IT department.');
+        });
+    
+        it('should return a human readable error message if validation error', () => {
+            const {errors} = error;
+            const key = Object.keys(errors)[0];
+            const humanReadableErrorMessages = mongooseService.parseHumanReadableMessages(error);
+    
+            console.log(humanReadableErrorMessages);
+    
+            expect(humanReadableErrorMessages.length).toBe(1);
+            expect(humanReadableErrorMessages[0]).toBe(errors[key]['message']);
+        });
+    
+        it('should return a human readable error message if NON validation error', () => {
+            error.errors = {
+                ...getOneMongooseError(chance.word())
+            };
+            const key = Object.keys(error.errors)[0];
+            const {errors} = error;
+            const humanReadableErrorMessages = mongooseService.parseHumanReadableMessages(error);
+    
+            console.log(humanReadableErrorMessages);
+    
+            expect(humanReadableErrorMessages.length).toBe(1);
+            expect(humanReadableErrorMessages[0]).toBe(`'${errors[key]['name']}': ${errors[key]['message']}`);
+        });
     });
 
-    it('should return an unknown error', () => {
-        const humanReadableErrorMessages = mongooseService.parseHumanReadableMessages(undefined);
+    describe('getObjectIds()', () => {
+        let objects;
 
-        expect(humanReadableErrorMessages.length).toBe(1);
-        expect(humanReadableErrorMessages[0]).toBe('Uh oh, an unknown error occurred, please contact the IT department.');
-    });
+        it('should return an empty array an empty array is passed in', () => {
+            objects = [];
+            const emptyArray = [];
 
-    it('should return a human readable error message if validation error', () => {
-        const {errors} = error;
-        const key = Object.keys(errors)[0];
-        const humanReadableErrorMessages = mongooseService.parseHumanReadableMessages(error);
+            const actualObjectIds = mongooseService.getObjectIds(objects);
 
-        console.log(humanReadableErrorMessages);
+            expect(actualObjectIds).toEqual(emptyArray);
+        });
 
-        expect(humanReadableErrorMessages.length).toBe(1);
-        expect(humanReadableErrorMessages[0]).toBe(errors[key]['message']);
-    });
+        it('should return an array of each objects _id attribute', () => {
+            const object1 = {_id: chance.string()};
+            const object2 = {_id: chance.string()};
+            const object3 = {_id: chance.string()};
+            objects = [object1, object2, object3];
+            const expectedObjectIds = [object1._id, object2._id, object3._id];
 
-    it('should return a human readable error message if NON validation error', () => {
-        error.errors = {
-            ...getOneMongooseError(chance.word())
-        };
-        const key = Object.keys(error.errors)[0];
-        const {errors} = error;
-        const humanReadableErrorMessages = mongooseService.parseHumanReadableMessages(error);
+            const actualObjectIds = mongooseService.getObjectIds(objects);
 
-        console.log(humanReadableErrorMessages);
-
-        expect(humanReadableErrorMessages.length).toBe(1);
-        expect(humanReadableErrorMessages[0]).toBe(`'${errors[key]['name']}': ${errors[key]['message']}`);
+            expect(actualObjectIds).toEqual(expectedObjectIds);
+        });
     });
 });

--- a/test/services/ticketService.spec.js
+++ b/test/services/ticketService.spec.js
@@ -245,7 +245,7 @@ describe('ticketService test suite', () => {
             when(mockTicketModel.aggregate)
                 .calledWith(expect.any(Array))
                 .mockResolvedValue([]);
-        })
+        });
 
         it('should not throw an error', async () => {
             materialIds = [];

--- a/test/services/ticketService.spec.js
+++ b/test/services/ticketService.spec.js
@@ -241,6 +241,12 @@ describe('ticketService test suite', () => {
     describe('getLengthOfEachMaterialUsedByTickets()', () => {
         let materialIds;
 
+        beforeEach(() => {
+            when(mockTicketModel.aggregate)
+                .calledWith(expect.any(Array))
+                .mockResolvedValue([]);
+        })
+
         it('should not throw an error', async () => {
             materialIds = [];
             await expect(ticketService.getLengthOfEachMaterialUsedByTickets(materialIds)).resolves.not.toThrowError();


### PR DESCRIPTION
# Description

This PR does a pretty cool thing in my opinion.

Currently, this application allows users to store Purchased Material ("purchaseOrders"). This application also allows users to use part of the materials that were purchased. The amount used is stored on a ticket database object, specifically the attribute called `ticket.lengthUsed`.

The need for computing the "net" amount of material available was brought up, and this PR makes that happen.

The formula for the net material available is `Sum(purchaseOrder) - Sum(materialUsedByTickets) = Net Material Sitting in inventory`)

## Verification
<img width="1919" alt="image" src="https://user-images.githubusercontent.com/42784674/224512248-57323335-dc95-4ded-a6c0-30caaf407f57.png">
> The net amount of material available is displayed on the `/material-inventory` page