### PR TITLE
Add new Mongoose Table: `downtimeReason`

### DIFF
--- a/application/models/downtimeLedger.js
+++ b/application/models/downtimeLedger.js
@@ -1,0 +1,25 @@
+const mongoose = require('mongoose');
+mongoose.Schema.Types.String.set('trim', true);
+const Schema = mongoose.Schema;
+
+const downtimeLedgerSchema = new Schema({
+    ticketId: {
+        type: Schema.Types.ObjectId,
+        ref: 'Ticket',
+        required: true
+    },
+    reason: {
+        type: String,
+        required: true
+    },
+    delayDurationInMinutes: {
+        type: Number,
+        required: true,
+        min: 1,
+
+    }
+}, { timestamps: true });
+
+const DowntimeLedger = mongoose.model('downtimeLedger', downtimeLedgerSchema);
+
+module.exports = DowntimeLedger;

--- a/application/models/downtimeReason.js
+++ b/application/models/downtimeReason.js
@@ -1,0 +1,19 @@
+const mongoose = require('mongoose');
+mongoose.Schema.Types.String.set('trim', true);
+const Schema = mongoose.Schema;
+
+const downtimeReasonSchema = new Schema({
+    ticketId: {
+        type: Schema.Types.ObjectId,
+        ref: 'Ticket',
+        required: true
+    },
+    reason: {
+        type: String,
+        required: true
+    }
+}, { timestamps: true });
+
+const DowntimeReason = mongoose.model('downtimeReason', downtimeReasonSchema);
+
+module.exports = DowntimeReason;

--- a/application/models/downtimeReason.js
+++ b/application/models/downtimeReason.js
@@ -3,11 +3,6 @@ mongoose.Schema.Types.String.set('trim', true);
 const Schema = mongoose.Schema;
 
 const downtimeReasonSchema = new Schema({
-    ticketId: {
-        type: Schema.Types.ObjectId,
-        ref: 'Ticket',
-        required: true
-    },
     reason: {
         type: String,
         required: true

--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 mongoose.Schema.Types.String.set('trim', true);
 const Schema = mongoose.Schema;
 const productSchema = require('../schemas/product');
-const chargeSchema = require('./charge').schema;
+const chargeSchema = require('../schemas/charge');
 const destinationSchema = require('../schemas/destination');
 const departmentNotesSchema = require('../schemas/departmentNotes');
 const {standardPriority, getAllPriorities} = require('../enums/priorityEnum');

--- a/application/schemas/charge.js
+++ b/application/schemas/charge.js
@@ -42,6 +42,4 @@ const chargeSchema = new Schema({
     }
 }, { timestamps: true });
 
-const Charge = mongoose.model('Charge', chargeSchema);
-
-module.exports = Charge;
+module.exports = chargeSchema;

--- a/test/models/downtimeLedger.spec.js
+++ b/test/models/downtimeLedger.spec.js
@@ -1,0 +1,113 @@
+const chance = require('chance').Chance();
+const DowntimeReasonLedger = require('../../application/models/downtimeLedger');
+const mongoose = require('mongoose');
+const databaseService = require('../../application/services/databaseService');
+
+describe('validation', () => {
+    let downtimeLedgerAttributes;
+
+    beforeEach(() => {
+        downtimeLedgerAttributes = {
+            ticketId: new mongoose.Types.ObjectId(),
+            reason: chance.string(),
+            delayDurationInMinutes: chance.d100()
+        };
+    });
+
+    it('should not fail validation if all attributes are defined correctly', () => {
+        const downtimeLedgerRecord = new DowntimeReasonLedger(downtimeLedgerAttributes);
+
+        const error = downtimeLedgerRecord.validateSync();
+
+        expect(error).toBeUndefined();
+    });
+
+    describe('attribute: ticketId', () => {
+        it('should fail validation if attribute is not defined', () => {
+            delete downtimeLedgerAttributes.ticketId;
+            const downtimeLedgerRecord = new DowntimeReasonLedger(downtimeLedgerAttributes);
+
+            const error = downtimeLedgerRecord.validateSync();
+
+            expect(error).toBeDefined();
+        });
+
+        it('should be of type mongoose.ObjectId', () => {
+            const downtimeLedgerRecord = new DowntimeReasonLedger(downtimeLedgerAttributes);
+
+            expect(downtimeLedgerRecord.ticketId).toEqual(expect.any(mongoose.Types.ObjectId));
+        });
+    });
+
+    describe('attribute: reason', () => {
+        it('should fail validation if attribute is not defined', () => {
+            delete downtimeLedgerAttributes.reason;
+            const downtimeLedgerRecord = new DowntimeReasonLedger(downtimeLedgerAttributes);
+
+            const error = downtimeLedgerRecord.validateSync();
+
+            expect(error).toBeDefined();
+        });
+
+        it('should be of type String', () => {
+            const downtimeLedgerRecord = new DowntimeReasonLedger(downtimeLedgerAttributes);
+
+            expect(downtimeLedgerRecord.reason).toEqual(expect.any(String));
+        });
+
+        it('should trim attribute', () => {
+            const expectedReason = chance.string();
+            downtimeLedgerAttributes.reason = '   ' + expectedReason + '  ';
+            const downtimeLedgerRecord = new DowntimeReasonLedger(downtimeLedgerAttributes);
+
+            expect(downtimeLedgerRecord.reason).toEqual(expectedReason);
+        });
+    });
+
+    describe('attribute: delayDurationInMinutes', () => {
+        it('should fail validation if attribute is not defined', () => {
+            delete downtimeLedgerAttributes.delayDurationInMinutes;
+            const downtimeLedgerRecord = new DowntimeReasonLedger(downtimeLedgerAttributes);
+
+            const error = downtimeLedgerRecord.validateSync();
+
+            expect(error).toBeDefined();
+        });
+
+        it('should be of type Number', () => {
+            const downtimeLedgerRecord = new DowntimeReasonLedger(downtimeLedgerAttributes);
+
+            expect(downtimeLedgerRecord.delayDurationInMinutes).toEqual(expect.any(Number));
+        });
+
+        it('should fail validation if attribute is less than 1', () => {
+            const invalidDuration = chance.integer({max: 0});
+            downtimeLedgerAttributes.delayDurationInMinutes = invalidDuration;
+            const downtimeLedgerRecord = new DowntimeReasonLedger(downtimeLedgerAttributes);
+
+            const error = downtimeLedgerRecord.validateSync();
+
+            expect(error).toBeDefined();
+        });
+    });
+
+    describe('verify timestamps on created object', () => {
+        beforeEach(async () => {
+            await databaseService.connectToTestMongoDatabase();
+        });
+
+        afterEach(async () => {
+            await databaseService.closeDatabase();
+        });
+
+        describe('verify timestamps on created object', () => {
+            it('should have a "createdAt" attribute once object is saved', async () => {
+                const downtimeLedgerRecord = new DowntimeReasonLedger(downtimeLedgerAttributes);
+                let savedDowntimeLedger = await downtimeLedgerRecord.save({validateBeforeSave: false});
+    
+                expect(savedDowntimeLedger.createdAt).toBeDefined();
+                expect(savedDowntimeLedger.updatedAt).toBeDefined();
+            });
+        });
+    });
+});

--- a/test/models/downtimeReason.spec.js
+++ b/test/models/downtimeReason.spec.js
@@ -1,6 +1,5 @@
 const chance = require('chance').Chance();
 const DowntimeReason = require('../../application/models/downtimeReason');
-const mongoose = require('mongoose');
 const databaseService = require('../../application/services/databaseService');
 
 describe('validation', () => {
@@ -8,7 +7,6 @@ describe('validation', () => {
 
     beforeEach(() => {
         downtimeReasonAttributes = {
-            ticketId: new mongoose.Types.ObjectId(),
             reason: chance.string()
         };
     });

--- a/test/models/downtimeReason.spec.js
+++ b/test/models/downtimeReason.spec.js
@@ -1,0 +1,85 @@
+const chance = require('chance').Chance();
+const DowntimeReason = require('../../application/models/downtimeReason');
+const mongoose = require('mongoose');
+const databaseService = require('../../application/services/databaseService');
+
+describe('validation', () => {
+    let downtimeReasonAttributes;
+
+    beforeEach(() => {
+        downtimeReasonAttributes = {
+            ticketId: new mongoose.Types.ObjectId(),
+            reason: chance.string()
+        };
+    });
+
+    it('should not fail validation if all attributes are defined correctly', () => {
+        const downtimeReason = new DowntimeReason(downtimeReasonAttributes);
+
+        const error = downtimeReason.validateSync();
+
+        expect(error).toBeUndefined();
+    });
+
+    describe('attribute: ticketId', () => {
+        it('should fail validation if attribute is not defined', () => {
+            delete downtimeReasonAttributes.ticketId;
+            const downtimeReason = new DowntimeReason(downtimeReasonAttributes);
+
+            const error = downtimeReason.validateSync();
+
+            expect(error).toBeDefined();
+        });
+
+        it('should be of type mongoose.ObjectId', () => {
+            const downtimeReason = new DowntimeReason(downtimeReasonAttributes);
+
+            expect(downtimeReason.ticketId).toEqual(expect.any(mongoose.Types.ObjectId));
+        });
+    });
+
+    describe('attribute: reason', () => {
+        it('should fail validation if attribute is not defined', () => {
+            delete downtimeReasonAttributes.reason;
+            const downtimeReason = new DowntimeReason(downtimeReasonAttributes);
+
+            const error = downtimeReason.validateSync();
+
+            expect(error).toBeDefined();
+        });
+
+        it('should be of type String', () => {
+            const downtimeReason = new DowntimeReason(downtimeReasonAttributes);
+
+            expect(downtimeReason.reason).toEqual(expect.any(String));
+        });
+
+        it('should trim attribute', () => {
+            const expectedReason = chance.string();
+            downtimeReasonAttributes.reason = '   ' + expectedReason + '  ';
+            const downtimeReason = new DowntimeReason(downtimeReasonAttributes);
+
+            expect(downtimeReason.reason).toEqual(expectedReason);
+        });
+    });
+
+    describe('verify timestamps on created object', () => {
+        beforeEach(async () => {
+            await databaseService.connectToTestMongoDatabase();
+        });
+
+        afterEach(async () => {
+            await databaseService.closeDatabase();
+        });
+
+        describe('verify timestamps on created object', () => {
+            it('should have a "createdAt" attribute once object is saved', async () => {
+                const downtimeReason = new DowntimeReason(downtimeReasonAttributes);
+                let savedDowntimeReason = await downtimeReason.save({validateBeforeSave: false});
+    
+                expect(savedDowntimeReason.createdAt).toBeDefined();
+                expect(savedDowntimeReason.updatedAt).toBeDefined();
+            });
+        });
+    });
+});

--- a/test/models/downtimeReason.spec.js
+++ b/test/models/downtimeReason.spec.js
@@ -21,23 +21,6 @@ describe('validation', () => {
         expect(error).toBeUndefined();
     });
 
-    describe('attribute: ticketId', () => {
-        it('should fail validation if attribute is not defined', () => {
-            delete downtimeReasonAttributes.ticketId;
-            const downtimeReason = new DowntimeReason(downtimeReasonAttributes);
-
-            const error = downtimeReason.validateSync();
-
-            expect(error).toBeDefined();
-        });
-
-        it('should be of type mongoose.ObjectId', () => {
-            const downtimeReason = new DowntimeReason(downtimeReasonAttributes);
-
-            expect(downtimeReason.ticketId).toEqual(expect.any(mongoose.Types.ObjectId));
-        });
-    });
-
     describe('attribute: reason', () => {
         it('should fail validation if attribute is not defined', () => {
             delete downtimeReasonAttributes.reason;

--- a/test/schemas/charge.spec.js
+++ b/test/schemas/charge.spec.js
@@ -1,15 +1,18 @@
 
 const chance = require('chance').Chance();
-const ChargeModel = require('../../application/models/charge');
+const chargeSchema = require('../../application/schemas/charge');
+const mongoose = require('mongoose');
 
 describe('validation', () => {
-    let chargeAttributes;
+    let chargeAttributes,
+        ChargeModel;
 
     beforeEach(() => {
         chargeAttributes = {
             ProductNumber: chance.word() + `-${chance.letter()}`,
             PriceM: String(chance.floating())
         };
+        ChargeModel = mongoose.model('DepartmentNotes', chargeSchema);
     });
 
     describe('attribute: productNumber (aka ProductNumber)', () => {


### PR DESCRIPTION
# Description

This PR creates two new mongoose database table:
  1. `downtimeReason`
  2. `downtimeLedger`

Currently, it is important that the system tracks the total amount of time that a ticket spends in production.

These database table allow for users/employees to enter the amount of time that a ticket was delayed, and the reason for which the delay occurred.