### PR TITLE
Add `CustomSelect` and `TextArea` Component

### DIFF
--- a/application/api/models/baseProduct.ts
+++ b/application/api/models/baseProduct.ts
@@ -126,16 +126,23 @@ const productSchema = new Schema<IBaseProduct>({
     ref: 'Die',
     required: true
   },
+  /* Calculated Field - see lucid: Delete this */
   frameNumberAcross: {
     type: Number,
-    required: false,
+    required: true,
     min: 0
   },
+  /* Calculated Field - see lucid: Delete this */
   frameNumberAround: {
     type: Number,
-    required: false,
+    required: true,
     min: 0
   },
+
+  // TODO:
+    /* frameRepeat: Calculated Field - see lucid: Delete this */
+
+
   primaryMaterial: {
     type: Schema.Types.ObjectId,
     ref: 'Material',

--- a/application/api/models/baseProduct.ts
+++ b/application/api/models/baseProduct.ts
@@ -46,8 +46,6 @@ export interface IBaseProduct extends SchemaTimestampsConfig, mongoose.Document 
   spotPlate: boolean,
   numberOfColors: number,
   die: mongoose.Schema.Types.ObjectId,
-  frameNumberAcross?: number,
-  frameNumberAround?: number,
   primaryMaterial: mongoose.Schema.Types.ObjectId,
   secondaryMaterial?: mongoose.Schema.Types.ObjectId,
   finish?: mongoose.Schema.Types.ObjectId,
@@ -126,23 +124,6 @@ const productSchema = new Schema<IBaseProduct>({
     ref: 'Die',
     required: true
   },
-  /* Calculated Field - see lucid: Delete this */
-  frameNumberAcross: {
-    type: Number,
-    required: true,
-    min: 0
-  },
-  /* Calculated Field - see lucid: Delete this */
-  frameNumberAround: {
-    type: Number,
-    required: true,
-    min: 0
-  },
-
-  // TODO:
-    /* frameRepeat: Calculated Field - see lucid: Delete this */
-
-
   primaryMaterial: {
     type: Schema.Types.ObjectId,
     ref: 'Material',

--- a/application/react/Customer/Contact/ContactForm/ContactForm.tsx
+++ b/application/react/Customer/Contact/ContactForm/ContactForm.tsx
@@ -92,7 +92,6 @@ export const ContactForm = (props) => {
           register={register}
           isRequired={false}
           errors={errors}
-          isMultiSelect={false}
         />
       <button className='submit-button' type="submit">Submit</button>
     </form>

--- a/application/react/Customer/CustomerForm/CustomerForm.tsx
+++ b/application/react/Customer/CustomerForm/CustomerForm.tsx
@@ -192,7 +192,6 @@ export const CustomerForm = () => {
                   register={register}
                   isRequired={false}
                   errors={errors}
-                  isMultiSelect={false}
                 />
               </div>
             </div>

--- a/application/react/Die/DieForm/DieForm.tsx
+++ b/application/react/Die/DieForm/DieForm.tsx
@@ -22,7 +22,11 @@ export const DieForm = () => {
   const { mongooseId } = useParams();
   const isUpdateRequest = mongooseId && mongooseId.length > 0;
 
-  const { register, handleSubmit, formState: { errors }, reset } = useForm<DieFormAttributes>();
+  const { register, handleSubmit, formState: { errors }, reset } = useForm<DieFormAttributes>({
+    defaultValues: {
+      quantity: 1
+    }
+  });
 
   useEffect(() => {
     preloadFormData()
@@ -240,7 +244,6 @@ export const DieForm = () => {
               register={register}
               errors={errors}
               isRequired={true}
-              defaultValue='1'
             />
             <button className='create-entry submit-button' type='submit'>{isUpdateRequest ? 'Update' : 'Create'}</button>
           </form>

--- a/application/react/Product/ProductForm/ProductForm.tsx
+++ b/application/react/Product/ProductForm/ProductForm.tsx
@@ -33,7 +33,16 @@ export const ProductForm = () => {
   const [finishes, setFinishes ] = useState<SelectOption[]>([])
   const [customers, setCustomers ] = useState<SelectOption[]>([])
 
-  const { register, handleSubmit, formState: { errors }, reset, control } = useForm<ProductFormAttributes>();
+  const { register, handleSubmit, formState: { errors }, reset, control } = useForm<ProductFormAttributes>({
+    defaultValues: {
+      unwindDirection: defaultUnwindDirection,
+      ovOrEpm: defaultOvOrEpm,
+      finishType: defaultFinishType,
+      coreDiameter: 3,
+      labelsPerRoll: 1000,
+      spotPlate: false
+    },
+  });
 
   const preloadFormData = async () => {
     const dies = await getDies();
@@ -116,33 +125,25 @@ export const ProductForm = () => {
               errors={errors}
               isRequired={true}
             />
-            <Select
+            <CustomSelect
               attribute='unwindDirection'
               label='Unwind Direction'
               options={unwindDirections.map((direction) => ({ value: String(direction), displayName: String(direction) }))}
               register={register}
               errors={errors}
-              isRequired={true}
-              defaultValue={`${defaultUnwindDirection}`}
-            />
-            <CustomSelect 
-              attribute='unwindDirection'
-              label='Unwind Direction'
-              options={unwindDirections.map((direction) => ({ value: String(direction), displayName: String(direction) }))}
-              errors={errors}
-              isRequired={true}
               control={control}
+              isRequired={true}
             />
-            <Select
+            <CustomSelect
               attribute='ovOrEpm'
               label='OV / EPM'
               options={ovOrEpmOptions.map((option) => ({ value: option, displayName: option }))}
               register={register}
               errors={errors}
-              defaultValue={defaultOvOrEpm}
+              control={control}
               isRequired={true}
             />
-            <Input
+            <TextArea
               attribute='artNotes'
               label="Art Notes"
               register={register}
@@ -154,13 +155,13 @@ export const ProductForm = () => {
               register={register}
               errors={errors}
             />
-            <Select
+            <CustomSelect
               attribute='finishType'
               label='Finish Types'
               options={finishTypes.map((finishType) => ({ value: finishType, displayName: finishType }))}
               register={register}
               errors={errors}
-              defaultValue={defaultFinishType}
+              control={control}
               isRequired={true}
             />
             <Input
@@ -168,7 +169,6 @@ export const ProductForm = () => {
               label="Core Diameter"
               register={register}
               errors={errors}
-              defaultValue='3'
               isRequired={true}
             />
             <Input
@@ -176,10 +176,9 @@ export const ProductForm = () => {
               label="Labels Per Roll"
               register={register}
               errors={errors}
-              defaultValue='1000'
               isRequired={true}
             />
-            <Input
+            <TextArea
               attribute='dieCuttingNotes'
               label="Die Cutting Notes"
               register={register}
@@ -197,7 +196,6 @@ export const ProductForm = () => {
               register={register}
               errors={errors}
               fieldType='checkbox'
-              defaultValue={'false'}
             />
             <Input
               attribute='numberOfColors'
@@ -206,12 +204,13 @@ export const ProductForm = () => {
               errors={errors}
               isRequired={true}
             />
-            <Select 
+            <CustomSelect 
               attribute='die'
               label="Die"
               options={dies}
               register={register}
               errors={errors}
+              control={control}
               isRequired={true}
             />
             <Input
@@ -226,34 +225,38 @@ export const ProductForm = () => {
               register={register}
               errors={errors}
             />
-            <Select 
+            <CustomSelect 
               attribute='primaryMaterial'
               label="Primary Material"
               options={materials}
               register={register}
               errors={errors}
+              control={control}
               isRequired={true}
             />
-            <Select 
+            <CustomSelect 
               attribute='secondaryMaterial'
               label="Secondary Material"
               options={materials}
               register={register}
               errors={errors}
+              control={control}
             />
-            <Select 
+            <CustomSelect 
               attribute='finish'
               label="Finish"
               options={finishes}
               register={register}
               errors={errors}
+              control={control}
             />
-            <Select 
+            <CustomSelect 
               attribute='customer'
               label="Customer"
               options={customers}
               register={register}
               errors={errors}
+              control={control}
               isRequired={true}
             />
             <button className='create-entry submit-button' type='submit'>{isUpdateRequest ? 'Update' : 'Create'}</button>

--- a/application/react/Product/ProductForm/ProductForm.tsx
+++ b/application/react/Product/ProductForm/ProductForm.tsx
@@ -73,8 +73,6 @@ export const ProductForm = () => {
       spotPlate: product.spotPlate,
       numberOfColors: product.numberOfColors,
       die: product.die,
-      frameNumberAcross: product.frameNumberAcross,
-      frameNumberAround: product.frameNumberAround,
       primaryMaterial: product.primaryMaterial,
       secondaryMaterial: product.secondaryMaterial,
       finish: product.finish,
@@ -213,18 +211,6 @@ export const ProductForm = () => {
               control={control}
               isRequired={true}
             />
-            <Input
-              attribute='frameNumberAcross'
-              label="Frame Number Across"
-              register={register}
-              errors={errors}
-            />
-            <Input
-              attribute='frameNumberAround'
-              label="Frame Number Around"
-              register={register}
-              errors={errors}
-            />
             <CustomSelect 
               attribute='primaryMaterial'
               label="Primary Material"
@@ -281,8 +267,6 @@ type ProductFormAttributes = {
   spotPlate: boolean;
   numberOfColors: number;
   die: MongooseId;
-  frameNumberAcross: number;
-  frameNumberAround: number;
   primaryMaterial: MongooseId;
   secondaryMaterial: MongooseId;
   finish: MongooseId;

--- a/application/react/Product/ProductForm/ProductForm.tsx
+++ b/application/react/Product/ProductForm/ProductForm.tsx
@@ -18,6 +18,8 @@ import axios, { AxiosError, AxiosResponse } from 'axios';
 import { useSuccessMessage } from '../../_hooks/useSuccessMessage';
 import { defaultUnwindDirection } from '../../../api/enums/unwindDirectionsEnum';
 import { defaultOvOrEpm } from '../../../api/enums/ovOrEpmEnum';
+import { TextArea } from '../../_global/FormInputs/TextArea/TextArea';
+import { CustomSelect } from '../../_global/FormInputs/CustomSelect/CustomSelect';
 
 const productTableUrl = '/react-ui/tables/product'
 
@@ -31,7 +33,7 @@ export const ProductForm = () => {
   const [finishes, setFinishes ] = useState<SelectOption[]>([])
   const [customers, setCustomers ] = useState<SelectOption[]>([])
 
-  const { register, handleSubmit, formState: { errors }, reset } = useForm<ProductFormAttributes>();
+  const { register, handleSubmit, formState: { errors }, reset, control } = useForm<ProductFormAttributes>();
 
   const preloadFormData = async () => {
     const dies = await getDies();
@@ -123,6 +125,14 @@ export const ProductForm = () => {
               isRequired={true}
               defaultValue={`${defaultUnwindDirection}`}
             />
+            <CustomSelect 
+              attribute='unwindDirection'
+              label='Unwind Direction'
+              options={unwindDirections.map((direction) => ({ value: String(direction), displayName: String(direction) }))}
+              errors={errors}
+              isRequired={true}
+              control={control}
+            />
             <Select
               attribute='ovOrEpm'
               label='OV / EPM'
@@ -138,7 +148,7 @@ export const ProductForm = () => {
               register={register}
               errors={errors}
             />
-            <Input
+            <TextArea
               attribute='pressNotes'
               label="Press Notes"
               register={register}

--- a/application/react/Quote/InputSection/DieInput/DieInput.tsx
+++ b/application/react/Quote/InputSection/DieInput/DieInput.tsx
@@ -7,6 +7,12 @@ import axios, { AxiosError } from 'axios';
 import { Die } from '../../../_types/databasemodels/Die.ts';
 import { useErrorMessage } from '../../../_hooks/useErrorMessage';
 
+{
+  /* TODO @Gavin (9-17-2027): 
+    1) Can this page be converted to use react-hook-form
+    2) if yes, then can I deprecate and remove the <DropdownField> and <TextField> components
+  */
+}
 const Die = (props) => {
   const dieOverride = quoteStore.quoteInputs.dieOverride as Die;
   const [ dies, setDies ] = useState<Die[]>([]);

--- a/application/react/_global/FormInputs/CustomSelect/CustomSelect.scss
+++ b/application/react/_global/FormInputs/CustomSelect/CustomSelect.scss
@@ -1,0 +1,51 @@
+.custom-select-container {
+  position: relative;
+  width: 200px;
+}
+
+.select-selected {
+  padding: 10px;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border-radius: 5px;
+}
+
+.dropdown-arrow {
+  margin-left: 10px;
+}
+
+.dropdown-arrow.active {
+  transform: rotate(180deg);
+}
+
+.select-items {
+  position: absolute;
+  background-color: white;
+  border: 1px solid #ccc;
+  width: 100%;
+  z-index: 999;
+  margin-top: 5px;
+  border-radius: 5px;
+}
+
+.dropdown-item {
+  padding: 10px;
+  cursor: pointer;
+}
+
+.dropdown-item:hover {
+  background-color: #f0f0f0;
+}
+
+.same-as-selected {
+  background-color: #d0d0d0;
+}
+
+.error {
+  color: red;
+  margin-top: 10px;
+}

--- a/application/react/_global/FormInputs/CustomSelect/CustomSelect.scss
+++ b/application/react/_global/FormInputs/CustomSelect/CustomSelect.scss
@@ -22,7 +22,7 @@
   transform: rotate(180deg);
 }
 
-.select-items {
+.select-items-v2 {
   position: absolute;
   background-color: white;
   border: 1px solid #ccc;

--- a/application/react/_global/FormInputs/CustomSelect/CustomSelect.tsx
+++ b/application/react/_global/FormInputs/CustomSelect/CustomSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import './CustomSelect.scss';
 import { SelectOption } from '../Select/Select.tsx';
 import { FieldErrors, FieldValues, UseFormRegister, Path, UseFormSetValue, Controller, Control } from 'react-hook-form';
@@ -17,19 +17,34 @@ type Props<T extends FieldValues> = {
 
 export const CustomSelect = <T extends FieldValues>(props: Props<T>) => {
   const { attribute, options, label, errors, isRequired, control, register } = props;
-
   const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = useRef<HTMLInputElement>(null);
 
+  /* Setup validation rules: see https://react-hook-form.com/get-started#Applyvalidation for more */
   register(attribute, 
     { required: isRequired ? "Please select an option" : undefined }
   )
+
+  // Close dropdown if clicked outside
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("click", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("click", handleClickOutside);
+    };
+  }, []);
 
   const toggleDropdown = () => {
     setIsOpen(!isOpen);
   };
 
   return (
-    <div className="custom-select-container">
+    <div className="custom-select-container" ref={dropdownRef}>
       <label>{label}<span className='red'>{isRequired ? '*' : ''}</span>:</label>
       <Controller
         control={control}

--- a/application/react/_global/FormInputs/CustomSelect/CustomSelect.tsx
+++ b/application/react/_global/FormInputs/CustomSelect/CustomSelect.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import './CustomSelect.scss';
+import { SelectOption } from '../Select/Select.tsx';
+import { FieldErrors, FieldValues, UseFormRegister, Path, UseFormSetValue, Controller, Control } from 'react-hook-form';
+
+type Props<T extends FieldValues> = {
+  attribute: Path<T>,
+  options: SelectOption[],
+  label: string,
+  errors: FieldErrors,
+  defaultValue?: string,
+  isRequired?: boolean,
+  control: Control<T, any>
+}
+
+export const CustomSelect = <T extends FieldValues>(props: Props<T>) => {
+  const { attribute, options, label, errors, defaultValue, isRequired, control } = props;
+
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleDropdown = () => {
+    setIsOpen(!isOpen);
+  };
+
+  return (
+    <div className="custom-select-container">
+      <Controller
+        control={control}
+        name={attribute}
+        render={({ field: { onChange, value } }) => (
+          <>
+            {/* Selected Option: */}
+            <div className="select-selected" onClick={toggleDropdown}>
+              {value || "Please select an option"}
+              <span className={`dropdown-arrow ${isOpen ? "active" : ""}`}>▼</span>
+            </div>
+
+            {/* All Available Options: */}
+            <div className="select-items">
+              {options.map((option, index) => (
+                <div
+                  key={index}
+                  className={`dropdown-item ${option.value == value ? "same-as-selected" : ""
+                    }`}
+                  onClick={() => onChange(option.value)}
+                >
+                  {option.displayName}
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+      />
+    </div>
+  );
+}

--- a/application/react/_global/FormInputs/CustomSelect/CustomSelect.tsx
+++ b/application/react/_global/FormInputs/CustomSelect/CustomSelect.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import './CustomSelect.scss';
 import { SelectOption } from '../Select/Select.tsx';
 import { FieldErrors, FieldValues, UseFormRegister, Path, UseFormSetValue, Controller, Control } from 'react-hook-form';
+import FormErrorMessage from '../../FormErrorMessage/FormErrorMessage.js';
 
 type Props<T extends FieldValues> = {
   attribute: Path<T>,
@@ -14,7 +15,7 @@ type Props<T extends FieldValues> = {
 }
 
 export const CustomSelect = <T extends FieldValues>(props: Props<T>) => {
-  const { attribute, options, label, errors, defaultValue, isRequired, control } = props;
+  const { attribute, options, label, errors, isRequired, control } = props;
 
   const [isOpen, setIsOpen] = useState(false);
 
@@ -24,33 +25,65 @@ export const CustomSelect = <T extends FieldValues>(props: Props<T>) => {
 
   return (
     <div className="custom-select-container">
+      <label>{label}<span className='red'>{isRequired ? '*' : ''}</span>:</label>
       <Controller
         control={control}
         name={attribute}
         render={({ field: { onChange, value } }) => (
-          <>
+          <div>
             {/* Selected Option: */}
             <div className="select-selected" onClick={toggleDropdown}>
-              {value || "Please select an option"}
+              {value || `Please select an option`}
               <span className={`dropdown-arrow ${isOpen ? "active" : ""}`}>▼</span>
             </div>
 
             {/* All Available Options: */}
-            <div className="select-items">
+            {isOpen && <div className="select-items-v2">  {/* TODO: @Storm: I had to rename select-items -> select-items-v2 because some global class or Jquery was breaking this! Change if needed */}
+              <DropdownOption 
+                option={{displayName: `Please select an option`, value: ''}}
+                key={-1}
+                onClick={() => {
+                  onChange('')
+                  setIsOpen(false)
+                }}
+              />
               {options.map((option, index) => (
-                <div
+                <DropdownOption 
+                  option={option} 
+                  isSelected={option.value == value} 
                   key={index}
-                  className={`dropdown-item ${option.value == value ? "same-as-selected" : ""
-                    }`}
-                  onClick={() => onChange(option.value)}
-                >
-                  {option.displayName}
-                </div>
+                  onClick={() => {
+                    onChange(option.value)
+                    setIsOpen(false)
+                  }}
+                />
               ))}
-            </div>
-          </>
+            </div>}
+          </div>
         )}
       />
+      
+      <FormErrorMessage errors={errors} name={attribute} />
     </div>
   );
+}
+
+type DropdownOptionProps = {
+  option: SelectOption,
+  key: number,
+  onClick: () => void,
+  isSelected?: boolean,
+}
+
+const DropdownOption = ({ option, key, onClick, isSelected }: DropdownOptionProps) => {
+  return (
+    <div
+      key={key}
+      className={`dropdown-item ${isSelected ? "same-as-selected" : ""
+        }`}
+      onClick={onClick}
+    >
+      {option.displayName}
+    </div>
+  )
 }

--- a/application/react/_global/FormInputs/CustomSelect/CustomSelect.tsx
+++ b/application/react/_global/FormInputs/CustomSelect/CustomSelect.tsx
@@ -11,13 +11,18 @@ type Props<T extends FieldValues> = {
   errors: FieldErrors,
   defaultValue?: string,
   isRequired?: boolean,
-  control: Control<T, any>
+  control: Control<T, any>,
+  register: UseFormRegister<T>,
 }
 
 export const CustomSelect = <T extends FieldValues>(props: Props<T>) => {
-  const { attribute, options, label, errors, isRequired, control } = props;
+  const { attribute, options, label, errors, isRequired, control, register } = props;
 
   const [isOpen, setIsOpen] = useState(false);
+
+  register(attribute, 
+    { required: isRequired ? "Please select an option" : undefined }
+  )
 
   const toggleDropdown = () => {
     setIsOpen(!isOpen);

--- a/application/react/_global/FormInputs/Input/Input.tsx
+++ b/application/react/_global/FormInputs/Input/Input.tsx
@@ -9,7 +9,6 @@ type Props<T extends FieldValues> = {
   register: UseFormRegister<T>
   errors: FieldErrors,
   placeholder?: string
-  defaultValue?: string
   isRequired?: boolean
   additionalRegisterOptions?: any
   onChange?: () => void,
@@ -25,7 +24,7 @@ interface WithForwardRefType extends React.FC<Props<FieldValues>>  {
 
 /* @Gavin More client side validation rules can be configured in react-hook-form. see https://react-hook-form.com/get-started#Applyvalidation */
 export const Input: WithForwardRefType = forwardRef((props, customRef) => {
-  const { placeholder, errors, attribute, defaultValue, label, register, isRequired, fieldType, dataAttributes} = props
+  const { placeholder, errors, attribute, label, register, isRequired, fieldType, dataAttributes} = props
 
   const { ref, ...rest } = register(attribute,
     { required: isRequired ? "This is required" : undefined }
@@ -45,7 +44,6 @@ export const Input: WithForwardRefType = forwardRef((props, customRef) => {
           }
         }}
         {...dataAttributes}
-        { ...(fieldType === 'checkbox'? { defaultChecked: (defaultValue == 'true' ? true : false) } : {defaultValue: defaultValue}) }
       />
       <FormErrorMessage errors={errors} name={attribute} />
     </div>

--- a/application/react/_global/FormInputs/TextArea/TextArea.tsx
+++ b/application/react/_global/FormInputs/TextArea/TextArea.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import './TextArea.scss';
+import { FieldErrors, FieldValues, Path, UseFormRegister } from 'react-hook-form';
+import FormErrorMessage from '../../FormErrorMessage/FormErrorMessage';
+
+type Props<T extends FieldValues> = {
+  attribute: Path<T>
+  label: string
+  register: UseFormRegister<T>
+  errors: FieldErrors,
+  isRequired?: boolean,
+  placeholder?: string,
+  dataAttributes?: { [key: `data-${string}`]: string },
+  rows?: number,
+  cols?: number
+}
+
+export const TextArea = <T extends FieldValues>(props: Props<T>) => {
+  const { attribute, label, register, errors, isRequired, placeholder, dataAttributes, rows, cols } = props;
+
+  const { ...rest } = register(attribute,
+    { required: isRequired ? "This is required" : undefined }
+  );
+
+  return (
+    <div className='input-wrapper'>
+      <label>{label}<span className='red'>{isRequired ? '*' : ''}</span>:</label>
+      <textarea
+        {...register(attribute,
+          { required: isRequired ? "This is required" : undefined }
+        )}
+        placeholder={placeholder}
+        name={attribute}
+        {...dataAttributes}
+        { ...(rows ? { rows: rows } : {}) }
+        { ...(cols ? { cols: cols } : {}) }
+      />
+      <FormErrorMessage errors={errors} name={attribute} />
+    </div>
+  )
+}

--- a/test/models/baseProduct.spec.js
+++ b/test/models/baseProduct.spec.js
@@ -536,62 +536,6 @@ describe('Product Model', () => {
         });
     });
 
-    describe('attribute: frameNumberAcross', () => {
-        it('should not be required', () => {
-            delete productAttributes.frameNumberAcross;
-            const product = new BaseProductModel(productAttributes);
-
-            const error = product.validateSync();
-
-            expect(error).toBeUndefined();
-        });
-
-        it('should be a number', () => {
-            productAttributes.frameNumberAcross = chance.d100();
-            
-            const product = new BaseProductModel(productAttributes);
-
-            expect(product.frameNumberAcross).toEqual(expect.any(Number));
-        });
-
-        it('should fail if value is negative', () => {
-            productAttributes.frameNumberAcross = chance.d100() * -1;
-            const product = new BaseProductModel(productAttributes);
-
-            const error = product.validateSync();
-
-            expect(error).toBeDefined();
-        });
-    });
-
-    describe('attribute: frameNumberAround', () => {
-        it('should not be required', () => {
-            delete productAttributes.frameNumberAround;
-            const product = new BaseProductModel(productAttributes);
-
-            const error = product.validateSync();
-
-            expect(error).toBeUndefined();
-        });
-
-        it('should be a number', () => {
-            productAttributes.frameNumberAround = chance.d100();
-            
-            const product = new BaseProductModel(productAttributes);
-
-            expect(product.frameNumberAround).toEqual(expect.any(Number));
-        });
-
-        it('should fail if value is negative', () => {
-            productAttributes.frameNumberAround = chance.d100() * -1;
-            const product = new BaseProductModel(productAttributes);
-
-            const error = product.validateSync();
-
-            expect(error).toBeDefined();
-        });
-    });
-
     describe('verify database interactions', () => {
         let savedCustomer,
             savedDie,


### PR DESCRIPTION
# Description

Previously, we had two custom components setup and integrated with react-hook-form:

`<Input .../>`
`<Select .../>`

Whenever we were creating a form that required a large amount of user text, we just used the Input component.

However, it was determined that, we instead needed a `<TextArea .../>` component so we could show multiple lines.

It was also determined that we could/should not use the default HTML <select ... /> which is exactly what the wrapper component <Select .../> was doing under the hood.

This was due to <select being pretty hard/in-flexible to apply custom styles to

So this PR adds a new component `<CustomSelect />` that rebuilds the select field, without using HTMLs <select (it was not easy lol)
