### PR TITLE
Feature: Sort `ticket.products` in ascending order according to `ticket.productNumber`

### DIFF
--- a/application/models/ticket.js
+++ b/application/models/ticket.js
@@ -100,6 +100,13 @@ const ticketSchema = new Schema({
     },
     products: {
         type: [productSchema],
+        set: function(products) {
+            products && products.sort(function(product1, product2) {
+                return getNumberToTheRightOfTheHyphen(product1.productNumber) - getNumberToTheRightOfTheHyphen(product2.productNumber);
+            });
+            
+            return products;
+        }
     },
     extraCharges: {
         type: [chargeSchema]
@@ -363,6 +370,10 @@ async function addRowToWorkflowStepDbTable(next) {
         console.log(`Error during mongoose ticketSchema.pre('updateOne') or ticketSchema.pre('findOneAndUpdate') hook: ${error}; attributes used: ${JSON.stringify(workflowStepAttributes)}`);
         return next(error);
     }
+}
+
+function getNumberToTheRightOfTheHyphen(productNumber) {
+    return Number(productNumber.split('-')[1]);
 }
 
 ticketSchema.pre('updateOne', addRowToWorkflowStepDbTable);

--- a/application/views/viewTickets.ejs
+++ b/application/views/viewTickets.ejs
@@ -426,7 +426,6 @@
 
         <!-- Cutting | In Progress -->
         <% const cuttingInProgressTickets = helperMethods.getEmptyArrayIfUndefined(cuttingTicketsGroupedByDepartmentStatus['IN PROGRESS']) %>
-        <h1>test: <%= cuttingInProgressTickets[0].collection.collectionName %></h1>
         <%- include('partials/ticket-table.ejs', {
           tableIdentifier: 'cutting-in-progress',
           cssClassToUseForTableColoring: 'red-master',

--- a/test/models/ticket.spec.js
+++ b/test/models/ticket.spec.js
@@ -61,6 +61,31 @@ describe('validation', () => {
         expect(() => new TicketModel(ticketAttributes)).toThrowError();
     });
 
+    describe('attribute: products', () => {
+        it('should store the products in ascending order according to their productNumber', () => {
+            const productNumbersInSortedOrder = ['164D-001', '164D-003', '164D-045'];
+            ticketAttributes.products = [
+                {productNumber: productNumbersInSortedOrder[1]},
+                {productNumber: productNumbersInSortedOrder[2]},
+                {productNumber: productNumbersInSortedOrder[0]},
+            ];
+
+            const {products} = new TicketModel(ticketAttributes);
+
+            expect(products[0].productNumber).toBe(productNumbersInSortedOrder[0]);
+            expect(products[1].productNumber).toBe(productNumbersInSortedOrder[1]);
+            expect(products[2].productNumber).toBe(productNumbersInSortedOrder[2]);
+        });
+
+        it('should default to an empty array', () => {
+            delete ticketAttributes.products;
+
+            const {products} = new TicketModel(ticketAttributes);
+
+            expect(products).toEqual([]);
+        });
+    });
+
     describe('attribute: ticketNumber (aka TicketNumber)', () => {
         it('should contain attribute', () => {
             const ticket = new TicketModel(ticketAttributes);


### PR DESCRIPTION
# Description

It was decided that instead of storing the following data:

```
const ticket = {
  products: [{ productNumber: 'foobar-999' }, { productNumber: 'foobar-001' }]
}
```

We instead wish to sort that array according to the product.productNumber to the following:
```
const ticket = {
  products: [{ productNumber: 'foobar-001' }, { productNumber: 'foobar-999' }]
}
```

This PR does those things
