### PR TITLE
Feature: Enable Public Access to S3 so Users can Download their Uploads

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -12,4 +12,38 @@ provider "aws" {
 
 resource "aws_s3_bucket" "the-label-factory-file-uploads" {
     bucket = "the-label-factory-file-uploads-${var.environment_name}"
+    lifecycle {
+        prevent_destroy = true
+    }
+}
+
+resource "aws_s3_bucket_public_access_block" "file-uploads-public-access-block" {
+  bucket = aws_s3_bucket.the-label-factory-file-uploads.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+resource "aws_s3_bucket_policy" "allow-public-access" {
+  bucket = aws_s3_bucket.the-label-factory-file-uploads.id
+  policy = data.aws_iam_policy_document.allow-public-access.json
+}
+
+data "aws_iam_policy_document" "allow-public-access" {
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.the-label-factory-file-uploads.arn}/*"
+    ]
+  }
 }


### PR DESCRIPTION
# Description

A PR was recently merged that created a brand new S3 bucket to store user uploaded files (technically an old one existed prior to that which but was deprecated and will be deleted soon).

This new bucket however did not have public access rights, so if a user attempted to download a file from that bucket, they were denied access. This PR provides public read access to that bucket.