### PR TITLE
Fix: Don't Cache Parcel Build

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "parcel build",
+    "build": "parcel build --no-cache",
     "start": "npm run build && npx tsx application/api/index.ts",
     "react": "npm run parcel:remove-cache && parcel watch",
     "test": "jest",


### PR DESCRIPTION
# Description

There's an error on heroku that occurs when the parcel build is attempted to be cached. This is likely an operation denied by heroku - potentially because of the directory parcel is attempting to store the cache being protected.

This PR (for now) disables the parcel cache.