### PR TITLE
wip: refactoring how material inventory is calculated

### DIFF
--- a/application/controllers/materialInventoryController.js
+++ b/application/controllers/materialInventoryController.js
@@ -16,33 +16,16 @@ router.get('/', async (request, response) => {
         const distinctMaterialObjectIds = mongooseService.getObjectIds(allMaterials);
         const distinctMaterialIds = materialService.getMaterialIds(allMaterials);
 
-        const allPurchaseOrders = await purchaseOrderService.getPurchaseOrdersForMaterials(distinctMaterialObjectIds);
-        const materialIdToPurchaseOrders = materialInventoryService.mapMaterialIdToPurchaseOrders(distinctMaterialObjectIds, allPurchaseOrders);
+        const materialIdToLengthInInventory = await purchaseOrderService.getMaterialIdToLengthInInventory(distinctMaterialObjectIds);
+        const materialIdToLengthUsedByTickets = await ticketService.getMaterialIdToLengthUsedByTickets(distinctMaterialIds);
+        const materialIdToLengthOrdered = await purchaseOrderService.getMaterialIdToLengthOrdered(distinctMaterialObjectIds)
 
-        const purchaseOrdersThatHaveArrived = purchaseOrderService.findPurchaseOrdersThatHaveArrived(allPurchaseOrders);
-        const purchaseOrdersThatHaveNotArrived = purchaseOrderService.findPurchaseOrdersThatHaveNotArrived(allPurchaseOrders);
-
-        const lengthOfAllMaterialsInInventory = purchaseOrderService.computeLengthOfMaterial(purchaseOrdersThatHaveArrived);
-        const lengthOfAllMaterialsOrdered = purchaseOrderService.computeLengthOfMaterial(purchaseOrdersThatHaveNotArrived);
-
-        const materialObjectIdToLengthUsedByTickets = await ticketService.getLengthOfEachMaterialUsedByTickets(distinctMaterialIds);
-
-        const materialInventories = allMaterials.map((material) => {
-            const feetOfMaterialAlreadyUsedByTickets = materialObjectIdToLengthUsedByTickets[material.materialId] || 0;
-            const purchaseOrdersForMaterial = materialIdToPurchaseOrders[material._id];
-
-            return materialInventoryService.buildMaterialInventory(material, purchaseOrdersForMaterial, feetOfMaterialAlreadyUsedByTickets);
-        });
-
-        const netLengthOfMaterialInInventory = materialInventoryService.computeNetLengthOfMaterialInInventory(materialInventories);
-
-        return response.render('viewMaterialInventory', {
-            materialInventories,
-            lengthOfAllMaterialsInInventory,
-            lengthOfAllMaterialsOrdered,
-            netLengthOfMaterialInInventory,
-            totalPurchaseOrders: allPurchaseOrders.length
-        });
+        // TODO (3-11-2023): The problem is that some database tables refer to the materialId as link to a specific material (i.e. purchaseOrders) while other database tables refer to the materialId (i.e. 9111, 2413) as the link to a specific material
+        // This makes this current approach difficult. Is there a problem with this approach, or is there a problem with how the data is being stored. I.e. should I refer to a material ONLY ever using objectIds or ONLY ever using materialIds. Good luck future self. May the force be with you.
+        response.send(`materialIdToLengthInInventory => ${JSON.stringify(materialIdToLengthInInventory)} 
+            \n\n materialIdToLengthUsedByTickets => ${JSON.stringify(materialIdToLengthUsedByTickets)}
+            \n\n materialIdToLengthOrdered => ${JSON.stringify(materialIdToLengthOrdered)}
+            `);
 
     } catch (error) {
         console.log(`An error occurred while attempting to load /material-inventory: ${error}`);
@@ -51,5 +34,48 @@ router.get('/', async (request, response) => {
         return response.redirect('back');
     }
 });
+
+// router.get('/', async (request, response) => {
+//     try {
+//         const allMaterials = await materialService.getAllMaterials();
+
+//         const distinctMaterialObjectIds = mongooseService.getObjectIds(allMaterials);
+//         const distinctMaterialIds = materialService.getMaterialIds(allMaterials);
+
+//         const allPurchaseOrders = await purchaseOrderService.getPurchaseOrdersForMaterials(distinctMaterialObjectIds);
+//         const materialIdToPurchaseOrders = materialInventoryService.mapMaterialIdToPurchaseOrders(distinctMaterialObjectIds, allPurchaseOrders);
+
+//         const purchaseOrdersThatHaveArrived = purchaseOrderService.findPurchaseOrdersThatHaveArrived(allPurchaseOrders);
+//         const purchaseOrdersThatHaveNotArrived = purchaseOrderService.findPurchaseOrdersThatHaveNotArrived(allPurchaseOrders);
+
+//         const lengthOfAllMaterialsInInventory = purchaseOrderService.computeLengthOfMaterial(purchaseOrdersThatHaveArrived);
+//         const lengthOfAllMaterialsOrdered = purchaseOrderService.computeLengthOfMaterial(purchaseOrdersThatHaveNotArrived);
+
+//         const materialObjectIdToLengthUsedByTickets = await ticketService.getLengthOfEachMaterialUsedByTickets(distinctMaterialIds);
+
+//         const materialInventories = allMaterials.map((material) => {
+//             const feetOfMaterialAlreadyUsedByTickets = materialObjectIdToLengthUsedByTickets[material.materialId] || 0;
+//             const purchaseOrdersForMaterial = materialIdToPurchaseOrders[material._id];
+
+//             return materialInventoryService.buildMaterialInventory(material, purchaseOrdersForMaterial, feetOfMaterialAlreadyUsedByTickets);
+//         });
+
+//         const netLengthOfMaterialInInventory = materialInventoryService.computeNetLengthOfMaterialInInventory(materialInventories);
+
+//         return response.render('viewMaterialInventory', {
+//             materialInventories,
+//             lengthOfAllMaterialsInInventory,
+//             lengthOfAllMaterialsOrdered,
+//             netLengthOfMaterialInInventory,
+//             totalPurchaseOrders: allPurchaseOrders.length
+//         });
+
+//     } catch (error) {
+//         console.log(`An error occurred while attempting to load /material-inventory: ${error}`);
+
+//         request.flash('errors', [`The following error occurred: ${error}`]);
+//         return response.redirect('back');
+//     }
+// });
 
 module.exports = router;

--- a/application/services/ticketService.js
+++ b/application/services/ticketService.js
@@ -137,7 +137,7 @@ module.exports.groupTicketsByDestination = (tickets) => {
     return ticketsGroupedByDestination;
 };
 
-module.exports.getLengthOfEachMaterialUsedByTickets = async (materialIds) => {
+module.exports.getMaterialIdToLengthUsedByTickets = async (materialIds) => {
     const lengthOfEachMaterialAlreadyUsedByTickets = await TicketModel.aggregate([
         { $match: { primaryMaterial: { $in: materialIds } } },
         { $group: { _id: '$primaryMaterial', lengthUsed: { $sum: '$totalMaterialLength'}}}


### PR DESCRIPTION
# Description

This PR is a WIP ("Work in Progress") - it may or may not ever be completed.

I was attempting to find a good long term solution for calculating various material inventory information.

Currently the approach that is used works fine.

However, long term, it mayyy not scale well enough - I'm certain if this will be the case.

Even if this scalability isn't a problem, the database calculations should be brought further up to the database itself instead of making bulk object queries and performing data processing on the server.

Mongoose DB allows for `.aggregate` methods that can be used to perform many/most calculations on the database server itself, and methods such as this should be preferred instead of post processing data.

See [this code comment](https://github.com/gavinvaske/the_recipe_book/compare/wip-refactor-material-inventory-calculations?expand=1#diff-5d6898323affc7aec6296a15783a4c691f4b5eda3961bbc1e239a61eb36c6716R23) for another reason why I left this work as a WIP.