### PR TITLE
Convert `POST` endpoint to `PATCH`

### DIFF
--- a/application/controllers/ticketController.js
+++ b/application/controllers/ticketController.js
@@ -124,7 +124,7 @@ router.post('/find-department-statuses', (request, response) => {
     });
 });
 
-router.post('/update/:id', async (request, response) => {
+router.patch('/:id', async (request, response) => {
     const ticketId = request.params.id;
 
     try {

--- a/application/public/js/main.js
+++ b/application/public/js/main.js
@@ -14,8 +14,8 @@ $( document ).ready(function() {
 
     function updateTicket(ticketAttributes, ticketId, callback) {
         $.ajax({
-            url: `/tickets/update/${ticketId}`,
-            type: 'POST',
+            url: `/tickets/${ticketId}`,
+            type: 'PATCH',
             data: ticketAttributes,
             success: function(updatedTicket) {
                 if (callback) {


### PR DESCRIPTION
# Description

There's an endpoint that is called to make a attribute-level update to an object. The endpoint should use the `PATCH` HTTP verb to abide by RESTful best practices. Also verbs in an RESTful endpoint are 🤮 

This PR makes those changes
