### PR TITLE
`Q of L`: Close `Modal` Component on Background Clicked

### DIFF
--- a/application/react/_global/Modal/Modal.tsx
+++ b/application/react/_global/Modal/Modal.tsx
@@ -13,7 +13,10 @@ export const Modal = (props) => {
     VERY IMPORTANT! Otherwise clicks on this modal bubble up to an unknown number of parents. 
     If this is removed, bad stuff will happen when modals are clicked...
   */
-  const onClick = (e) => e.stopPropagation();
+  const onClick = (e) => {
+    onClose();
+    e.stopPropagation();  // VERY IMPORTANT: Prevents this click from bubbling up to parents'
+  }
 
   return (
     <div className='modal-background' onClick={(e) => onClick(e)}>


### PR DESCRIPTION
# Description

When user clicks the dark background of a modal, close the modal.

In addition to allowing a user to click on the X button. 