### PR TITLE
Add New Database Attribute: `material.materialCategory`

### DIFF
--- a/application/controllers/materialController.js
+++ b/application/controllers/materialController.js
@@ -2,6 +2,7 @@ const router = require('express').Router();
 const MaterialModel = require('../models/material');
 const {verifyJwtToken} = require('../middleware/authorize');
 const VendorModel = require('../models/vendor');
+const MaterialCategoryModel = require('../models/materialCategory');
 
 const SHOW_ALL_MATERIALS_ENDPOINT = '/materials';
 
@@ -36,8 +37,9 @@ router.get('/', async (request, response) => {
 
 router.get('/form', async (request, response) => {
     const vendors = await VendorModel.find().exec();
+    const materialCategories = await MaterialCategoryModel.find().exec();
 
-    return response.render('createMaterial', { vendors });
+    return response.render('createMaterial', { vendors, materialCategories });
 });
 
 router.post('/form', async (request, response) => {

--- a/application/controllers/materialController.js
+++ b/application/controllers/materialController.js
@@ -59,8 +59,13 @@ router.get('/update/:id', async (request, response) => {
     try {
         const material = await MaterialModel.findById(request.params.id);
         const vendors = await VendorModel.find().exec();
+        const materialCategories = await MaterialCategoryModel.find().exec();
 
-        return response.render('updateMaterial', { material, vendors });
+        return response.render('updateMaterial', {
+            material, 
+            vendors,
+            materialCategories 
+        });
     } catch (error) {
         console.log(error);
         request.flash('errors', [error.message]);

--- a/application/models/material.js
+++ b/application/models/material.js
@@ -20,6 +20,11 @@ const schema = new Schema({
 
             return vendorId;
         }
+    },
+    materialCategoryId: {
+        type: Schema.Types.ObjectId,
+        ref: 'MaterialCategory',
+        required: false
     }
 }, { timestamps: true });
 

--- a/application/models/material.js
+++ b/application/models/material.js
@@ -11,20 +11,25 @@ const schema = new Schema({
         type: String,
         required: true
     },
-    vendorId: {
+    vendor: {
         type: Schema.Types.ObjectId,
         ref: 'Vendor',
         required: false,
-        set: function(vendorId) {
-            if (vendorId === '') return null;
+        set: function(vendorObjectId) {
+            if (vendorObjectId === '') return null;
 
-            return vendorId;
+            return vendorObjectId;
         }
     },
-    materialCategoryId: {
+    materialCategory: {
         type: Schema.Types.ObjectId,
         ref: 'MaterialCategory',
-        required: false
+        required: false,
+        set: function(materialCategoryObjectId) {
+            if (materialCategoryObjectId === '') return null;
+
+            return materialCategoryObjectId;
+        }
     }
 }, { timestamps: true });
 

--- a/application/views/createMaterial.ejs
+++ b/application/views/createMaterial.ejs
@@ -22,7 +22,7 @@
              </div>
              <div class="form-group">
                 <label for="vendor-selection">Vendor:</label>
-                <select name="vendorId" id="vendor-selection">
+                <select name="vendor" id="vendor-selection">
                     <option value='' selected>Choose Here</option>
                     <% vendors && vendors.forEach((vendor, index) => { %>
                         <option value="<%= vendor.id %>"><%= vendor.name %></option>
@@ -31,7 +31,7 @@
              </div>
              <div class="form-group">
                 <label for="material-category-selection">Material Category:</label>
-                <select name="materialCategoryId" id="material-category-selection">
+                <select name="materialCategory" id="material-category-selection">
                     <option value='' selected>Choose Here</option>
                     <% materialCategories && materialCategories.forEach((materialCategory, index) => { %>
                         <option value="<%= materialCategory.id %>"><%= materialCategory.name %></option>

--- a/application/views/createMaterial.ejs
+++ b/application/views/createMaterial.ejs
@@ -29,6 +29,15 @@
                     <% }) %>
                 </select>
              </div>
+             <div class="form-group">
+                <label for="material-category-selection">Material Category:</label>
+                <select name="materialCategoryId" id="material-category-selection">
+                    <option value='' selected>Choose Here</option>
+                    <% materialCategories && materialCategories.forEach((materialCategory, index) => { %>
+                        <option value="<%= materialCategory.id %>"><%= materialCategory.name %></option>
+                    <% }) %>
+                </select>
+             </div>
             <button class="create-entry submit-button" type="submit" value="Create Material">Create</button>
         </form>
     </div>

--- a/application/views/updateMaterial.ejs
+++ b/application/views/updateMaterial.ejs
@@ -20,11 +20,19 @@
             <label for="name">Material ID</label>
             <input type="text" name="materialId" id="materialId" value="<%= material.materialId %>">
             <label for="vendor-selection">Vendor:</label>
-            <select name="vendorId" id="vendor-selection">
-                <option value='' <%= material.vendorId ? '' : 'selected' %>>N/A</option>
+            <select name="vendor" id="vendor-selection">
+                <option value='' <%= material.vendor ? '' : 'selected' %>>N/A</option>
                 <% vendors && vendors.forEach((vendor, index) => { %>
-                    <% const isSelected = (material.vendorId && material.vendorId.toString() === vendor._id.toString()) ? 'selected' : ''; %>
+                    <% const isSelected = (material.vendor && material.vendor.toString() === vendor._id.toString()) ? 'selected' : ''; %>
                     <option value="<%= vendor.id %>" <%= isSelected %>><%= vendor.name %></option>
+                <% }) %>
+            </select>
+            <label for="material-category-selection">Material Category:</label>
+            <select name="materialCategory" id="material-category-selection">
+                <option value='' <%= material.materialCategory ? '' : 'selected' %>>N/A</option>
+                <% materialCategories && materialCategories.forEach((materialCategory, index) => { %>
+                    <% const isSelected = (material.materialCategory && material.materialCategory.toString() === materialCategory._id.toString()) ? 'selected' : ''; %>
+                    <option value="<%= materialCategory.id %>" <%= isSelected %>><%= materialCategory.name %></option>
                 <% }) %>
             </select>
             <button type="submit" class="submit-button">Update Material</button>

--- a/test/models/material.spec.js
+++ b/test/models/material.spec.js
@@ -57,9 +57,9 @@ describe('validation', () => {
         });
     });
 
-    describe('attribute: vendorId', () => {
+    describe('attribute: vendor', () => {
         it('should not be a required attribute', () => {
-            delete materialAttributes.vendorId;
+            delete materialAttributes.vendor;
             const material = new MaterialModel(materialAttributes);
 
             const error = material.validateSync();
@@ -68,8 +68,8 @@ describe('validation', () => {
         });
 
         it('should fail validation if the datatype is not a mongoose object ID', () => {
-            const invalidVendorId = chance.word();
-            materialAttributes.vendorId = invalidVendorId;
+            const invalidVendor = chance.word();
+            materialAttributes.vendor = invalidVendor;
             const material = new MaterialModel(materialAttributes);
 
             const error = material.validateSync();
@@ -78,8 +78,7 @@ describe('validation', () => {
         });
 
         it('should pass validation if value is a mongoose object id', () => {
-            const vendorId = new mongoose.Types.ObjectId();
-            materialAttributes.vendorId = vendorId;
+            materialAttributes.vendor = new mongoose.Types.ObjectId();
             const material = new MaterialModel(materialAttributes);
             
             const error = material.validateSync();
@@ -87,29 +86,28 @@ describe('validation', () => {
             expect(error).toBeUndefined();
         });
 
-        it('should set the vendorId equal to null if an empty string is passed in', () => {
-            const vendorId = '';
-            materialAttributes.vendorId = vendorId;
+        it('should set the vendor equal to null if an empty string is passed in', () => {
+            materialAttributes.vendor = '';
             const material = new MaterialModel(materialAttributes);
             
             const error = material.validateSync();
 
             expect(error).toBeUndefined();
-            expect(material.vendorId).toEqual(null);
+            expect(material.vendor).toEqual(null);
         });
     });
 
-    describe('attribute: materialCategoryId', () => {
+    describe('attribute: materialCategory', () => {
         it('should have attribute', () => {
-            materialAttributes.materialCategoryId = new mongoose.Types.ObjectId();
+            materialAttributes.materialCategory = new mongoose.Types.ObjectId();
 
             const material = new MaterialModel(materialAttributes);
 
-            expect(material.materialCategoryId).toBeDefined();
+            expect(material.materialCategory).toBeDefined();
         });
 
         it('should fail validation if attribute is the wrong type', () => {
-            materialAttributes.materialCategoryId = chance.word();
+            materialAttributes.materialCategory = chance.word();
             const material = new MaterialModel(materialAttributes);
 
             const error = material.validateSync();
@@ -118,22 +116,32 @@ describe('validation', () => {
         });
 
         it('should handle storing valid mongoose object Ids', () => {
-            materialAttributes.materialCategoryId = new mongoose.Types.ObjectId();
+            materialAttributes.materialCategory = new mongoose.Types.ObjectId();
             const material = new MaterialModel(materialAttributes);
 
             const error = material.validateSync();
 
             expect(error).toBeUndefined();
-            expect(mongoose.Types.ObjectId.isValid(material.materialCategoryId)).toBe(true);
+            expect(mongoose.Types.ObjectId.isValid(material.materialCategory)).toBe(true);
         });
 
         it('should pass validation if attribute is missing', () => {
-            delete materialAttributes.materialCategoryId;
+            delete materialAttributes.materialCategory;
             const material = new MaterialModel(materialAttributes);
 
             const error = material.validateSync();
 
             expect(error).toBeUndefined();
+        });
+
+        it('should set the attribute to null if an empty string is passed in', () => {
+            materialAttributes.materialCategory = '';
+            const material = new MaterialModel(materialAttributes);
+            
+            const error = material.validateSync();
+
+            expect(error).toBeUndefined();
+            expect(material.materialCategory).toEqual(null);
         });
     });
 });

--- a/test/models/material.spec.js
+++ b/test/models/material.spec.js
@@ -98,4 +98,42 @@ describe('validation', () => {
             expect(material.vendorId).toEqual(null);
         });
     });
+
+    describe('attribute: materialCategoryId', () => {
+        it('should have attribute', () => {
+            materialAttributes.materialCategoryId = new mongoose.Types.ObjectId();
+
+            const material = new MaterialModel(materialAttributes);
+
+            expect(material.materialCategoryId).toBeDefined();
+        });
+
+        it('should fail validation if attribute is the wrong type', () => {
+            materialAttributes.materialCategoryId = chance.word();
+            const material = new MaterialModel(materialAttributes);
+
+            const error = material.validateSync();
+
+            expect(error).toBeDefined();
+        });
+
+        it('should handle storing valid mongoose object Ids', () => {
+            materialAttributes.materialCategoryId = new mongoose.Types.ObjectId();
+            const material = new MaterialModel(materialAttributes);
+
+            const error = material.validateSync();
+
+            expect(error).toBeUndefined();
+            expect(mongoose.Types.ObjectId.isValid(material.materialCategoryId)).toBe(true);
+        });
+
+        it('should pass validation if attribute is missing', () => {
+            delete materialAttributes.materialCategoryId;
+            const material = new MaterialModel(materialAttributes);
+
+            const error = material.validateSync();
+
+            expect(error).toBeUndefined();
+        });
+    });
 });


### PR DESCRIPTION
# Description

This PR adds a new attribute to the `material` mongoDb database table called `materialCategory`.

This attribute references items from the `materialCategory` (relationships in a noSql database, *gasp* 😉 ).

This PR also updates the UI pages responsible for Creating/Updating this attribute.

## Verification
<img width="1076" alt="image" src="https://user-images.githubusercontent.com/42784674/229646828-1ee7520b-9a78-4fcd-affe-e4e5b95140a9.png">

> New selection added to material `Create` page

<img width="1112" alt="image" src="https://user-images.githubusercontent.com/42784674/229646979-2cdf5baf-5e44-4c91-89b8-58cc626cd816.png">

> New select added to material `Update` page