### PR TITLE
`react-query` Bug Fix

### DIFF
--- a/application/react/User/Profile/Profile.tsx
+++ b/application/react/User/Profile/Profile.tsx
@@ -17,6 +17,8 @@ export const Profile = () => {
     initialData: []
   })
 
+  const { register, handleSubmit, formState: { errors }, reset } = useForm<FieldValues>();
+
   useEffect(() => {
     reset({
       email: loggedInUser?.email,
@@ -26,9 +28,7 @@ export const Profile = () => {
       phoneNumber: loggedInUser?.phoneNumber,
       jobRole: loggedInUser?.jobRole
     })
-  }, [loggedInUser])
-
-  const { register, handleSubmit, formState: { errors }, reset } = useForm<FieldValues>();
+  }, [loggedInUser, reset])
 
   if (isError) {
     useErrorMessage(error)


### PR DESCRIPTION
# Description

There was an issue when the following happened:

1. a user visited their profile page
2. the user navigated to another page by clicking a button on the navbar
3. a user navigated back to their profile via the navbar

When (1) a user would see a populated profile form on their profile page, with stuff like their name, birthdate, ect

When (3) the form would be empty

This PR fixes (3)