### PR TITLE
Upgrade Mongoose `V7` to `V8`

### DIFF
--- a/application/services/databaseService.js
+++ b/application/services/databaseService.js
@@ -11,10 +11,7 @@ module.exports.connectToMongoDatabase = async (databaseUrl) => {
         throw new Error('Database URL is not defined');
     }
 
-    await mongoose.connect(databaseUrl, {
-        useNewUrlParser: true,
-        useUnifiedTopology: true
-    });
+    await mongoose.connect(databaseUrl, {});
 };
 
 module.exports.connectToTestMongoDatabase = async () => {
@@ -23,10 +20,7 @@ module.exports.connectToTestMongoDatabase = async () => {
     }
 
     mongod = await MongoMemoryServer.create();
-    mongoose.connect(mongod.getUri(), {
-        useNewUrlParser: true,
-        useUnifiedTopology: true
-    });
+    mongoose.connect(mongod.getUri(), {});
 };
 
 module.exports.closeDatabase = async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "mobx": "6.12.3",
         "mobx-react-lite": "4.0.5",
         "mongodb-memory-server": "9.2.0",
-        "mongoose": "7.6.11",
+        "mongoose": "8.4.0",
         "mongoose-delete": "1.0.2",
         "multer": "1.4.5-lts.1",
         "parcel": "2.12.0",
@@ -2066,7 +2066,6 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.7.tgz",
       "integrity": "sha512-dCHW/oEX0KJ4NjDULBo3JiOaK5+6axtpBbS+ao2ZInoAL9/YRQLhXzSNAFz7hP4nzLkIqsfYAK/PDE3+XHny0Q==",
-      "optional": true,
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -9061,9 +9060,9 @@
       }
     },
     "node_modules/kareem": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.5.1.tgz",
-      "integrity": "sha512-7jFxRVm+jD+rkq3kY0iZDJfsO2/t4BBPeEb2qKn2lR/9KhuksYk5hxzfRYWMPV8P/x2d0kHD306YyWLzjjH+uA==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.6.3.tgz",
+      "integrity": "sha512-C3iHfuGUXK2u8/ipq9LfjFfXFxAZMQJJq7vLS45r3D9Y2xQ/m4S8zaR4zMLFWh9AsNPXmcFfUDhTEO8UIC/V6Q==",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -9661,8 +9660,7 @@
     "node_modules/memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-      "optional": true
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
@@ -9905,20 +9903,20 @@
       }
     },
     "node_modules/mongoose": {
-      "version": "7.6.11",
-      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-7.6.11.tgz",
-      "integrity": "sha512-/MBaeXqGxNaOgtlzhXgsV2TwpH2nU7ipqI1bGx/Q6IMo5OYh5CTBX2H8fpYD2BHKVMvIvIxfJIzeidqr6ieVhw==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.4.0.tgz",
+      "integrity": "sha512-fgqRMwVEP1qgRYfh+tUe2YBBFnPO35FIg2lfFH+w9IhRGg1/ataWGIqvf/MjwM29cZ60D5vSnqtN2b8Qp0sOZA==",
       "dependencies": {
-        "bson": "^5.5.0",
-        "kareem": "2.5.1",
-        "mongodb": "5.9.1",
+        "bson": "^6.7.0",
+        "kareem": "2.6.3",
+        "mongodb": "6.6.2",
         "mpath": "0.9.0",
         "mquery": "5.0.0",
         "ms": "2.1.3",
-        "sift": "16.0.1"
+        "sift": "17.1.3"
       },
       "engines": {
-        "node": ">=14.20.1"
+        "node": ">=16.20.1"
       },
       "funding": {
         "type": "opencollective",
@@ -9933,33 +9931,51 @@
         "mongoose": "5.x || 6.x || 7.x || 8.x"
       }
     },
-    "node_modules/mongoose/node_modules/mongodb": {
-      "version": "5.9.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.9.1.tgz",
-      "integrity": "sha512-NBGA8AfJxGPeB12F73xXwozt8ZpeIPmCUeWRwl9xejozTXFes/3zaep9zhzs1B/nKKsw4P3I4iPfXl3K7s6g+Q==",
+    "node_modules/mongoose/node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
       "dependencies": {
-        "bson": "^5.5.0",
-        "mongodb-connection-string-url": "^2.6.0",
-        "socks": "^2.7.1"
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/mongoose/node_modules/bson": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.7.0.tgz",
+      "integrity": "sha512-w2IquM5mYzYZv6rs3uN2DZTOBe2a0zXLj53TGDqwF4l6Sz/XsISrisXOJihArF9+BZ6Cq/GjVht7Sjfmri7ytQ==",
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/mongoose/node_modules/mongodb": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.6.2.tgz",
+      "integrity": "sha512-ZF9Ugo2JCG/GfR7DEb4ypfyJJyiKbg5qBYKRintebj8+DNS33CyGMkWbrS9lara+u+h+yEOGSRiLhFO/g1s1aw==",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.5",
+        "bson": "^6.7.0",
+        "mongodb-connection-string-url": "^3.0.0"
       },
       "engines": {
-        "node": ">=14.20.1"
-      },
-      "optionalDependencies": {
-        "@mongodb-js/saslprep": "^1.1.0"
+        "node": ">=16.20.1"
       },
       "peerDependencies": {
         "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.0.0",
-        "kerberos": "^1.0.0 || ^2.0.0",
-        "mongodb-client-encryption": ">=2.3.0 <3",
-        "snappy": "^7.2.2"
+        "@mongodb-js/zstd": "^1.1.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
       },
       "peerDependenciesMeta": {
         "@aws-sdk/credential-providers": {
           "optional": true
         },
         "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
           "optional": true
         },
         "kerberos": {
@@ -9970,13 +9986,48 @@
         },
         "snappy": {
           "optional": true
+        },
+        "socks": {
+          "optional": true
         }
+      }
+    },
+    "node_modules/mongoose/node_modules/mongodb-connection-string-url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.1.tgz",
+      "integrity": "sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^13.0.0"
       }
     },
     "node_modules/mongoose/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/mongoose/node_modules/tr46": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "dependencies": {
+        "punycode": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/mongoose/node_modules/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/mpath": {
       "version": "0.9.0",
@@ -11386,9 +11437,9 @@
       }
     },
     "node_modules/sift": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/sift/-/sift-16.0.1.tgz",
-      "integrity": "sha512-Wv6BjQ5zbhW7VFefWusVP33T/EM0vYikCaQ2qR8yULbsilAT8/wQaXvuQ3ptGLpoKx+lihJE3y2UTgKDyyNHZQ=="
+      "version": "17.1.3",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-17.1.3.tgz",
+      "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ=="
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
@@ -11527,7 +11578,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
       "integrity": "sha512-kvzhi7vqKTfkh0PZU+2D2PIllw2ymqJKujUcyPMd9Y75Nv4nPbGJZXNhxsgdQab2BmlDct1YnfQCguEvHr7VsQ==",
-      "optional": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "mobx": "6.12.3",
     "mobx-react-lite": "4.0.5",
     "mongodb-memory-server": "9.2.0",
-    "mongoose": "7.6.11",
+    "mongoose": "8.4.0",
     "mongoose-delete": "1.0.2",
     "multer": "1.4.5-lts.1",
     "parcel": "2.12.0",

--- a/test/models/baseProductSnapshot.spec.js
+++ b/test/models/baseProductSnapshot.spec.js
@@ -4,7 +4,6 @@ const databaseService = require('../../application/services/databaseService');
 const testDataGenerator = require('../testDataGenerator');
 const { MAX_FRAME_LENGTH_INCHES } = require('../../application/enums/constantsEnum');
 
-const DieModel = require('../../application/models/Die');
 const MaterialModel = require('../../application/models/material');
 const FinishModel = require('../../application/models/finish');
 const CustomerModel = require('../../application/models/customer');
@@ -55,7 +54,9 @@ describe('BaseProductSnapshot', () => {
         it('should be a valid dieModel', async () => {
             const baseProductSnapshot = new BaseProductSnapshotModel(baseProductSnapshotAttributes);
 
-            const error = await DieModel.validate(baseProductSnapshot.die);
+            const error = baseProductSnapshot.validateSync();
+
+            console.log(error);
 
             expect(error).toBeUndefined();
         });

--- a/test/models/baseProductSnapshot.spec.js
+++ b/test/models/baseProductSnapshot.spec.js
@@ -56,8 +56,6 @@ describe('BaseProductSnapshot', () => {
 
             const error = baseProductSnapshot.validateSync();
 
-            console.log(error);
-
             expect(error).toBeUndefined();
         });
     });

--- a/test/services/databaseService.spec.js
+++ b/test/services/databaseService.spec.js
@@ -23,10 +23,7 @@ it('should attempt to connect to mongo database', () => {
     databaseService.connectToMongoDatabase(databaseUrl);
 
     expect(mongoose.connect).toHaveBeenCalledTimes(1);
-    expect(mongoose.connect).toHaveBeenCalledWith(databaseUrl, {
-        useNewUrlParser: true,
-        useUnifiedTopology: true
-    });
+    expect(mongoose.connect).toHaveBeenCalledWith(databaseUrl, {});
 });
 
 describe('test environment database interactions', () => {


### PR DESCRIPTION
# Description

Mongoose is currently on version 8+

This PR makes the major update from V7 to V8, adheiring to their migration guide.

Luckily their breaking changes impacting almost nothing