### PR TITLE
Proof-of-Concept: How close modals

### DIFF
--- a/application/react/App/App.tsx
+++ b/application/react/App/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Route, Routes } from 'react-router-dom';
 import QuoteForm from '../Quote/QuoteForm/QuoteForm';
 import { CustomerForm } from '../Customer/CustomerForm/CustomerForm';
@@ -32,6 +32,24 @@ import { Profile } from '../User/Profile/Profile';
 const queryClient = new QueryClient();
 
 export function App() {
+
+  useEffect(() => {
+    document.addEventListener('mousedown', (e) => {
+      const classesWhoseClickShouldNotCloseAnything = ['modal', 'btn', 'btn-primary', 'btn-secondary', 'btn-success', 'quick-filter-dropdown', 'btn-split'];
+      console.log('classes on clicked element', Object.values(e.target.classList))
+      const isModal = classesWhoseClickShouldNotCloseAnything.some(className => e.target.classList.contains(className));
+      console.log('is modal?', isModal)
+
+      // Question (9-4-2025): If storm is going to use "active" class on modals, filters, popups, ect, then should we remove it when clicked outside of the modal?
+      if (!isModal) {
+        //document.querySelector('.active')?.classList.remove('active');
+        const elements = document.querySelectorAll('.active');
+        console.log('elements', elements)
+        Array.from(elements).forEach((el) => el.classList.remove('active'));
+      }
+    })
+  })
+
   return (
     <QueryClientProvider client={queryClient}>
       <Routes >

--- a/application/react/User/Profile/Profile.tsx
+++ b/application/react/User/Profile/Profile.tsx
@@ -56,6 +56,8 @@ export const Profile = () => {
         acceptedMimeTypes={['image/jpeg', 'image/png', 'image/jpg']}
       ></UploadProfilePicture>
 
+      <div style={{backgroundColor: 'red'}} className={'modal2'}>FOOOBAR THIS IS SOMETHING TO CLICK</div>
+
       <form onSubmit={handleSubmit(onSubmit)} data-test='user-form'>
         <Input
           attribute='email'

--- a/application/react/_global/FilterBar/FilterBar.tsx
+++ b/application/react/_global/FilterBar/FilterBar.tsx
@@ -101,7 +101,7 @@ export const FilterBar = observer(<T extends any>(props: Props<T>) => {
             <i className="fa-regular fa-chevron-down"></i>
           </button>
         </div>
-        <div className={`quick-filter-dropdown quick-filter-drpdwn dropdown ${isDropdownDisplayed ? 'active' : ''}`}>
+        <div className={`quick-filter-dropdown quick-filter-drpdwn dropdown modal ${isDropdownDisplayed ? 'active' : ''}`}>
           <h5><b>Quick filters</b></h5>
           {renderTextQuickFilters(textQuickFilters, store)}
         </div>


### PR DESCRIPTION
# Description

This draft PR is simply a POC for me to experiement with closing all active modals when a user clicks off of one.

The biggest challenge I'm running into, is that each "modal" maintains a state:


```
const [isActive, setIsActive] = useState()
```

And thus, I can't do the naive approach, which is to have a global `useEffect` on the `App.tsx` level which then attaches a click event listener to the document, which closes all modals when a user clicks on a non-modal element.

Because, that class is "ripped" off of the react component, but the "isActive" is not changed appropriately, leading to inconsitencies.


My next potential approach is to register all modals globally, using mobX state.

Then, the component itself has no idea if a modal is open or closes, it must use simply use a "toggle" and getIsActive(someIdentifier) to learn if the modal is active or not.

Then when a user clicks on a non-modal element, I can clear that state, and then all components who are referencing that state will have an update cascade.

This feeeeels like over-engineering, but simultaneously, it feeeels like the only way. I'll sleep on thisss... tbd