### PR TITLE
Add/Update Ticket Attributes: `departmentToJobComment`, `totalMaterialLength`, `attempts`

### DIFF
--- a/application/enums/departmentsEnum.js
+++ b/application/enums/departmentsEnum.js
@@ -23,45 +23,45 @@ const BILLING_READY = 'BILLING READY';
 const SHIPPING_READY = 'SHIPPING READY';
 
 // departments
-const ORDER_PREP_DEPARTMENT = 'ORDER-PREP';
-const ART_PREP_DEPARTMENT = 'ART-PREP';
-const PRE_PRINTING_DEPARTMENT = 'PRE-PRINTING';
-const PRINTING_DEPARTMENT = 'PRINTING';
-const CUTTING_DEPARTMENT = 'CUTTING';
-const WINDING_DEPARTMENT = 'WINDING';
-const PACKAGING_DEPARTMENT = 'PACKAGING';
-const SHIPPING_DEPARTMENT = 'SHIPPING';
-const BILLING_DEPARTMENT = 'BILLING';
-const COMPLETE_DEPARTMENT = 'COMPLETED';
+module.exports.ORDER_PREP_DEPARTMENT = 'ORDER-PREP';
+module.exports.ART_PREP_DEPARTMENT = 'ART-PREP';
+module.exports.PRE_PRINTING_DEPARTMENT = 'PRE-PRINTING';
+module.exports.PRINTING_DEPARTMENT = 'PRINTING';
+module.exports.CUTTING_DEPARTMENT = 'CUTTING';
+module.exports.WINDING_DEPARTMENT = 'WINDING';
+module.exports.PACKAGING_DEPARTMENT = 'PACKAGING';
+module.exports.SHIPPING_DEPARTMENT = 'SHIPPING';
+module.exports.BILLING_DEPARTMENT = 'BILLING';
+module.exports.COMPLETE_DEPARTMENT = 'COMPLETED';
 
 module.exports.departmentToStatusesMappingForTicketObjects = {
-    [ORDER_PREP_DEPARTMENT]: [
+    [this.ORDER_PREP_DEPARTMENT]: [
         NEEDS_ATTENTION,
         ON_HOLD,
         PROOFING_COMPLETE,
         WAITING_ON_CUSTOMER,
         WAITING_ON_APPROVAL
     ],
-    [ART_PREP_DEPARTMENT]: [
+    [this.ART_PREP_DEPARTMENT]: [
         NEEDS_ATTENTION,
         ON_HOLD,
         IN_PROGRESS,
         NEEDS_PROOF
     ],
-    [PRE_PRINTING_DEPARTMENT]: [
+    [this.PRE_PRINTING_DEPARTMENT]: [
         NEEDS_ATTENTION,
         ON_HOLD,
         IN_PROGRESS,
         SEND_TO_PRINTING
     ],
-    [PRINTING_DEPARTMENT]: [
+    [this.PRINTING_DEPARTMENT]: [
         ON_HOLD,
         IN_PROGRESS,
         PRINTING_READY,
         PRINTER_ONE_SCHEDULE,
         PRINTER_TWO_SCHEDULE
     ],
-    [CUTTING_DEPARTMENT]: [
+    [this.CUTTING_DEPARTMENT]: [
         ON_HOLD,
         IN_PROGRESS,
         CUTTING_READY,
@@ -69,28 +69,28 @@ module.exports.departmentToStatusesMappingForTicketObjects = {
         DELTA_TWO_SCHEDULE,
         ROTOFLEX_ONE_SCHEDULE
     ],
-    [WINDING_DEPARTMENT]: [
+    [this.WINDING_DEPARTMENT]: [
         ON_HOLD,
         IN_PROGRESS,
         WINDING_READY
     ],
-    [PACKAGING_DEPARTMENT]: [
+    [this.PACKAGING_DEPARTMENT]: [
         ON_HOLD,
         IN_PROGRESS,
         PACKAGING_READY
     ],
-    [SHIPPING_DEPARTMENT]: [
+    [this.SHIPPING_DEPARTMENT]: [
         ON_HOLD,
         IN_PROGRESS,
         SHIPPING_READY,
         FARMED_OUT_TICKETS
     ],
-    [BILLING_DEPARTMENT]: [
+    [this.BILLING_DEPARTMENT]: [
         ON_HOLD,
         IN_PROGRESS,
         BILLING_READY
     ],
-    [COMPLETE_DEPARTMENT]: []
+    [this.COMPLETE_DEPARTMENT]: []
 };
 
 module.exports.removeDepartmentStatusesAUserIsNotAllowedToSelect = (departmentStatuses) => {
@@ -101,14 +101,12 @@ module.exports.removeDepartmentStatusesAUserIsNotAllowedToSelect = (departmentSt
 };
 
 module.exports.productionDepartmentsAndDepartmentStatuses = {
-    [PRE_PRINTING_DEPARTMENT]: this.departmentToStatusesMappingForTicketObjects[PRE_PRINTING_DEPARTMENT],
-    [PRINTING_DEPARTMENT]: this.departmentToStatusesMappingForTicketObjects[PRINTING_DEPARTMENT],
-    [CUTTING_DEPARTMENT]: this.departmentToStatusesMappingForTicketObjects[CUTTING_DEPARTMENT],
-    [WINDING_DEPARTMENT]: this.departmentToStatusesMappingForTicketObjects[WINDING_DEPARTMENT],
-    [PACKAGING_DEPARTMENT]: this.departmentToStatusesMappingForTicketObjects[PACKAGING_DEPARTMENT]
+    [this.PRE_PRINTING_DEPARTMENT]: this.departmentToStatusesMappingForTicketObjects[this.PRE_PRINTING_DEPARTMENT],
+    [this.PRINTING_DEPARTMENT]: this.departmentToStatusesMappingForTicketObjects[this.PRINTING_DEPARTMENT],
+    [this.CUTTING_DEPARTMENT]: this.departmentToStatusesMappingForTicketObjects[this.CUTTING_DEPARTMENT],
+    [this.WINDING_DEPARTMENT]: this.departmentToStatusesMappingForTicketObjects[this.WINDING_DEPARTMENT],
+    [this.PACKAGING_DEPARTMENT]: this.departmentToStatusesMappingForTicketObjects[this.PACKAGING_DEPARTMENT]
 };
-
-module.exports.COMPLETE_DEPARTMENT = COMPLETE_DEPARTMENT;
 
 module.exports.getAllDepartments = () => {
     return Object.keys(this.departmentToStatusesMappingForTicketObjects);

--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -224,7 +224,13 @@ const ticketSchema = new Schema({
                 });
             }
             return sum;
-        }
+        },
+        set: function(totalMaterialLength) {
+            const feetPerAttempt = 50;
+
+            return totalMaterialLength + (this.attempts * feetPerAttempt);
+        },
+        min: 0
     },
     customerName: {
         type: String,

--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -4,10 +4,11 @@ const Schema = mongoose.Schema;
 const productSchema = require('../schemas/product');
 const chargeSchema = require('./charge').schema;
 const destinationSchema = require('../schemas/destination');
+const departmentNotesSchema = require('../schemas/departmentNotes');
 const {standardPriority, getAllPriorities} = require('../enums/priorityEnum');
 const MaterialModel = require('../models/material');
 const WorkflowStepModel = require('../models/WorkflowStep');
-const {getAllDepartments} = require('../enums/departmentsEnum');
+const departmentsEnum = require('../enums/departmentsEnum');
 
 // For help deciphering these regex expressions, visit: https://regexr.com/
 TICKET_NUMBER_REGEX = /^\d{1,}$/;
@@ -37,42 +38,12 @@ async function validateMaterialExists(materialId) {
 
 function validateKeysAreAllValidDepartments(departmentToHoldReason) {
     const potentiallyValidDepartmentNames = Object.keys(departmentToHoldReason.toJSON());
-    const validDepartmentNames = getAllDepartments();
+    const validDepartmentNames = departmentsEnum.getAllDepartments();
 
     return potentiallyValidDepartmentNames.every((departmentName) => {
         return validDepartmentNames.includes(departmentName);
     });
 }
-
-const departmentNotesSchema = new Schema({
-    orderPrep: {
-        type: String
-    },
-    artPrep: {
-        type: String
-    },
-    prePrinting: {
-        type: String
-    },
-    printing: {
-        type: String
-    },
-    cutting: {
-        type: String
-    },
-    winding: {
-        type: String
-    },
-    shipping: {
-        type: String
-    },
-    billing: {
-        type: String
-    }
-}, {
-    timestamps: true,
-    strict: 'throw'
-});
 
 const ticketSchema = new Schema({
     primaryMaterial: {
@@ -279,6 +250,16 @@ const ticketSchema = new Schema({
         type: Schema.Types.ObjectId,
         ref: 'TicketGroup',
         required: false
+    },
+    departmentToJobComment: {
+        type: departmentNotesSchema,
+        required: false
+    },
+    attempts: {
+        type: Number,
+        required: false,
+        default: 0,
+        min: 0
     }
 }, { timestamps: true });
 

--- a/application/schemas/departmentNotes.js
+++ b/application/schemas/departmentNotes.js
@@ -1,0 +1,48 @@
+const mongoose = require('mongoose');
+mongoose.Schema.Types.String.set('trim', true);
+const Schema = mongoose.Schema;
+const departmentsEnum = require('../enums/departmentsEnum');
+
+const departmentNotesSchema = new Schema({
+    orderPrep: {
+        type: String,
+        alias: departmentsEnum.ORDER_PREP_DEPARTMENT
+    },
+    artPrep: {
+        type: String,
+        alias: departmentsEnum.ART_PREP_DEPARTMENT
+    },
+    prePrinting: {
+        type: String,
+        alias: departmentsEnum.PRE_PRINTING_DEPARTMENT
+    },
+    printing: {
+        type: String,
+        alias: departmentsEnum.PRINTING_DEPARTMENT
+    },
+    cutting: {
+        type: String,
+        alias: departmentsEnum.CUTTING_DEPARTMENT
+    },
+    winding: {
+        type: String,
+        alias: departmentsEnum.WINDING_DEPARTMENT
+    },
+    packaging: {
+        type: String,
+        alias: departmentsEnum.PACKAGING_DEPARTMENT
+    },
+    shipping: {
+        type: String,
+        alias: departmentsEnum.SHIPPING_DEPARTMENT
+    },
+    billing: {
+        type: String,
+        alias: departmentsEnum.BILLING_DEPARTMENT
+    }
+}, {
+    timestamps: true,
+    strict: 'throw'
+});
+
+module.exports = departmentNotesSchema;

--- a/test/models/ticket.spec.js
+++ b/test/models/ticket.spec.js
@@ -629,6 +629,7 @@ describe('validation', () => {
                 printing: chance.string(),
                 cutting: chance.string(),
                 winding: chance.string(),
+                packaging: chance.string(),
                 shipping: chance.string(),
                 billing: chance.string(),
             };
@@ -660,6 +661,7 @@ describe('validation', () => {
             expect(ticket.departmentNotes.printing).toEqual(departmentNotes.printing);
             expect(ticket.departmentNotes.cutting).toEqual(departmentNotes.cutting);
             expect(ticket.departmentNotes.winding).toEqual(departmentNotes.winding);
+            expect(ticket.departmentNotes.packaging).toEqual(departmentNotes.packaging);
             expect(ticket.departmentNotes.shipping).toEqual(departmentNotes.shipping);
             expect(ticket.departmentNotes.billing).toEqual(departmentNotes.billing);
         });
@@ -987,7 +989,14 @@ describe('validation', () => {
             expect(error).toBe(undefined);
         });
 
-        it('should ')
+        it('should store the note on the correct department', () => {
+            const department = chance.pickone(departmentsEnum.getAllDepartmentsWithDepartmentStatuses());
+            const jobComment = chance.string();
+            ticketAttributes.departmentToJobComment[department] = jobComment;
+            const ticket = new TicketModel(ticketAttributes);
+
+            expect(ticket.departmentToJobComment[department]).toEqual(jobComment);
+        });
     });
 
     describe('attribute: numberOfProofsThatHaveNotBeenUploadedYet', () => {

--- a/test/schemas/departmentNotes.spec.js
+++ b/test/schemas/departmentNotes.spec.js
@@ -47,7 +47,7 @@ describe('validation', () => {
         const departmentNotes = new DepartmentNotesModel(departmentNotesAttributes);
         
         expect(departmentNotes[department]).toEqual(note);
-    })
+    });
 
     describe('aliases', () => {
         beforeEach(() => {

--- a/test/schemas/departmentNotes.spec.js
+++ b/test/schemas/departmentNotes.spec.js
@@ -1,0 +1,111 @@
+const chance = require('chance').Chance();
+const departmentNotesSchema = require('../../application/schemas/departmentNotes');
+const departmentsEnum = require('../../application/enums/departmentsEnum');
+const mongoose = require('mongoose');
+const databaseService = require('../../application/services/databaseService');
+
+describe('validation', () => {
+    let departmentNotesAttributes,
+        DepartmentNotesModel;
+
+    beforeEach(async () => {
+        departmentNotesAttributes = {
+            orderPrep: chance.string(),
+            artPrep: chance.string(),
+            prePrinting: chance.string(),
+            printing: chance.string(),
+            cutting: chance.string(),
+            winding: chance.string(),
+            packaging: chance.string(),
+            shipping: chance.string(),
+            billing: chance.string()
+        };
+        DepartmentNotesModel = mongoose.model('DepartmentNotes', departmentNotesSchema);
+    });
+
+    it('should validate if all attributes are defined successfully', () => {
+        const departmentNotes = new DepartmentNotesModel(departmentNotesAttributes);
+    
+        const error = departmentNotes.validateSync();
+
+        expect(error).toBe(undefined);
+    });
+
+    it('should have one key for every department', () => {
+        const departmentNotes = new DepartmentNotesModel(departmentNotesAttributes);
+        const actualNumberOfKeys = Object.keys(departmentNotes.toJSON()).length;
+        const numberOfMongooseKeysToIgnore = 1;
+        const expectedNumberOfKeys = departmentsEnum.getAllDepartmentsWithDepartmentStatuses().length;
+
+        expect(actualNumberOfKeys - numberOfMongooseKeysToIgnore).toBe(expectedNumberOfKeys);
+    });
+
+    it('should trim values', () => {
+        const department = chance.pickone(departmentsEnum.getAllDepartmentsWithDepartmentStatuses());
+        const note = chance.string();
+        departmentNotesAttributes[department] = '  ' + note + '   ';
+        const departmentNotes = new DepartmentNotesModel(departmentNotesAttributes);
+        
+        expect(departmentNotes[department]).toEqual(note);
+    })
+
+    describe('aliases', () => {
+        beforeEach(() => {
+            departmentNotesAttributes = {
+                [departmentsEnum.ORDER_PREP_DEPARTMENT]: chance.string(),
+                [departmentsEnum.ART_PREP_DEPARTMENT]: chance.string(),
+                [departmentsEnum.PRE_PRINTING_DEPARTMENT]: chance.string(),
+                [departmentsEnum.PRINTING_DEPARTMENT]: chance.string(),
+                [departmentsEnum.CUTTING_DEPARTMENT]: chance.string(),
+                [departmentsEnum.WINDING_DEPARTMENT]: chance.string(),
+                [departmentsEnum.PACKAGING_DEPARTMENT]: chance.string(),
+                [departmentsEnum.SHIPPING_DEPARTMENT]: chance.string(),
+                [departmentsEnum.BILLING_DEPARTMENT]: chance.string()
+            };
+        });
+
+        it('should validate if all attributes are defined successfully', () => {
+            const departmentNotes = new DepartmentNotesModel(departmentNotesAttributes);
+        
+            const error = departmentNotes.validateSync();
+    
+            expect(error).toBe(undefined);
+        });
+
+        it('should have one key for every department', () => {
+            const departmentNotes = new DepartmentNotesModel(departmentNotesAttributes);
+            const actualNumberOfKeys = Object.keys(departmentNotes.toJSON()).length;
+            const numberOfMongooseKeysToIgnore = 1;
+            const expectedNumberOfKeys = departmentsEnum.getAllDepartmentsWithDepartmentStatuses().length;
+    
+            expect(actualNumberOfKeys - numberOfMongooseKeysToIgnore).toBe(expectedNumberOfKeys);
+        });
+
+        it('should throw an error if an unknown key is attempted to be set onto the schema', () => {
+            const someRandomKey = chance.word();
+            departmentNotesAttributes[someRandomKey] = chance.string();
+
+            expect(() => new DepartmentNotesModel(departmentNotesAttributes)).toThrow();
+        });
+    });
+
+    describe('verify timestamps on created object', () => {
+        beforeEach(async () => {
+            await databaseService.connectToTestMongoDatabase();
+        });
+
+        afterEach(async () => {
+            await databaseService.closeDatabase();
+        });
+
+        describe('verify timestamps on created object', () => {
+            it('should have a "createdAt" attribute once object is saved', async () => {
+                const departmentNotes = new DepartmentNotesModel(departmentNotesAttributes);
+                let savedDepartmentNotes = await departmentNotes.save({validateBeforeSave: false});
+    
+                expect(savedDepartmentNotes.createdAt).toBeDefined();
+                expect(savedDepartmentNotes.updatedAt).toBeDefined();
+            });
+        });
+    });
+});


### PR DESCRIPTION
# Description

This PR mainly adds/updates attributes on the mongoose `ticket` table.
  1. `departmentToJobComment`: This is a brand new field whose purpose is to store notes added by a user after they completely finish their work in a specific department
  2. `attempts`: This is a brand new attribute whose purpose is to store the number 50 foot frames used when completing a ticket. This attribute is used by the field `totalMaterialLength` such that `totalMaterialLength = totalMaterialLength + (attempts * 50)`
  3. `totalMaterialLength`: This field existed before, but now, I changed how this field is calculated. When a user attempts to set it after this PR is merged, an extra calculation will also be applied to it: totalMaterialLength = totalMaterialLength + (attempts * 50).

This PR also does some miscellaneous things such as module.export-ing departments from `departmentsEnum.js`