### PR TITLE
Feature: Make Data in UI Tables Searchable

### DIFF
--- a/application/public/js/search-and-filtering.js
+++ b/application/public/js/search-and-filtering.js
@@ -1,0 +1,61 @@
+function findSearchableText(htmlElement) {
+    const searchableItems = htmlElement.find('.searchable');
+    let searchableText = '';
+
+    searchableItems && searchableItems.each(function() {
+        searchableText += $(this).text() + ' ';
+    });
+
+    return searchableText.toUpperCase();
+};
+
+function showAllNeccessaryTables(tables) {
+    tables.each(function() {
+        const table = $(this);
+        const tableRows = $(this).find('.table-row');
+
+        if (tableRows.length === 0) {
+            return true;
+        }
+
+        table.show();
+
+        tableRows.each(function() {
+            const row = $(this);
+            row.show();
+        })
+    })
+};
+
+$('.search-input').on('keyup', function() {
+    const searchQuery = $(this).val().toUpperCase();
+    const tables = $('.status-section');
+
+    if (!searchQuery) {
+        showAllNeccessaryTables(tables);
+        return;
+    } 
+    
+    tables && tables.each(function() {
+        const table = $(this);
+        let shouldRenderTable = false;
+
+        const rows = $(this).find('.table-row');
+        
+        rows && rows.each(function() {
+            const row = $(this);
+
+            const searchableText = findSearchableText(row)
+            const isRowAMatch = searchableText.includes(searchQuery)
+
+            if (isRowAMatch) {
+                row.show();
+                shouldRenderTable = true;
+            } else {
+                row.hide();
+            }
+        });
+
+        shouldRenderTable === true ? table.show() : table.hide();
+    });
+});

--- a/application/public/js/search-and-filtering.js
+++ b/application/public/js/search-and-filtering.js
@@ -23,8 +23,8 @@ function showAllNeccessaryTables(tables) {
         tableRows.each(function() {
             const row = $(this);
             row.show();
-        })
-    })
+        });
+    });
 };
 
 $('.search-input').on('keyup', function() {
@@ -45,8 +45,8 @@ $('.search-input').on('keyup', function() {
         rows && rows.each(function() {
             const row = $(this);
 
-            const searchableText = findSearchableText(row)
-            const isRowAMatch = searchableText.includes(searchQuery)
+            const searchableText = findSearchableText(row);
+            const isRowAMatch = searchableText.includes(searchQuery);
 
             if (isRowAMatch) {
                 row.show();

--- a/application/views/layout.ejs
+++ b/application/views/layout.ejs
@@ -28,6 +28,7 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
     <script src="/js/jquery-ui.min.js"></script>
     <script src="/js/main.js"></script>
+    <script src="/js/search-and-filtering.js"></script>
     <script src="/js/custom-dropdown.js"></script>
     <script src="/js/admin-panel-tables.js"></script>
     <script src="/js/particles.min.js"></script>

--- a/application/views/partials/tableColumns/date-picker-column.ejs
+++ b/application/views/partials/tableColumns/date-picker-column.ejs
@@ -1,5 +1,5 @@
 <div class='column-td bg-white'>
     <div class='date-picker-wrapper'>
-        <input type="text" id="datepicker" value="<%= columnValue %>">
+        <input class='searchable' type="text" id="datepicker" value="<%= columnValue %>">
     </div>
 </div>

--- a/application/views/partials/tableColumns/hold-reason-column.ejs
+++ b/application/views/partials/tableColumns/hold-reason-column.ejs
@@ -1,5 +1,5 @@
 <div class='column-td bg-white on-hold-status-cell'>
-    <span class='on-hold-reason-text searchable'>rrr<%= ticket.departmentToHoldReason && ticket.departmentToHoldReason.get(departmentIdentifier) %></span>
+    <span class='on-hold-reason-text searchable'><%= ticket.departmentToHoldReason && ticket.departmentToHoldReason.get(departmentIdentifier) %></span>
     <%- include('../on-hold-dropdown', {
         allHoldReasonsForThisDepartment: allHoldReasonsForThisDepartment,
       }) 

--- a/application/views/partials/tableColumns/hold-reason-column.ejs
+++ b/application/views/partials/tableColumns/hold-reason-column.ejs
@@ -1,5 +1,5 @@
 <div class='column-td bg-white on-hold-status-cell'>
-    <span class='on-hold-reason-text'><%= ticket.departmentToHoldReason && ticket.departmentToHoldReason.get(departmentIdentifier) %></span>
+    <span class='on-hold-reason-text searchable'>rrr<%= ticket.departmentToHoldReason && ticket.departmentToHoldReason.get(departmentIdentifier) %></span>
     <%- include('../on-hold-dropdown', {
         allHoldReasonsForThisDepartment: allHoldReasonsForThisDepartment,
       }) 

--- a/application/views/partials/tableColumns/text-column.ejs
+++ b/application/views/partials/tableColumns/text-column.ejs
@@ -1,1 +1,1 @@
-<div class='column-td bg-white'><%= columnValue %></div>
+<div class='column-td bg-white searchable'><%= columnValue %></div>

--- a/application/views/partials/tableColumns/user-column.ejs
+++ b/application/views/partials/tableColumns/user-column.ejs
@@ -8,7 +8,7 @@
         <% if (assignedUser) { %>
             <img src='<%= helperMethods.getProfilePictureUrl(assignedUser) %>'>
         <% } %>
-        <span class="tooltiptext assignee-name-column"><%= assignedUser ? assignedUser.fullName : 'N/A' %> </span>
+        <span class="tooltiptext assignee-name-column searchable"><%= assignedUser ? assignedUser.fullName : 'N/A' %> </span>
     </div>
-    <span class='department-name department-column'><%= destination ? destination.department : 'N/A' %></span>
+    <span class='department-name department-column searchable'><%= destination ? destination.department : 'N/A' %></span>
 </div>

--- a/application/views/partials/ticket-workflow-sorting-filtering.ejs
+++ b/application/views/partials/ticket-workflow-sorting-filtering.ejs
@@ -45,9 +45,9 @@
         </a>
     </div>
     <div class='all-wrapper tooltip'>
-        <a href="http://localhost:8080/die-lines/">
+        <a href="/requests">
             <span class="tooltiptext">See Requests</span>
-            <button class='sort btn-sort' href="http://localhost:8080/die-lines/"><i class="far fa-credit-card-front"></i> Requests</button>
+            <button class='sort btn-sort' href="/requests"><i class="far fa-credit-card-front"></i> Requests</button>
         </a>
     </div>
 </div>


### PR DESCRIPTION
# Description

Currently there exists a UI page (viewable at `${baseUrl}/tickets` that renders 37 HTML-like tables.

Each table has unique columns.

We wish to make all of these tables searchable via a searchfield that the user may type into, and only rows that match the search should be shown.

At first look, this was a crazy complex problem, but the following is the solution I settled on.

Bonus: This functionality also works with the tables on the `${baseUrl}/requests` page
## Solution

Using jquery, my "sudo" code is as follows:

When user types in a search query, then convert each row of every table into a single string of searchable text.

Compare the user's search query against this big string (i.e. using javascript's `.includes()` method.

If that row is not a match, hide it.

It wasn't quite that simple, since if the user deletes their search, the hidden rows need to be unhidden. Also if all of the rows in a table are hidden, the entire table needs to be hidden. This took some extra code to work out, but I'm pretty happy with the solution.

## Verification
![search-feature-ELI](https://user-images.githubusercontent.com/42784674/230240328-50cde611-3164-41a7-82c3-fb2749674a8d.gif)

> Pretty slick right 😉 🎊 