### PR TITLE
Feature: Make `material.name` Uppercase by Default

### DIFF
--- a/application/models/material.js
+++ b/application/models/material.js
@@ -5,7 +5,8 @@ const Schema = mongoose.Schema;
 const schema = new Schema({
     name: {
         type: String,
-        required: true
+        required: true,
+        uppercase: true
     },
     materialId: {
         type: String,

--- a/test/models/material.spec.js
+++ b/test/models/material.spec.js
@@ -21,6 +21,13 @@ describe('validation', () => {
     });
 
     describe('attribute: name', () => {
+        it('should be a string', () => {
+            materialAttributes.name = chance.integer();
+            const material = new MaterialModel(materialAttributes);
+
+            expect(material.name).toEqual(expect.any(String));
+        });
+
         it('should trim whitespace around "name"', () => {
             const name = chance.string();
             materialAttributes.name = ' ' + name + ' ';

--- a/test/models/material.spec.js
+++ b/test/models/material.spec.js
@@ -12,22 +12,31 @@ describe('validation', () => {
         };
     });
 
-    describe('successful validation', () => {
-        it('should validate when required attributes are defined', () => {
-            const finish = new MaterialModel(materialAttributes);
-    
-            const error = finish.validateSync();
-    
-            expect(error).toBe(undefined);
-        });
+    it('should validate when required attributes are defined', () => {
+        const finish = new MaterialModel(materialAttributes);
 
+        const error = finish.validateSync();
+
+        expect(error).toBe(undefined);
+    });
+
+    describe('attribute: name', () => {
         it('should trim whitespace around "name"', () => {
             const name = chance.string();
             materialAttributes.name = ' ' + name + ' ';
 
             const material = new MaterialModel(materialAttributes);
 
-            expect(material.name).toBe(name);
+            expect(material.name).toBe(name.toUpperCase());
+        });
+
+        it('should uppercase the attribute', () => {
+            const lowerCaseName = chance.string().toLowerCase();
+            materialAttributes.name = lowerCaseName;
+
+            const material = new MaterialModel(materialAttributes);
+
+            expect(material.name).toBe(lowerCaseName.toUpperCase());
         });
     });
 


### PR DESCRIPTION
# Description

This PR updates the mongoose schema on material.name such that any string used is set to uppercase by default.