### PR TITLE
Add material.locations 

### DIFF
--- a/application/api/controllers/materialController.ts
+++ b/application/api/controllers/materialController.ts
@@ -13,6 +13,7 @@ import * as mongooseService from '../services/mongooseService.ts';
 
 const SHOW_ALL_MATERIALS_ENDPOINT = '/materials';
 import { SERVER_ERROR, SUCCESS } from '../enums/httpStatusCodes.ts';
+import { DESCENDING } from '../enums/mongooseSortMethods.ts';
 
 router.use(verifyBearerToken);
 
@@ -30,7 +31,7 @@ router.delete('/:mongooseId', async (request, response) => {
 
 router.get('/', async (request, response) => {
     try {
-        const materials = await MaterialModel.find().exec();
+        const materials = await MaterialModel.find().sort({ updatedAt: DESCENDING }).exec();
 
         return response.json(materials);
     } catch (error) {

--- a/application/api/controllers/materialLengthAdjustmentController.ts
+++ b/application/api/controllers/materialLengthAdjustmentController.ts
@@ -3,6 +3,7 @@ const router = Router();
 import { CREATED_SUCCESSFULLY, SERVER_ERROR, SUCCESS } from '../enums/httpStatusCodes.ts';
 import { verifyBearerToken } from '../middleware/authorize.ts';
 import { MaterialLengthAdjustmentModel } from '../models/materialLengthAdjustment.ts';
+import { DESCENDING } from '../enums/mongooseSortMethods.ts';
 
 router.use(verifyBearerToken);
 
@@ -23,7 +24,7 @@ router.post('/', async (request, response) => {
 
 router.get('/', async (request, response) => {
   try {
-    const materialLengthAdjustments = await MaterialLengthAdjustmentModel.find().exec();
+    const materialLengthAdjustments = await MaterialLengthAdjustmentModel.find().sort({ updatedAt: DESCENDING }).exec();
 
     return response.json(materialLengthAdjustments);
   } catch (error) {

--- a/application/api/controllers/materialOrdersController.ts
+++ b/application/api/controllers/materialOrdersController.ts
@@ -70,7 +70,7 @@ router.patch('/:mongooseId', async (request, response) => {
 
 router.get('/', async (_, response) => {
     try {
-        const materialOrders = await MaterialOrderModel.find().sort({ createdAt: DESCENDING }).exec();
+        const materialOrders = await MaterialOrderModel.find().sort({ updatedAt: DESCENDING }).exec();
 
         return response.json(materialOrders);
     } catch (error) {

--- a/application/api/controllers/productController.ts
+++ b/application/api/controllers/productController.ts
@@ -94,7 +94,7 @@ router.delete('/:mongooseId', async (request: Request, response: Response) => {
 
 router.get('/', async (_: Request, response: Response) => {
   try {
-    const products = await BaseProductModel.find().sort({ createdAt: DESCENDING }).exec();
+    const products = await BaseProductModel.find().sort({ updatedAt: DESCENDING }).exec();
 
     return response.json(products);
   } catch (error) {

--- a/application/api/controllers/quoteController.ts
+++ b/application/api/controllers/quoteController.ts
@@ -26,7 +26,7 @@ router.post('/', async (request, response) => {
 
 router.get('/', async (_: Request, response: Response) => {
   try {
-    const quotes = await QuoteModel.find().sort({ createdAt: DESCENDING }).exec();
+    const quotes = await QuoteModel.find().sort({ updatedAt: DESCENDING }).exec();
 
     return response.json(quotes);
   } catch (error) {

--- a/application/api/models/material.ts
+++ b/application/api/models/material.ts
@@ -35,10 +35,11 @@ function roundNumberToNthDecimalPlace(nthDecimalPlaces) {
 }
 
 export interface IMaterial extends SchemaTimestampsConfig, mongoose.Document  {
+  // TODO @Gavin: Verify these types are correct.
   name: string;
-  materialId: mongoose.Schema.Types.ObjectId;
-  vendor: mongoose.Schema.Types.ObjectId;
-  materialCategory: mongoose.Schema.Types.ObjectId;
+  materialId: string;
+  vendor: mongoose.Types.ObjectId;
+  materialCategory: mongoose.Types.ObjectId;
   weight: number;
   costPerMsi: number;
   freightCostPerMsi: number;
@@ -46,7 +47,7 @@ export interface IMaterial extends SchemaTimestampsConfig, mongoose.Document  {
   faceColor: string;
   adhesive: string;
   thickness: number;
-  adhesiveCategory: mongoose.Schema.Types.ObjectId;
+  adhesiveCategory: mongoose.Types.ObjectId;
   quotePricePerMsi: number;
   description: string;
   whenToUse: string;
@@ -56,7 +57,7 @@ export interface IMaterial extends SchemaTimestampsConfig, mongoose.Document  {
   adhesiveWeightPerMsi: number;
   linerWeightPerMsi: number;
   locations: string[];
-  linerType: mongoose.Schema.Types.ObjectId;
+  linerType: mongoose.Types.ObjectId;
   productNumber: string;
   masterRollSize: number;
   image: string;

--- a/application/api/models/material.ts
+++ b/application/api/models/material.ts
@@ -35,7 +35,6 @@ function roundNumberToNthDecimalPlace(nthDecimalPlaces) {
 }
 
 export interface IMaterial extends SchemaTimestampsConfig, mongoose.Document  {
-  // TODO @Gavin: Verify these types are correct.
   name: string;
   materialId: string;
   vendor: mongoose.Types.ObjectId;

--- a/application/api/models/material.ts
+++ b/application/api/models/material.ts
@@ -1,4 +1,4 @@
-import mongoose from 'mongoose';
+import mongoose, { SchemaTimestampsConfig } from 'mongoose';
 mongoose.Schema.Types.String.set('trim', true);
 const Schema = mongoose.Schema;
 import { Decimal } from 'decimal.js';
@@ -23,13 +23,41 @@ function roundNumberToNthDecimalPlace(nthDecimalPlaces) {
     };
 }
 
+export interface IMaterial extends SchemaTimestampsConfig, mongoose.Document  {
+  name: string;
+  materialId: mongoose.Schema.Types.ObjectId;
+  vendor: mongoose.Schema.Types.ObjectId;
+  materialCategory: mongoose.Schema.Types.ObjectId;
+  weight: number;
+  costPerMsi: number;
+  freightCostPerMsi: number;
+  width: number;
+  faceColor: string;
+  adhesive: string;
+  thickness: number;
+  adhesiveCategory: mongoose.Schema.Types.ObjectId;
+  quotePricePerMsi: number;
+  description: string;
+  whenToUse: string;
+  alternativeStock?: string;
+  length: number;
+  facesheetWeightPerMsi: number;
+  adhesiveWeightPerMsi: number;
+  linerWeightPerMsi: number;
+  locations: string[];
+  linerType: mongoose.Schema.Types.ObjectId;
+  productNumber: string;
+  masterRollSize: number;
+  image: string;
+}
+
 const weightPerMsiAttribute = {
     type: Number,
     min: 0,
     set: roundNumberToNthDecimalPlace(FOUR_DECIMAL_PLACES),
 };
 
-const schema = new Schema({
+const schema = new Schema<IMaterial>({
     name: {
         type: String,
         required: true,
@@ -131,8 +159,8 @@ const schema = new Schema({
         ...weightPerMsiAttribute,
         required: true
     },
-    location: {
-        type: String,
+    locations: {
+        type: [String],
         required: true
     },
     linerType: {
@@ -166,4 +194,4 @@ const schema = new Schema({
     strict: 'throw'
 });
 
-export const MaterialModel = mongoose.model('Material', schema);
+export const MaterialModel = mongoose.model<IMaterial>('Material', schema);

--- a/application/api/models/material.ts
+++ b/application/api/models/material.ts
@@ -10,9 +10,16 @@ const FOUR_DECIMAL_PLACES = 4;
 
 // For help deciphering these regex expressions, visit: https://regexr.com/
 const URL_VALIDATION_REGEX = /((([A-Za-z]{3,9}:(?:\/\/)?)(?:[-;:&=\+\$,\w]+@)?[A-Za-z0-9.-]+|(?:www.|[-;:&=\+\$,\w]+@)[A-Za-z0-9.-]+)((?:\/[\+~%\/.\w-_]*)?\??(?:[-\+=&;%@.\w_]*)#?(?:[\w]*))?)/;
+const LOCATION_REGEX = /^[a-zA-Z][1-9][0-9]?$/;
 
 function validateUrl(url) {
     return URL_VALIDATION_REGEX.test(url);
+}
+
+function validateLocations(locations) {
+  return locations.every((location) => {
+    return LOCATION_REGEX.test(location)
+  });
 }
 
 function roundNumberToNthDecimalPlace(nthDecimalPlaces) {
@@ -161,7 +168,13 @@ const schema = new Schema<IMaterial>({
     },
     locations: {
         type: [String],
-        required: true
+        required: true,
+        validate: [
+          {
+            validator: validateLocations,
+            message: 'Each location must start with a letter and end with a number between 1 and 99 (Ex: C13).'
+          }
+        ]
     },
     linerType: {
         type: Schema.Types.ObjectId,

--- a/application/api/models/material.ts
+++ b/application/api/models/material.ts
@@ -16,10 +16,14 @@ function validateUrl(url) {
     return URL_VALIDATION_REGEX.test(url);
 }
 
-function validateLocations(locations) {
+function validateLocationsFormat(locations) {
   return locations.every((location) => {
     return LOCATION_REGEX.test(location)
   });
+}
+
+function validateLocationsAreUnique(locations) {
+  return new Set(locations).size === locations.length;
 }
 
 function roundNumberToNthDecimalPlace(nthDecimalPlaces) {
@@ -168,11 +172,17 @@ const schema = new Schema<IMaterial>({
     },
     locations: {
         type: [String],
+        uppercase: true,
         required: true,
+        set: (locations: string[]) => locations.map(location => location.toUpperCase()),
         validate: [
           {
-            validator: validateLocations,
+            validator: validateLocationsFormat,
             message: 'Each location must start with a letter and end with a number between 1 and 99 (Ex: C13).'
+          },
+          {
+            validator: validateLocationsAreUnique,
+            message: 'Each location must be unique (i.e no duplicates allowed).'
           }
         ]
     },

--- a/application/react/Material/MaterialForm/MaterialForm.tsx
+++ b/application/react/Material/MaterialForm/MaterialForm.tsx
@@ -36,7 +36,6 @@ export const MaterialForm = () => {
 
     axios.get('/materials/' + mongooseId)
       .then(({ data }: { data: IMaterial }) => {
-        console.log('material locations: ', data.locations)
         const formValues: IMaterialFormAttributes = {
           name: data.name,
           materialId: data.materialId,

--- a/application/react/Material/MaterialForm/MaterialForm.tsx
+++ b/application/react/Material/MaterialForm/MaterialForm.tsx
@@ -9,7 +9,7 @@ import { Vendor } from '../../_types/databasemodels/vendor.ts';
 import { MaterialCategory } from '../../_types/databasemodels/materialCategory.ts';
 import { AdhesiveCategory } from '../../_types/databasemodels/adhesiveCategory.ts';
 import { LinerType } from '../../_types/databasemodels/linerType.ts';
-import { Material } from '../../_types/databasemodels/material.ts';
+import { IMaterial } from '../../../api/models/material.ts';
 import { useErrorMessage } from '../../_hooks/useErrorMessage';
 import { useSuccessMessage } from '../../_hooks/useSuccessMessage';
 import { MongooseId } from '../../_types/typeAliases';
@@ -19,7 +19,7 @@ import { MaterialLocationSelector } from './MaterialLocationSelector/MaterialLoc
 const materialTableUrl = '/react-ui/tables/material'
 
 export const MaterialForm = () => {
-  const { register, handleSubmit, formState: { errors }, reset, setValue } = useForm<MaterialFormAttributes>();
+  const { register, handleSubmit, formState: { errors }, reset, setValue, getValues, watch } = useForm<IMaterialFormAttributes>();
   const navigate = useNavigate();
   const { mongooseId } = useParams();
   const axios = useAxios();
@@ -35,8 +35,9 @@ export const MaterialForm = () => {
     if (!isUpdateRequest) return;
 
     axios.get('/materials/' + mongooseId)
-      .then(({ data }: {data: Material}) => {
-        const formValues: MaterialFormAttributes = {
+      .then(({ data }: { data: IMaterial }) => {
+        console.log('material locations: ', data.locations)
+        const formValues: IMaterialFormAttributes = {
           name: data.name,
           materialId: data.materialId,
           thickness: data.thickness,
@@ -54,14 +55,14 @@ export const MaterialForm = () => {
           facesheetWeightPerMsi: data.facesheetWeightPerMsi,
           adhesiveWeightPerMsi: data.adhesiveWeightPerMsi,
           linerWeightPerMsi: data.linerWeightPerMsi,
-          location: data.location,
+          locations: data.locations,
           productNumber: data.productNumber,
           masterRollSize: data.masterRollSize,
           image: data.image,
           linerType: data.linerType,
-          adhesiveCategory: data.adhesiveCategory as MongooseId,
-          vendor: data.vendor as MongooseId,
-          materialCategory: data.materialCategory as MongooseId
+          adhesiveCategory: data.adhesiveCategory,
+          vendor: data.vendor,
+          materialCategory: data.materialCategory
         }
 
         reset(formValues) // pre-populate form with existing values from the DB
@@ -121,7 +122,7 @@ export const MaterialForm = () => {
       .catch((error: AxiosError) => useErrorMessage(error))
   }, [])
 
-  const onSubmit = (formData: MaterialFormAttributes) => {
+  const onSubmit = (formData: IMaterialFormAttributes) => {
     if (isUpdateRequest) {
       axios.patch(`/materials/${mongooseId}`, formData)
         .then((_) => {
@@ -270,6 +271,7 @@ export const MaterialForm = () => {
                 />
                 <MaterialLocationSelector 
                   setValue={setValue}
+                  getValues={getValues}
                 />
                 <Input
                   attribute='productNumber'
@@ -335,7 +337,7 @@ export const MaterialForm = () => {
   )
 }
 
-export type MaterialFormAttributes = {
+export interface IMaterialFormAttributes {
   name: string;
   materialId: string;
   vendor: MongooseId;

--- a/application/react/Material/MaterialForm/MaterialForm.tsx
+++ b/application/react/Material/MaterialForm/MaterialForm.tsx
@@ -14,11 +14,12 @@ import { useErrorMessage } from '../../_hooks/useErrorMessage';
 import { useSuccessMessage } from '../../_hooks/useSuccessMessage';
 import { MongooseId } from '../../_types/typeAliases';
 import { useAxios } from '../../_hooks/useAxios';
+import { MaterialLocationSelector } from './MaterialLocationSelector/MaterialLocationSelector.tsx';
 
 const materialTableUrl = '/react-ui/tables/material'
 
 export const MaterialForm = () => {
-  const { register, handleSubmit, formState: { errors }, reset } = useForm<MaterialFormAttributes>();
+  const { register, handleSubmit, formState: { errors }, reset, setValue } = useForm<MaterialFormAttributes>();
   const navigate = useNavigate();
   const { mongooseId } = useParams();
   const axios = useAxios();
@@ -267,12 +268,8 @@ export const MaterialForm = () => {
                   isRequired={true}
                   errors={errors}
                 />
-                <Input
-                  attribute='location'
-                  label="Location"
-                  register={register}
-                  isRequired={true}
-                  errors={errors}
+                <MaterialLocationSelector 
+                  setValue={setValue}
                 />
                 <Input
                   attribute='productNumber'
@@ -359,7 +356,7 @@ export type MaterialFormAttributes = {
   facesheetWeightPerMsi: number;
   adhesiveWeightPerMsi: number;
   linerWeightPerMsi: number;
-  location: string;
+  locations: string[];
   linerType: MongooseId;
   productNumber: string;
   masterRollSize: number;

--- a/application/react/Material/MaterialForm/MaterialLocationSelector/MaterialLocationSelector.scss
+++ b/application/react/Material/MaterialForm/MaterialLocationSelector/MaterialLocationSelector.scss
@@ -1,0 +1,4 @@
+.location-error-message {
+  color: red;
+  font-style: italic
+}

--- a/application/react/Material/MaterialForm/MaterialLocationSelector/MaterialLocationSelector.tsx
+++ b/application/react/Material/MaterialForm/MaterialLocationSelector/MaterialLocationSelector.tsx
@@ -1,22 +1,30 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import './MaterialLocationSelector.scss'
-import { FieldValues, UseFormSetValue } from 'react-hook-form';
+import { FieldValues, Path, UseFormGetValues, UseFormSetValue } from 'react-hook-form';
 
 const locationRegex = /^[a-zA-Z][1-9][0-9]?$/;
 
 type Props<T extends FieldValues> = {
   setValue: UseFormSetValue<T>;
+  getValues: UseFormGetValues<T>;
 }
 
+const LOCATION_ATTRIBUTE_SELECTOR = 'locations'
+
 export const MaterialLocationSelector = <T extends FieldValues>(props: Props<T>) => {
-  const { setValue } = props
+  const { setValue, getValues } = props
   const [location, setLocation] = React.useState<string>('');
   const [locations, setLocations] = React.useState<string[]>([]);
   const [errorMessage, setErrorMessage] = React.useState('');
 
+  useEffect(() => {
+    const currentLocations = getValues(LOCATION_ATTRIBUTE_SELECTOR) || [];
+    setLocations(currentLocations);
+  }, [getValues(LOCATION_ATTRIBUTE_SELECTOR)]);
+
   const removeLocation = (locationToRemove) => {
     setLocations(locations.filter((loc) => loc!== locationToRemove));
-    setValue('locations', locations);
+    setValue(LOCATION_ATTRIBUTE_SELECTOR, locations);
   }
 
   const addLocation = (e) => {
@@ -36,7 +44,7 @@ export const MaterialLocationSelector = <T extends FieldValues>(props: Props<T>)
     } else {
       setLocations((prevLocations) => {
         const updatedLocations = [...prevLocations, newLocation];
-        setValue('locations', updatedLocations);
+        setValue(LOCATION_ATTRIBUTE_SELECTOR, updatedLocations);
         return updatedLocations;
       });
       setLocation('');

--- a/application/react/Material/MaterialForm/MaterialLocationSelector/MaterialLocationSelector.tsx
+++ b/application/react/Material/MaterialForm/MaterialLocationSelector/MaterialLocationSelector.tsx
@@ -1,0 +1,69 @@
+import React, { forwardRef, useRef } from 'react';
+import './MaterialLocationSelector.scss'
+import { FieldValues, UseFormRegister, UseFormSetValue } from 'react-hook-form';
+
+const locationRegex = /^[a-zA-Z][1-9][0-9]?$/;
+
+type Props<T extends FieldValues> = {
+  setValue: UseFormSetValue<T>;
+}
+
+export const MaterialLocationSelector = <T extends FieldValues>(props: Props<T>) => {
+  const { setValue } = props
+  const [location, setLocation] = React.useState<string>('');
+  const [locations, setLocations] = React.useState<string[]>([]);
+  const [errorMessage, setErrorMessage] = React.useState('');
+
+  const removeLocation = (locationToRemove) => {
+    setLocations(locations.filter((loc) => loc!== locationToRemove));
+    setValue('locations', locations);
+  }
+
+  const addLocation = (e) => {
+    e.preventDefault();
+
+    const newLocation = location.trim().toUpperCase();
+
+    if (!newLocation) return;
+
+    if (locations.includes(newLocation)) {
+      setErrorMessage('Location already exists');
+      return;
+    }
+
+    if (!locationRegex.test(newLocation)) {
+      setErrorMessage('Location must start with a letter and end with a number between 1 and 99 (Ex: C98)');
+    } else {
+      setLocations((prevLocations) => {
+        const updatedLocations = [...prevLocations, newLocation];
+        setValue('locations', updatedLocations);
+        return updatedLocations;
+      });
+      setLocation('');
+      setErrorMessage('');
+    }
+  }
+
+  return (
+    <div>
+      <p>Material Location(s)</p>
+      <span className='location-error-message'>{errorMessage}</span>
+      <input id='material-location-input' type='text' placeholder='Ex: C13' onChange={(e) => setLocation(e.target.value)}></input>
+      <button onClick={addLocation}>Click me Location</button>
+      <div>
+        {locations.map((location, index) => (
+          <LocationCard location={location} handleRemoveLocation={removeLocation} key={index} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+const LocationCard = ({location, handleRemoveLocation }) => {
+  return (
+    <div>
+      <p>Location: {location} </p>
+      <button onClick={() => handleRemoveLocation(location)}>Remove Location</button>
+    </div>
+  )
+}

--- a/application/react/Material/MaterialForm/MaterialLocationSelector/MaterialLocationSelector.tsx
+++ b/application/react/Material/MaterialForm/MaterialLocationSelector/MaterialLocationSelector.tsx
@@ -1,6 +1,6 @@
-import React, { forwardRef, useRef } from 'react';
+import React from 'react';
 import './MaterialLocationSelector.scss'
-import { FieldValues, UseFormRegister, UseFormSetValue } from 'react-hook-form';
+import { FieldValues, UseFormSetValue } from 'react-hook-form';
 
 const locationRegex = /^[a-zA-Z][1-9][0-9]?$/;
 

--- a/application/react/_types/databaseModels/material.ts
+++ b/application/react/_types/databaseModels/material.ts
@@ -25,7 +25,7 @@ export type Material = MongooseAttributes & {
   facesheetWeightPerMsi: number,
   adhesiveWeightPerMsi: number,
   linerWeightPerMsi: number,
-  location: string,
+  locations: string[],
   linerType: string,
   productNumber: string,
   masterRollSize: number,

--- a/test/models/material.spec.js
+++ b/test/models/material.spec.js
@@ -620,9 +620,27 @@ describe('File: material.js', () => {
     describe('attribute: locations', () => {
         it('should default to an empty array', () => {
             delete materialAttributes.locations;
-            const materail = new MaterialModel(materialAttributes);
+            const material = new MaterialModel(materialAttributes);
         
-            expect(materail.locations).toEqual([]);
+            expect(material.locations).toEqual([]);
+        });
+
+        it('should auto uppercase', () => {
+          const lowerCaseLocation = 'a1';
+          materialAttributes.locations = [lowerCaseLocation];
+          const material = new MaterialModel(materialAttributes);
+      
+          expect(material.locations).toEqual([lowerCaseLocation.toUpperCase()]);
+        });
+
+        it('should fail validation if duplicates exist', () => {
+          const location = 'P22';
+          materialAttributes.locations = [location, location];
+          const material = new MaterialModel(materialAttributes);
+          const { errors } = material.validateSync();
+      
+          expect(errors.locations).toBeDefined();
+          expect(errors?.locations?.properties?.message.includes('Each location must be unique (i.e no duplicates allowed).')).toBeTruthy();
         });
 
         it('should fail validation if one of the locaitons is not in the valid format (test #1)', () => {
@@ -635,6 +653,7 @@ describe('File: material.js', () => {
           const { errors } = material.validateSync();
           
           expect(errors.locations).toBeDefined();
+          expect(errors?.locations?.properties?.message.includes('Each location must start with a letter and end with a number between 1 and 99 (Ex: C13).')).toBeTruthy();
         })
 
         it('should fail validation if one of the locaitons is not in the valid format (test #2)', () => {

--- a/test/models/material.spec.js
+++ b/test/models/material.spec.js
@@ -617,21 +617,37 @@ describe('File: material.js', () => {
         });
     });
 
-    describe('attribute: location', () => {
-        it('should be required', () => {
-            delete materialAttributes.location;
-            const material = new MaterialModel(materialAttributes);
-
-            const error = material.validateSync();
-
-            expect(error).toBeDefined();
-        });
-
-        it('should be a string', () => {
+    describe('attribute: locations', () => {
+        it('should default to an empty array', () => {
+            delete materialAttributes.locations;
             const materail = new MaterialModel(materialAttributes);
         
-            expect(materail.location).toEqual(expect.any(String));
+            expect(materail.locations).toEqual([]);
         });
+
+        it('should fail validation if one of the locaitons is not in the valid format (test #1)', () => {
+          const invalidLocations = ['AA12', 'Z100'];
+          const validLocations = ['A1', 'z99'];
+          const locations = [chance.pickone(invalidLocations), chance.pickone(validLocations)];
+          materialAttributes.locations = locations;
+
+          const material = new MaterialModel(materialAttributes);
+          const { errors } = material.validateSync();
+          
+          expect(errors.locations).toBeDefined();
+        })
+
+        it('should fail validation if one of the locaitons is not in the valid format (test #2)', () => {
+          const invalidLocations = ['12', 'Z01', 'A'];
+          const validLocations = ['U10', 'p90'];
+          const locations = [chance.pickone(invalidLocations), chance.pickone(validLocations)];
+          materialAttributes.locations = locations;
+
+          const material = new MaterialModel(materialAttributes);
+          const { errors } = material.validateSync();
+          
+          expect(errors.locations).toBeDefined();
+        })
     });
 
     describe('attribute: linerType', () => {

--- a/test/models/material.spec.js
+++ b/test/models/material.spec.js
@@ -626,47 +626,47 @@ describe('File: material.js', () => {
         });
 
         it('should auto uppercase', () => {
-          const lowerCaseLocation = 'a1';
-          materialAttributes.locations = [lowerCaseLocation];
-          const material = new MaterialModel(materialAttributes);
+            const lowerCaseLocation = 'a1';
+            materialAttributes.locations = [lowerCaseLocation];
+            const material = new MaterialModel(materialAttributes);
       
-          expect(material.locations).toEqual([lowerCaseLocation.toUpperCase()]);
+            expect(material.locations).toEqual([lowerCaseLocation.toUpperCase()]);
         });
 
         it('should fail validation if duplicates exist', () => {
-          const location = 'P22';
-          materialAttributes.locations = [location, location];
-          const material = new MaterialModel(materialAttributes);
-          const { errors } = material.validateSync();
+            const location = 'P22';
+            materialAttributes.locations = [location, location];
+            const material = new MaterialModel(materialAttributes);
+            const { errors } = material.validateSync();
       
-          expect(errors.locations).toBeDefined();
-          expect(errors?.locations?.properties?.message.includes('Each location must be unique (i.e no duplicates allowed).')).toBeTruthy();
+            expect(errors.locations).toBeDefined();
+            expect(errors?.locations?.properties?.message.includes('Each location must be unique (i.e no duplicates allowed).')).toBeTruthy();
         });
 
         it('should fail validation if one of the locaitons is not in the valid format (test #1)', () => {
-          const invalidLocations = ['AA12', 'Z100'];
-          const validLocations = ['A1', 'z99'];
-          const locations = [chance.pickone(invalidLocations), chance.pickone(validLocations)];
-          materialAttributes.locations = locations;
+            const invalidLocations = ['AA12', 'Z100'];
+            const validLocations = ['A1', 'z99'];
+            const locations = [chance.pickone(invalidLocations), chance.pickone(validLocations)];
+            materialAttributes.locations = locations;
 
-          const material = new MaterialModel(materialAttributes);
-          const { errors } = material.validateSync();
+            const material = new MaterialModel(materialAttributes);
+            const { errors } = material.validateSync();
           
-          expect(errors.locations).toBeDefined();
-          expect(errors?.locations?.properties?.message.includes('Each location must start with a letter and end with a number between 1 and 99 (Ex: C13).')).toBeTruthy();
-        })
+            expect(errors.locations).toBeDefined();
+            expect(errors?.locations?.properties?.message.includes('Each location must start with a letter and end with a number between 1 and 99 (Ex: C13).')).toBeTruthy();
+        });
 
         it('should fail validation if one of the locaitons is not in the valid format (test #2)', () => {
-          const invalidLocations = ['12', 'Z01', 'A'];
-          const validLocations = ['U10', 'p90'];
-          const locations = [chance.pickone(invalidLocations), chance.pickone(validLocations)];
-          materialAttributes.locations = locations;
+            const invalidLocations = ['12', 'Z01', 'A'];
+            const validLocations = ['U10', 'p90'];
+            const locations = [chance.pickone(invalidLocations), chance.pickone(validLocations)];
+            materialAttributes.locations = locations;
 
-          const material = new MaterialModel(materialAttributes);
-          const { errors } = material.validateSync();
+            const material = new MaterialModel(materialAttributes);
+            const { errors } = material.validateSync();
           
-          expect(errors.locations).toBeDefined();
-        })
+            expect(errors.locations).toBeDefined();
+        });
     });
 
     describe('attribute: linerType', () => {

--- a/test/testDataGenerator.ts
+++ b/test/testDataGenerator.ts
@@ -73,7 +73,7 @@ function getMaterial() {
         facesheetWeightPerMsi: chance.floating({ min: 0.0001, fixed: 4 }),
         adhesiveWeightPerMsi: chance.floating({ min: 0.0001, fixed: 4 }),
         linerWeightPerMsi: chance.floating({ min: 0.0001, fixed: 4 }),
-        location: chance.word(),
+        locations: ['A1', 'Z99'],
         linerType: new mongoose.Types.ObjectId(),
         productNumber: chance.string(),
         masterRollSize: chance.integer({ min: 1, max: 10 }),


### PR DESCRIPTION
# Description

This PR adds the attribute `material.locations`. The idea behind this attribute is operators can select where a material is currently at, such as: `C1`, `Z22`.

This PR also updates the create/edit material UI pages to enable setting this value