### PR TITLE
Fix Bug Causing Infinite Loop

### DIFF
--- a/application/react/_auth/ProtectedRoute/ProtectedRoute.tsx
+++ b/application/react/_auth/ProtectedRoute/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import React, { useLayoutEffect, useState } from 'react';
-import { useLocation, Navigate, Outlet } from "react-router-dom";
+import { useLocation, Navigate, Outlet, useNavigate } from "react-router-dom";
 import { useAuth } from "../../_hooks/useAuth";
 import { useRefreshToken } from '../../_hooks/useRefreshToken';
 import { LoadingIndicator } from '../../_global/LoadingIndicator/LoadingIndicator';
@@ -17,6 +17,7 @@ export const ProtectedRoute = (props: Props) => {
   const { auth }: { auth: UserAuth} = useAuth();
   const refreshAccessToken = useRefreshToken();
   const location = useLocation();
+  const navigate = useNavigate();
 
   /* 
     This useEffect checks if the accessToken is null (this usually happens when the page refreshes).
@@ -27,10 +28,10 @@ export const ProtectedRoute = (props: Props) => {
 
     const getNewAccessToken = async () => {
         try {
-          await refreshAccessToken();
+          await refreshAccessToken(); // throws if the refreshToken is expired or non-existant.
         }
         catch (err) {
-          console.error(err);
+          navigate('/react-ui/login', {state: { from: location }, replace: true });
         }
         finally {
           isMounted && setIsLoading(false);

--- a/application/react/_hooks/useRefreshToken.ts
+++ b/application/react/_hooks/useRefreshToken.ts
@@ -1,11 +1,10 @@
 import axios from "axios";
-import { useNavigate } from "react-router-dom";
 import { UserAuth } from "../_context/authProvider";
 import { useAuth } from "./useAuth";
 
 export const useRefreshToken = () => {
   const { setAuth } = useAuth();
-  const fetchAccessToken = async (): Promise<UserAuth> => {
+  const fetchAccessToken = async (): Promise<void> => {
     let userAuth: UserAuth = {
       accessToken: '',
       authRoles: []
@@ -19,11 +18,10 @@ export const useRefreshToken = () => {
       userAuth = response.data
 
       setAuth(userAuth);
-    } catch (error) {
+    } catch (error) { /* throws if the refreshToken is expired or non-existant. */ 
       setAuth(userAuth)
+      throw error;
     }
-
-    return userAuth;
   }
 
   return fetchAccessToken


### PR DESCRIPTION
# Description

In some situations, like not having logged into the site for awhile.

When I tried to navigate to a "ProtectedComponent" a pre-check would occur. Part of this pre-check is to attempt to refresh the user's accessToken via their refreshToken (stored on the server securely 😉 )

However, the situation for handling an expired, or non-existant refreshToken was never handled correctly via the UI.

The server returns a 403 status error when this occurs, but the front-end wasn't handling this error and redirecting the user to the login page correctly. So instead, it attempted to refresh their access token over-and-over-and-over-and....

This PR fixes that